### PR TITLE
Add dynamic fee support for protocol and swap fees

### DIFF
--- a/contracts/UniswapV2Factory.sol
+++ b/contracts/UniswapV2Factory.sol
@@ -54,8 +54,8 @@ contract UniswapV2Factory is IUniswapV2Factory {
         protocolFeeDenominator = _protocolFeeDenominator;
     }
     
-    function setSwapFee(address pair, uint8 swapFee) external {
+    function setSwapFee(address _pair, uint8 _swapFee) external {
         require(msg.sender == feeToSetter, 'UniswapV2: FORBIDDEN');
-        IUniswapV2Pair(pair).setSwapFee(swapFee);
+        IUniswapV2Pair(_pair).setSwapFee(_swapFee);
     }
 }

--- a/contracts/UniswapV2Factory.sol
+++ b/contracts/UniswapV2Factory.sol
@@ -6,6 +6,7 @@ import './UniswapV2Pair.sol';
 contract UniswapV2Factory is IUniswapV2Factory {
     address public feeTo;
     address public feeToSetter;
+    uint8 public protocolFee = 5; // uses 0.05% (1/6 of 0.30%) per trade as default
 
     mapping(address => mapping(address => address)) public getPair;
     address[] public allPairs;
@@ -45,5 +46,16 @@ contract UniswapV2Factory is IUniswapV2Factory {
     function setFeeToSetter(address _feeToSetter) external {
         require(msg.sender == feeToSetter, 'UniswapV2: FORBIDDEN');
         feeToSetter = _feeToSetter;
+    }
+    
+    function setProtocolFee(uint8 _protocolFee) external {
+        require(msg.sender == feeToSetter, 'UniswapV2: FORBIDDEN');
+        require(_protocolFee > 0, 'UniswapV2: FORBIDDEN_FEE');
+        protocolFee = _protocolFee;
+    }
+    
+    function setSwapFee(address pair, uint8 swapFee) external {
+        require(msg.sender == feeToSetter, 'UniswapV2: FORBIDDEN');
+        IUniswapV2Pair(pair).setSwapFee(swapFee);
     }
 }

--- a/contracts/UniswapV2Factory.sol
+++ b/contracts/UniswapV2Factory.sol
@@ -6,7 +6,7 @@ import './UniswapV2Pair.sol';
 contract UniswapV2Factory is IUniswapV2Factory {
     address public feeTo;
     address public feeToSetter;
-    uint8 public protocolFee = 5; // uses 0.05% (1/6 of 0.30%) per trade as default
+    uint8 public protocolFeeDenominator = 5; // uses 0.05% (1/~6 of 0.30%) per trade as default
 
     mapping(address => mapping(address => address)) public getPair;
     address[] public allPairs;
@@ -48,10 +48,10 @@ contract UniswapV2Factory is IUniswapV2Factory {
         feeToSetter = _feeToSetter;
     }
     
-    function setProtocolFee(uint8 _protocolFee) external {
+    function setProtocolFee(uint8 _protocolFeeDenominator) external {
         require(msg.sender == feeToSetter, 'UniswapV2: FORBIDDEN');
-        require(_protocolFee > 0, 'UniswapV2: FORBIDDEN_FEE');
-        protocolFee = _protocolFee;
+        require(_protocolFeeDenominator > 0, 'UniswapV2: FORBIDDEN_FEE');
+        protocolFeeDenominator = _protocolFeeDenominator;
     }
     
     function setSwapFee(address pair, uint8 swapFee) external {

--- a/contracts/UniswapV2Pair.sol
+++ b/contracts/UniswapV2Pair.sol
@@ -93,10 +93,10 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
         emit Sync(reserve0, reserve1);
     }
 
-    // if fee is on, mint liquidity equivalent to ~1/protocolFee share of the growth in sqrt(k)
+    // if fee is on, mint liquidity equivalent to 1/ (protocolFeeDenominator + ~1) share of the growth in sqrt(k)
     function _mintFee(uint112 _reserve0, uint112 _reserve1) private returns (bool feeOn) {
         address feeTo = IUniswapV2Factory(factory).feeTo();
-        uint8 protocolFee = IUniswapV2Factory(factory).protocolFee();
+        uint8 protocolFeeDenominator = IUniswapV2Factory(factory).protocolFeeDenominator();
         feeOn = feeTo != address(0);
         uint _kLast = kLast; // gas savings
         if (feeOn) {
@@ -105,7 +105,7 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
                 uint rootKLast = Math.sqrt(_kLast);
                 if (rootK > rootKLast) {
                     uint numerator = totalSupply.mul(rootK.sub(rootKLast));
-                    uint denominator = rootK.mul(protocolFee).add(rootKLast);
+                    uint denominator = rootK.mul(protocolFeeDenominator).add(rootKLast);
                     uint liquidity = numerator / denominator;
                     if (liquidity > 0) _mint(feeTo, liquidity);
                 }

--- a/contracts/interfaces/IUniswapV2Factory.sol
+++ b/contracts/interfaces/IUniswapV2Factory.sol
@@ -4,6 +4,7 @@ interface IUniswapV2Factory {
     event PairCreated(address indexed token0, address indexed token1, address pair, uint);
 
     function feeTo() external view returns (address);
+    function protocolFee() external view returns (uint8);
     function feeToSetter() external view returns (address);
 
     function getPair(address tokenA, address tokenB) external view returns (address pair);
@@ -14,4 +15,6 @@ interface IUniswapV2Factory {
 
     function setFeeTo(address) external;
     function setFeeToSetter(address) external;
+    function setProtocolFee(uint8 _protocolFee) external;
+    function setSwapFee(address pair, uint8 swapFee) external;
 }

--- a/contracts/interfaces/IUniswapV2Pair.sol
+++ b/contracts/interfaces/IUniswapV2Pair.sol
@@ -41,6 +41,7 @@ interface IUniswapV2Pair {
     function price0CumulativeLast() external view returns (uint);
     function price1CumulativeLast() external view returns (uint);
     function kLast() external view returns (uint);
+    function swapFee() external view returns (uint8);
 
     function mint(address to) external returns (uint liquidity);
     function burn(address to) external returns (uint amount0, uint amount1);
@@ -49,4 +50,5 @@ interface IUniswapV2Pair {
     function sync() external;
 
     function initialize(address, address) external;
+    function setSwapFee(uint8) external;
 }


### PR DESCRIPTION
This PR implements the smart contract changes discussed in issue #1.

Changes in TokenPair factory:
- Adds `protocolFee` public variable, used as divider for the swap fee. `protocolFeePercentage = swapFeePercentage * 1/protocolFee+1` [changes](https://github.com/levelkdev/dxswap-core/pull/3/files#diff-6c9a63769521417254859f79606e0bc1R29)
```
    uint8 public protocolFee = 5; // uses 0.05% (1/6 of 0.30%) per trade as default
``` 
- Adds setProtocolFee and setSwapFee functions to token pair factory, they can be executed only by the feeToSetter address.[changes](https://github.com/levelkdev/dxswap-core/pull/3/files#diff-6c9a63769521417254859f79606e0bc1R72)
```
    function setProtocolFee(uint8 _protocolFee) external {
        require(msg.sender == feeToSetter, 'UniswapV2: FORBIDDEN');
        require(_protocolFee > 0, 'UniswapV2: FORBIDDEN_FEE');
        protocolFee = _protocolFee;
    }

    function setSwapFee(address pair, uint8 swapFee) external {
        require(msg.sender == feeToSetter, 'UniswapV2: FORBIDDEN');
        IUniswapV2Pair(pair).setSwapFee(swapFee);
    }
```
- Adds swapFee public variable in token pair contract using 0.3 % as default.(changes)[]
```
    uint8 public swapFee = 30; // uses 0.3% fee as default
```
- Adds `setSwapFee` function in the token pair, which can be called only by the pair factory contract. [changes](https://github.com/levelkdev/dxswap-core/pull/3/files#diff-6c9a63769521417254859f79606e0bc1R72)
```
    function setSwapFee(uint8 _swapFee) external {
        require(msg.sender == factory, 'UniswapV2: FORBIDDEN'); // sufficient check
        require(_swapFee <= 30, 'UniswapV2: FORBIDDEN_FEE'); // fee percentage check
        swapFee = _swapFee;
    }
```
- Swap fee denominator is 10000 instead of 1000, allowing use two decimals swap fee. [changes](https://github.com/levelkdev/dxswap-core/pull/3/files#diff-6c9a63769521417254859f79606e0bc1R189)
- Get protocolFee to be used in token pair form pair factory. [changes](https://github.com/levelkdev/dxswap-core/pull/3/files#diff-6c9a63769521417254859f79606e0bc1R99)

Added two test cases, one that tests the new protocolFee after changed and another that tests the swapFee after changed in #6 