### PR TITLE
Add init code pair hash to DXswapFactory

### DIFF
--- a/.openzeppelin/kovan.json
+++ b/.openzeppelin/kovan.json
@@ -268,9 +268,9 @@
     ],
     "dxswap-core/DXswapFactory": [
       {
-        "address": "0xD1A632Ea90e2d7a79f90ab6Dfa5432056Dde0CA8",
+        "address": "0x93F860a4810c2172C897B369260E3Ecc20a9e83f",
         "kind": "NonProxy",
-        "bytecodeHash": "f2d68ea1d18f7e4ce39e2f7de098d5846f7d6bbcd4e201df6387b95fb65f7426"
+        "bytecodeHash": "b60031a9d419eb18d0bdc8ebcca8ae415eb9c9b817719e888002c9599d6946cc"
       }
     ]
   },

--- a/build/contracts/DXswapERC20.json
+++ b/build/contracts/DXswapERC20.json
@@ -376,7 +376,7 @@
         "id": 2,
         "nodeType": "ImportDirective",
         "scope": 385,
-        "sourceUnit": 1845,
+        "sourceUnit": 1856,
         "src": "26:39:0",
         "symbolAliases": [],
         "unitAlias": ""
@@ -387,7 +387,7 @@
         "id": 3,
         "nodeType": "ImportDirective",
         "scope": 385,
-        "sourceUnit": 2412,
+        "sourceUnit": 2423,
         "src": "66:34:0",
         "symbolAliases": [],
         "unitAlias": ""
@@ -401,10 +401,10 @@
               "id": 4,
               "name": "IDXswapERC20",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 1844,
+              "referencedDeclaration": 1855,
               "src": "126:12:0",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_IDXswapERC20_$1844",
+                "typeIdentifier": "t_contract$_IDXswapERC20_$1855",
                 "typeString": "contract IDXswapERC20"
               }
             },
@@ -414,7 +414,7 @@
           }
         ],
         "contractDependencies": [
-          1844
+          1855
         ],
         "contractKind": "contract",
         "documentation": null,
@@ -422,7 +422,7 @@
         "id": 384,
         "linearizedBaseContracts": [
           384,
-          1844
+          1855
         ],
         "name": "DXswapERC20",
         "nodeType": "ContractDefinition",
@@ -434,10 +434,10 @@
               "id": 6,
               "name": "SafeMath",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 2411,
+              "referencedDeclaration": 2422,
               "src": "151:8:0",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_SafeMath_$2411",
+                "typeIdentifier": "t_contract$_SafeMath_$2422",
                 "typeString": "library SafeMath"
               }
             },
@@ -1150,7 +1150,7 @@
                                 "name": "keccak256",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2480,
+                                "referencedDeclaration": 2491,
                                 "src": "1086:9:0",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
@@ -1237,7 +1237,7 @@
                                 "name": "keccak256",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2480,
+                                "referencedDeclaration": 2491,
                                 "src": "1199:9:0",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
@@ -1329,7 +1329,7 @@
                                 "name": "keccak256",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2480,
+                                "referencedDeclaration": 2491,
                                 "src": "1239:9:0",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
@@ -1372,7 +1372,7 @@
                                   "name": "this",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2504,
+                                  "referencedDeclaration": 2515,
                                   "src": "1311:4:0",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_contract$_DXswapERC20_$384",
@@ -1444,7 +1444,7 @@
                               "name": "abi",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 2473,
+                              "referencedDeclaration": 2484,
                               "src": "1058:3:0",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_magic_abi",
@@ -1491,7 +1491,7 @@
                         "name": "keccak256",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 2480,
+                        "referencedDeclaration": 2491,
                         "src": "1035:9:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
@@ -1622,7 +1622,7 @@
                         "lValueRequested": false,
                         "memberName": "add",
                         "nodeType": "MemberAccess",
-                        "referencedDeclaration": 2360,
+                        "referencedDeclaration": 2371,
                         "src": "1425:15:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
@@ -1774,7 +1774,7 @@
                         "lValueRequested": false,
                         "memberName": "add",
                         "nodeType": "MemberAccess",
-                        "referencedDeclaration": 2360,
+                        "referencedDeclaration": 2371,
                         "src": "1473:17:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
@@ -2146,7 +2146,7 @@
                         "lValueRequested": false,
                         "memberName": "sub",
                         "nodeType": "MemberAccess",
-                        "referencedDeclaration": 2382,
+                        "referencedDeclaration": 2393,
                         "src": "1634:19:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
@@ -2244,7 +2244,7 @@
                         "lValueRequested": false,
                         "memberName": "sub",
                         "nodeType": "MemberAccess",
-                        "referencedDeclaration": 2382,
+                        "referencedDeclaration": 2393,
                         "src": "1684:15:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
@@ -2920,7 +2920,7 @@
                         "lValueRequested": false,
                         "memberName": "sub",
                         "nodeType": "MemberAccess",
-                        "referencedDeclaration": 2382,
+                        "referencedDeclaration": 2393,
                         "src": "2032:19:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
@@ -3072,7 +3072,7 @@
                         "lValueRequested": false,
                         "memberName": "add",
                         "nodeType": "MemberAccess",
-                        "referencedDeclaration": 2360,
+                        "referencedDeclaration": 2371,
                         "src": "2084:17:0",
                         "typeDescriptions": {
                           "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
@@ -3319,7 +3319,7 @@
                           "name": "msg",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2486,
+                          "referencedDeclaration": 2497,
                           "src": "2250:3:0",
                           "typeDescriptions": {
                             "typeIdentifier": "t_magic_message",
@@ -3540,7 +3540,7 @@
             "scope": 384,
             "src": "2161:144:0",
             "stateMutability": "nonpayable",
-            "superFunction": 1789,
+            "superFunction": 1800,
             "visibility": "external"
           },
           {
@@ -3561,7 +3561,7 @@
                           "name": "msg",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2486,
+                          "referencedDeclaration": 2497,
                           "src": "2397:3:0",
                           "typeDescriptions": {
                             "typeIdentifier": "t_magic_message",
@@ -3782,7 +3782,7 @@
             "scope": 384,
             "src": "2311:136:0",
             "stateMutability": "nonpayable",
-            "superFunction": 1798,
+            "superFunction": 1809,
             "visibility": "external"
           },
           {
@@ -3854,7 +3854,7 @@
                           "name": "msg",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2486,
+                          "referencedDeclaration": 2497,
                           "src": "2567:3:0",
                           "typeDescriptions": {
                             "typeIdentifier": "t_magic_message",
@@ -4034,7 +4034,7 @@
                                 "name": "msg",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2486,
+                                "referencedDeclaration": 2497,
                                 "src": "2622:3:0",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_magic_message",
@@ -4143,7 +4143,7 @@
                                     "name": "msg",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 2486,
+                                    "referencedDeclaration": 2497,
                                     "src": "2652:3:0",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_magic_message",
@@ -4182,7 +4182,7 @@
                               "lValueRequested": false,
                               "memberName": "sub",
                               "nodeType": "MemberAccess",
-                              "referencedDeclaration": 2382,
+                              "referencedDeclaration": 2393,
                               "src": "2636:31:0",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
@@ -4460,7 +4460,7 @@
             "scope": 384,
             "src": "2453:295:0",
             "stateMutability": "nonpayable",
-            "superFunction": 1809,
+            "superFunction": 1820,
             "visibility": "external"
           },
           {
@@ -4507,7 +4507,7 @@
                             "name": "block",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2476,
+                            "referencedDeclaration": 2487,
                             "src": "2899:5:0",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_block",
@@ -4568,10 +4568,10 @@
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "2879:7:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
@@ -4827,7 +4827,7 @@
                                     "name": "abi",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 2473,
+                                    "referencedDeclaration": 2484,
                                     "src": "3095:3:0",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_magic_abi",
@@ -4874,7 +4874,7 @@
                               "name": "keccak256",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 2480,
+                              "referencedDeclaration": 2491,
                               "src": "3085:9:0",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
@@ -4917,7 +4917,7 @@
                             "name": "abi",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2473,
+                            "referencedDeclaration": 2484,
                             "src": "2989:3:0",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_abi",
@@ -4964,7 +4964,7 @@
                       "name": "keccak256",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 2480,
+                      "referencedDeclaration": 2491,
                       "src": "2966:9:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
@@ -5101,7 +5101,7 @@
                       "name": "ecrecover",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 2478,
+                      "referencedDeclaration": 2489,
                       "src": "3234:9:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_ecrecover_pure$_t_bytes32_$_t_uint8_$_t_bytes32_$_t_bytes32_$returns$_t_address_$",
@@ -5315,10 +5315,10 @@
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "3270:7:0",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
@@ -5640,7 +5640,7 @@
             "scope": 384,
             "src": "2754:666:0",
             "stateMutability": "nonpayable",
-            "superFunction": 1843,
+            "superFunction": 1854,
             "visibility": "external"
           }
         ],

--- a/build/contracts/DXswapFactory.json
+++ b/build/contracts/DXswapFactory.json
@@ -1,10 +1,10 @@
 {
   "fileName": "DXswapFactory.sol",
   "contractName": "DXswapFactory",
-  "source": "pragma solidity =0.5.16;\n\nimport './interfaces/IDXswapFactory.sol';\nimport './DXswapPair.sol';\n\ncontract DXswapFactory is IDXswapFactory {\n    address public feeTo;\n    address public feeToSetter;\n    uint8 public protocolFeeDenominator = 5; // uses 0.05% (1/~6 of 0.30%) per trade as default\n\n    mapping(address => mapping(address => address)) public getPair;\n    address[] public allPairs;\n\n    event PairCreated(address indexed token0, address indexed token1, address pair, uint);\n\n    constructor(address _feeToSetter) public {\n        feeToSetter = _feeToSetter;\n    }\n\n    function allPairsLength() external view returns (uint) {\n        return allPairs.length;\n    }\n\n    function createPair(address tokenA, address tokenB) external returns (address pair) {\n        require(tokenA != tokenB, 'DXswapFactory: IDENTICAL_ADDRESSES');\n        (address token0, address token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);\n        require(token0 != address(0), 'DXswapFactory: ZERO_ADDRESS');\n        require(getPair[token0][token1] == address(0), 'DXswapFactory: PAIR_EXISTS'); // single check is sufficient\n        bytes memory bytecode = type(DXswapPair).creationCode;\n        bytes32 salt = keccak256(abi.encodePacked(token0, token1));\n        assembly {\n            pair := create2(0, add(bytecode, 32), mload(bytecode), salt)\n        }\n        IDXswapPair(pair).initialize(token0, token1);\n        getPair[token0][token1] = pair;\n        getPair[token1][token0] = pair; // populate mapping in the reverse direction\n        allPairs.push(pair);\n        emit PairCreated(token0, token1, pair, allPairs.length);\n    }\n\n    function setFeeTo(address _feeTo) external {\n        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');\n        feeTo = _feeTo;\n    }\n\n    function setFeeToSetter(address _feeToSetter) external {\n        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');\n        feeToSetter = _feeToSetter;\n    }\n    \n    function setProtocolFee(uint8 _protocolFeeDenominator) external {\n        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');\n        require(_protocolFeeDenominator > 0, 'DXswapFactory: FORBIDDEN_FEE');\n        protocolFeeDenominator = _protocolFeeDenominator;\n    }\n    \n    function setSwapFee(address _pair, uint8 _swapFee) external {\n        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');\n        IDXswapPair(_pair).setSwapFee(_swapFee);\n    }\n}\n",
+  "source": "pragma solidity =0.5.16;\n\nimport './interfaces/IDXswapFactory.sol';\nimport './DXswapPair.sol';\n\ncontract DXswapFactory is IDXswapFactory {\n    address public feeTo;\n    address public feeToSetter;\n    uint8 public protocolFeeDenominator = 5; // uses 0.05% (1/~6 of 0.30%) per trade as default\n    bytes32 public constant INIT_CODE_PAIR_HASH = keccak256(abi.encodePacked(type(DXswapPair).creationCode));\n\n    mapping(address => mapping(address => address)) public getPair;\n    address[] public allPairs;\n\n    event PairCreated(address indexed token0, address indexed token1, address pair, uint);\n\n    constructor(address _feeToSetter) public {\n        feeToSetter = _feeToSetter;\n    }\n\n    function allPairsLength() external view returns (uint) {\n        return allPairs.length;\n    }\n    function createPair(address tokenA, address tokenB) external returns (address pair) {\n        require(tokenA != tokenB, 'DXswapFactory: IDENTICAL_ADDRESSES');\n        (address token0, address token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);\n        require(token0 != address(0), 'DXswapFactory: ZERO_ADDRESS');\n        require(getPair[token0][token1] == address(0), 'DXswapFactory: PAIR_EXISTS'); // single check is sufficient\n        bytes memory bytecode = type(DXswapPair).creationCode;\n        bytes32 salt = keccak256(abi.encodePacked(token0, token1));\n        assembly {\n            pair := create2(0, add(bytecode, 32), mload(bytecode), salt)\n        }\n        IDXswapPair(pair).initialize(token0, token1);\n        getPair[token0][token1] = pair;\n        getPair[token1][token0] = pair; // populate mapping in the reverse direction\n        allPairs.push(pair);\n        emit PairCreated(token0, token1, pair, allPairs.length);\n    }\n\n    function setFeeTo(address _feeTo) external {\n        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');\n        feeTo = _feeTo;\n    }\n\n    function setFeeToSetter(address _feeToSetter) external {\n        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');\n        feeToSetter = _feeToSetter;\n    }\n    \n    function setProtocolFee(uint8 _protocolFeeDenominator) external {\n        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');\n        require(_protocolFeeDenominator > 0, 'DXswapFactory: FORBIDDEN_FEE');\n        protocolFeeDenominator = _protocolFeeDenominator;\n    }\n    \n    function setSwapFee(address _pair, uint8 _swapFee) external {\n        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');\n        IDXswapPair(_pair).setSwapFee(_swapFee);\n    }\n}\n",
   "sourcePath": "contracts/DXswapFactory.sol",
-  "sourceMap": "96:2355:1:-;;;201:39;;;-1:-1:-1;;;;201:39:1;-1:-1:-1;;;201:39:1;;;490:84;5:2:-1;;;;30:1;27;20:12;5:2;490:84:1;;;;;;;;;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;490:84:1;541:11;:26;;-1:-1:-1;;;;;;541:26:1;-1:-1:-1;;;;;541:26:1;;;;;;;;;96:2355;;;-1:-1:-1;96:2355:1;;",
-  "deployedSourceMap": "96:2355:1:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;96:2355:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;143:20;;;:::i;:::-;;;;-1:-1:-1;;;;;143:20:1;;;;;;;;;;;;;;169:26;;;:::i;2261:188::-;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;2261:188:1;;-1:-1:-1;;;;;2261:188:1;;;;;;;;:::i;:::-;;366:25;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;366:25:1;;:::i;201:39::-;;;:::i;:::-;;;;;;;;;;;;;;;;;;;1972:279;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;1972:279:1;;;;:::i;580:94::-;;;:::i;:::-;;;;;;;;;;;;;;;;1792:170;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;1792:170:1;-1:-1:-1;;;;;1792:170:1;;:::i;680:954::-;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;;;;;;680:954:1;;;;;;;;;;:::i;298:62::-;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;;;;;;298:62:1;;;;;;;;;;:::i;1640:146::-;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;1640:146:1;-1:-1:-1;;;;;1640:146:1;;:::i;143:20::-;;;-1:-1:-1;;;;;143:20:1;;:::o;169:26::-;;;-1:-1:-1;;;;;169:26:1;;:::o;2261:188::-;2353:11;;-1:-1:-1;;;;;2353:11:1;2339:10;:25;2331:62;;;;;-1:-1:-1;;;2331:62:1;;;;;;;;;;;;-1:-1:-1;;;2331:62:1;;;;;;;;;;;;;;;2403:39;;;-1:-1:-1;;;2403:39:1;;;;;;;;;;;-1:-1:-1;;;;;2403:29:1;;;;;:39;;;;;-1:-1:-1;;2403:39:1;;;;;;;-1:-1:-1;2403:29:1;:39;;;5:2:-1;;;;30:1;27;20:12;5:2;2403:39:1;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;2403:39:1;;;;2261:188;;:::o;366:25::-;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;366:25:1;;-1:-1:-1;366:25:1;:::o;201:39::-;;;-1:-1:-1;;;201:39:1;;;;;:::o;1972:279::-;2068:11;;-1:-1:-1;;;;;2068:11:1;2054:10;:25;2046:62;;;;;-1:-1:-1;;;2046:62:1;;;;;;;;;;;;-1:-1:-1;;;2046:62:1;;;;;;;;;;;;;;;2152:1;2126:23;:27;;;2118:68;;;;;-1:-1:-1;;;2118:68:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;2196:22;:48;;;;;;-1:-1:-1;;;2196:48:1;-1:-1:-1;;;;2196:48:1;;;;;;;;;1972:279::o;580:94::-;652:8;:15;580:94;:::o;1792:170::-;1879:11;;-1:-1:-1;;;;;1879:11:1;1865:10;:25;1857:62;;;;;-1:-1:-1;;;1857:62:1;;;;;;;;;;;;-1:-1:-1;;;1857:62:1;;;;;;;;;;;;;;;1929:11;:26;;-1:-1:-1;;;;;;1929:26:1;-1:-1:-1;;;;;1929:26:1;;;;;;;;;;1792:170::o;680:954::-;750:12;792:6;-1:-1:-1;;;;;782:16:1;:6;-1:-1:-1;;;;;782:16:1;;;774:63;;;;-1:-1:-1;;;774:63:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;848:14;864;891:6;-1:-1:-1;;;;;882:15:1;:6;-1:-1:-1;;;;;882:15:1;;:53;;920:6;928;882:53;;;901:6;909;882:53;847:88;;-1:-1:-1;847:88:1;-1:-1:-1;;;;;;953:20:1;;945:60;;;;;-1:-1:-1;;;945:60:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;1023:15:1;;;1058:1;1023:15;;;:7;:15;;;;;;;;:23;;;;;;;;;;;;:37;1015:76;;;;;-1:-1:-1;;;1015:76:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;1131:21;1155:29;;;;;;;;:::i;:::-;41:4:-1;34:5;30:16;25:3;21:26;14:5;7:41;87:2;83:7;78:2;73:3;69:12;65:26;61:2;54:38;1155:29:1;1131:53;;1194:12;1236:6;1244;1219:32;;;;;;-1:-1:-1;;;;;1219:32:1;-1:-1:-1;;;;;1219:32:1;;;;;;;;-1:-1:-1;;;;;1219:32:1;-1:-1:-1;;;;;1219:32:1;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;1219:32:1;;;1209:43;;;;;;1194:58;;1340:4;1329:8;1323:15;1318:2;1308:8;1304:17;1301:1;1293:52;1364:44;;;-1:-1:-1;;;1364:44:1;;-1:-1:-1;;;;;1364:44:1;;;;;;;;;;;;;;;;1285:60;;-1:-1:-1;1364:28:1;;;;;;:44;;;;;-1:-1:-1;;1364:44:1;;;;;;;;-1:-1:-1;1364:28:1;:44;;;5:2:-1;;;;30:1;27;20:12;5:2;1364:44:1;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;-1:-1;;;;;;;;;1418:15:1;;;;;;;:7;:15;;;;;;;;:23;;;;;;;;;;;;:30;;;;;-1:-1:-1;;;;;;1418:30:1;;;;;;;;1458:15;;;;;;:23;;;;;;;;:30;;;;;;;;1543:8;27:10:-1;;-1:-1;23:18;;45:23;;1543:19:1;;;;;;;;;;;;;;;;;;1611:15;;1577:50;;;;;;;;;;;;;;;;;;;;;;680:954;;;;;;;;:::o;298:62::-;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;298:62:1;;:::o;1640:146::-;1715:11;;-1:-1:-1;;;;;1715:11:1;1701:10;:25;1693:62;;;;;-1:-1:-1;;;1693:62:1;;;;;;;;;;;;-1:-1:-1;;;1693:62:1;;;;;;;;;;;;;;;1765:5;:14;;-1:-1:-1;;;;;;1765:14:1;-1:-1:-1;;;;;1765:14:1;;;;;;;;;;1640:146::o;96:2355::-;;;;;;;;:::o",
+  "sourceMap": "96:2464:1:-;;;201:39;;;-1:-1:-1;;;;201:39:1;-1:-1:-1;;;201:39:1;;;600:84;5:2:-1;;;;30:1;27;20:12;5:2;600:84:1;;;;;;;;;;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;600:84:1;651:11;:26;;-1:-1:-1;;;;;;651:26:1;-1:-1:-1;;;;;651:26:1;;;;;;;;;96:2464;;;-1:-1:-1;96:2464:1;;",
+  "deployedSourceMap": "96:2464:1:-;;;;8:9:-1;5:2;;;30:1;27;20:12;5:2;96:2464:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;143:20;;;:::i;:::-;;;;-1:-1:-1;;;;;143:20:1;;;;;;;;;;;;;;169:26;;;:::i;2370:188::-;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;2370:188:1;;-1:-1:-1;;;;;2370:188:1;;;;;;;;:::i;:::-;;476:25;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;476:25:1;;:::i;201:39::-;;;:::i;:::-;;;;;;;;;;;;;;;;;;;2081:279;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;2081:279:1;;;;:::i;690:94::-;;;:::i;:::-;;;;;;;;;;;;;;;;297:104;;;:::i;1901:170::-;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;1901:170:1;-1:-1:-1;;;;;1901:170:1;;:::i;789:954::-;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;;;;;;789:954:1;;;;;;;;;;:::i;408:62::-;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;;;;;;408:62:1;;;;;;;;;;:::i;1749:146::-;;;;;;13:2:-1;8:3;5:11;2:2;;;29:1;26;19:12;2:2;-1:-1;1749:146:1;-1:-1:-1;;;;;1749:146:1;;:::i;143:20::-;;;-1:-1:-1;;;;;143:20:1;;:::o;169:26::-;;;-1:-1:-1;;;;;169:26:1;;:::o;2370:188::-;2462:11;;-1:-1:-1;;;;;2462:11:1;2448:10;:25;2440:62;;;;;-1:-1:-1;;;2440:62:1;;;;;;;;;;;;-1:-1:-1;;;2440:62:1;;;;;;;;;;;;;;;2512:39;;;-1:-1:-1;;;2512:39:1;;;;;;;;;;;-1:-1:-1;;;;;2512:29:1;;;;;:39;;;;;-1:-1:-1;;2512:39:1;;;;;;;-1:-1:-1;2512:29:1;:39;;;5:2:-1;;;;30:1;27;20:12;5:2;2512:39:1;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;2512:39:1;;;;2370:188;;:::o;476:25::-;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;476:25:1;;-1:-1:-1;476:25:1;:::o;201:39::-;;;-1:-1:-1;;;201:39:1;;;;;:::o;2081:279::-;2177:11;;-1:-1:-1;;;;;2177:11:1;2163:10;:25;2155:62;;;;;-1:-1:-1;;;2155:62:1;;;;;;;;;;;;-1:-1:-1;;;2155:62:1;;;;;;;;;;;;;;;2261:1;2235:23;:27;;;2227:68;;;;;-1:-1:-1;;;2227:68:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;2305:22;:48;;;;;;-1:-1:-1;;;2305:48:1;-1:-1:-1;;;;2305:48:1;;;;;;;;;2081:279::o;690:94::-;762:8;:15;690:94;:::o;297:104::-;370:29;;;;;;;:::i;:::-;41:4:-1;34:5;30:16;25:3;21:26;14:5;7:41;87:2;83:7;78:2;73:3;69:12;65:26;61:2;54:38;370:29:1;353:47;;;;;;;;;;;;;;;36:153:-1;66:2;61:3;58:11;36:153;;176:10;;164:23;;-1:-1;;139:12;;;;98:2;89:12;;;;114;36:153;;;274:1;267:3;263:2;259:12;254:3;250:22;246:30;315:4;311:9;305:3;299:10;295:26;356:4;350:3;344:10;340:21;389:7;380;377:20;372:3;365:33;3:399;;;353:47:1;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;353:47:1;;;343:58;;;;;;297:104;:::o;1901:170::-;1988:11;;-1:-1:-1;;;;;1988:11:1;1974:10;:25;1966:62;;;;;-1:-1:-1;;;1966:62:1;;;;;;;;;;;;-1:-1:-1;;;1966:62:1;;;;;;;;;;;;;;;2038:11;:26;;-1:-1:-1;;;;;;2038:26:1;-1:-1:-1;;;;;2038:26:1;;;;;;;;;;1901:170::o;789:954::-;859:12;901:6;-1:-1:-1;;;;;891:16:1;:6;-1:-1:-1;;;;;891:16:1;;;883:63;;;;-1:-1:-1;;;883:63:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;957:14;973;1000:6;-1:-1:-1;;;;;991:15:1;:6;-1:-1:-1;;;;;991:15:1;;:53;;1029:6;1037;991:53;;;1010:6;1018;991:53;956:88;;-1:-1:-1;956:88:1;-1:-1:-1;;;;;;1062:20:1;;1054:60;;;;;-1:-1:-1;;;1054:60:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;1132:15:1;;;1167:1;1132:15;;;:7;:15;;;;;;;;:23;;;;;;;;;;;;:37;1124:76;;;;;-1:-1:-1;;;1124:76:1;;;;;;;;;;;;;;;;;;;;;;;;;;;;1240:21;1264:29;;;;;;;;:::i;:::-;41:4:-1;34:5;30:16;25:3;21:26;14:5;7:41;87:2;83:7;78:2;73:3;69:12;65:26;61:2;54:38;1264:29:1;1240:53;;1303:12;1345:6;1353;1328:32;;;;;;-1:-1:-1;;;;;1328:32:1;-1:-1:-1;;;;;1328:32:1;;;;;;;;-1:-1:-1;;;;;1328:32:1;-1:-1:-1;;;;;1328:32:1;;;;;;;;;;;;;49:4:-1;39:7;30;26:21;22:32;13:7;6:49;1328:32:1;;;1318:43;;;;;;1303:58;;1449:4;1438:8;1432:15;1427:2;1417:8;1413:17;1410:1;1402:52;1473:44;;;-1:-1:-1;;;1473:44:1;;-1:-1:-1;;;;;1473:44:1;;;;;;;;;;;;;;;;1394:60;;-1:-1:-1;1473:28:1;;;;;;:44;;;;;-1:-1:-1;;1473:44:1;;;;;;;;-1:-1:-1;1473:28:1;:44;;;5:2:-1;;;;30:1;27;20:12;5:2;1473:44:1;;;;8:9:-1;5:2;;;45:16;42:1;39;24:38;77:16;74:1;67:27;5:2;-1:-1;;;;;;;;;1527:15:1;;;;;;;:7;:15;;;;;;;;:23;;;;;;;;;;;;:30;;;;;-1:-1:-1;;;;;;1527:30:1;;;;;;;;1567:15;;;;;;:23;;;;;;;;:30;;;;;;;;1652:8;27:10:-1;;-1:-1;23:18;;45:23;;1652:19:1;;;;;;;;;;;;;;;;;;1720:15;;1686:50;;;;;;;;;;;;;;;;;;;;;;789:954;;;;;;;;:::o;408:62::-;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;408:62:1;;:::o;1749:146::-;1824:11;;-1:-1:-1;;;;;1824:11:1;1810:10;:25;1802:62;;;;;-1:-1:-1;;;1802:62:1;;;;;;;;;;;;-1:-1:-1;;;1802:62:1;;;;;;;;;;;;;;;1874:5;:14;;-1:-1:-1;;;;;;1874:14:1;-1:-1:-1;;;;;1874:14:1;;;;;;;;;;1749:146::o;96:2464::-;;;;;;;;:::o",
   "abi": [
     {
       "inputs": [
@@ -48,6 +48,21 @@
       ],
       "name": "PairCreated",
       "type": "event"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "INIT_CODE_PAIR_HASH",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
     },
     {
       "constant": true,
@@ -252,10 +267,10 @@
     "absolutePath": "contracts/DXswapFactory.sol",
     "exportedSymbols": {
       "DXswapFactory": [
-        630
+        641
       ]
     },
-    "id": 631,
+    "id": 642,
     "nodeType": "SourceUnit",
     "nodes": [
       {
@@ -274,8 +289,8 @@
         "file": "./interfaces/IDXswapFactory.sol",
         "id": 387,
         "nodeType": "ImportDirective",
-        "scope": 631,
-        "sourceUnit": 1925,
+        "scope": 642,
+        "sourceUnit": 1936,
         "src": "26:41:1",
         "symbolAliases": [],
         "unitAlias": ""
@@ -285,8 +300,8 @@
         "file": "./DXswapPair.sol",
         "id": 388,
         "nodeType": "ImportDirective",
-        "scope": 631,
-        "sourceUnit": 1713,
+        "scope": 642,
+        "sourceUnit": 1724,
         "src": "68:26:1",
         "symbolAliases": [],
         "unitAlias": ""
@@ -300,10 +315,10 @@
               "id": 389,
               "name": "IDXswapFactory",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 1924,
+              "referencedDeclaration": 1935,
               "src": "122:14:1",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_IDXswapFactory_$1924",
+                "typeIdentifier": "t_contract$_IDXswapFactory_$1935",
                 "typeString": "contract IDXswapFactory"
               }
             },
@@ -313,16 +328,16 @@
           }
         ],
         "contractDependencies": [
-          1712,
-          1924
+          1723,
+          1935
         ],
         "contractKind": "contract",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 630,
+        "id": 641,
         "linearizedBaseContracts": [
-          630,
-          1924
+          641,
+          1935
         ],
         "name": "DXswapFactory",
         "nodeType": "ContractDefinition",
@@ -332,7 +347,7 @@
             "id": 392,
             "name": "feeTo",
             "nodeType": "VariableDeclaration",
-            "scope": 630,
+            "scope": 641,
             "src": "143:20:1",
             "stateVariable": true,
             "storageLocation": "default",
@@ -359,7 +374,7 @@
             "id": 394,
             "name": "feeToSetter",
             "nodeType": "VariableDeclaration",
-            "scope": 630,
+            "scope": 641,
             "src": "169:26:1",
             "stateVariable": true,
             "storageLocation": "default",
@@ -386,7 +401,7 @@
             "id": 397,
             "name": "protocolFeeDenominator",
             "nodeType": "VariableDeclaration",
-            "scope": 630,
+            "scope": 641,
             "src": "201:39:1",
             "stateVariable": true,
             "storageLocation": "default",
@@ -425,12 +440,190 @@
             "visibility": "public"
           },
           {
+            "constant": true,
+            "id": 408,
+            "name": "INIT_CODE_PAIR_HASH",
+            "nodeType": "VariableDeclaration",
+            "scope": 641,
+            "src": "297:104:1",
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_bytes32",
+              "typeString": "bytes32"
+            },
+            "typeName": {
+              "id": 398,
+              "name": "bytes32",
+              "nodeType": "ElementaryTypeName",
+              "src": "297:7:1",
+              "typeDescriptions": {
+                "typeIdentifier": "t_bytes32",
+                "typeString": "bytes32"
+              }
+            },
+            "value": {
+              "argumentTypes": null,
+              "arguments": [
+                {
+                  "argumentTypes": null,
+                  "arguments": [
+                    {
+                      "argumentTypes": null,
+                      "expression": {
+                        "argumentTypes": null,
+                        "arguments": [
+                          {
+                            "argumentTypes": null,
+                            "id": 403,
+                            "name": "DXswapPair",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 1723,
+                            "src": "375:10:1",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_type$_t_contract$_DXswapPair_$1723_$",
+                              "typeString": "type(contract DXswapPair)"
+                            }
+                          }
+                        ],
+                        "expression": {
+                          "argumentTypes": [
+                            {
+                              "typeIdentifier": "t_type$_t_contract$_DXswapPair_$1723_$",
+                              "typeString": "type(contract DXswapPair)"
+                            }
+                          ],
+                          "id": 402,
+                          "name": "type",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 2510,
+                          "src": "370:4:1",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_function_metatype_pure$_t_address_$returns$__$",
+                            "typeString": "function (address) pure"
+                          }
+                        },
+                        "id": 404,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "functionCall",
+                        "lValueRequested": false,
+                        "names": [],
+                        "nodeType": "FunctionCall",
+                        "src": "370:16:1",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_magic_meta_type_t_contract$_DXswapPair_$1723",
+                          "typeString": "type(contract DXswapPair)"
+                        }
+                      },
+                      "id": 405,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "lValueRequested": false,
+                      "memberName": "creationCode",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": null,
+                      "src": "370:29:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes_memory_ptr",
+                        "typeString": "bytes memory"
+                      }
+                    }
+                  ],
+                  "expression": {
+                    "argumentTypes": [
+                      {
+                        "typeIdentifier": "t_bytes_memory_ptr",
+                        "typeString": "bytes memory"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": null,
+                      "id": 400,
+                      "name": "abi",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 2484,
+                      "src": "353:3:1",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_magic_abi",
+                        "typeString": "abi"
+                      }
+                    },
+                    "id": 401,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "lValueRequested": false,
+                    "memberName": "encodePacked",
+                    "nodeType": "MemberAccess",
+                    "referencedDeclaration": null,
+                    "src": "353:16:1",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_function_abiencodepacked_pure$__$returns$_t_bytes_memory_ptr_$",
+                      "typeString": "function () pure returns (bytes memory)"
+                    }
+                  },
+                  "id": 406,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": true,
+                  "kind": "functionCall",
+                  "lValueRequested": false,
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "353:47:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bytes_memory_ptr",
+                    "typeString": "bytes memory"
+                  }
+                }
+              ],
+              "expression": {
+                "argumentTypes": [
+                  {
+                    "typeIdentifier": "t_bytes_memory_ptr",
+                    "typeString": "bytes memory"
+                  }
+                ],
+                "id": 399,
+                "name": "keccak256",
+                "nodeType": "Identifier",
+                "overloadedDeclarations": [],
+                "referencedDeclaration": 2491,
+                "src": "343:9:1",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
+                  "typeString": "function (bytes memory) pure returns (bytes32)"
+                }
+              },
+              "id": 407,
+              "isConstant": false,
+              "isLValue": false,
+              "isPure": true,
+              "kind": "functionCall",
+              "lValueRequested": false,
+              "names": [],
+              "nodeType": "FunctionCall",
+              "src": "343:58:1",
+              "typeDescriptions": {
+                "typeIdentifier": "t_bytes32",
+                "typeString": "bytes32"
+              }
+            },
+            "visibility": "public"
+          },
+          {
             "constant": false,
-            "id": 403,
+            "id": 414,
             "name": "getPair",
             "nodeType": "VariableDeclaration",
-            "scope": 630,
-            "src": "298:62:1",
+            "scope": 641,
+            "src": "408:62:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -438,46 +631,46 @@
               "typeString": "mapping(address => mapping(address => address))"
             },
             "typeName": {
-              "id": 402,
+              "id": 413,
               "keyType": {
-                "id": 398,
+                "id": 409,
                 "name": "address",
                 "nodeType": "ElementaryTypeName",
-                "src": "306:7:1",
+                "src": "416:7:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_address",
                   "typeString": "address"
                 }
               },
               "nodeType": "Mapping",
-              "src": "298:47:1",
+              "src": "408:47:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_address_$_t_address_$_$",
                 "typeString": "mapping(address => mapping(address => address))"
               },
               "valueType": {
-                "id": 401,
+                "id": 412,
                 "keyType": {
-                  "id": 399,
+                  "id": 410,
                   "name": "address",
                   "nodeType": "ElementaryTypeName",
-                  "src": "325:7:1",
+                  "src": "435:7:1",
                   "typeDescriptions": {
                     "typeIdentifier": "t_address",
                     "typeString": "address"
                   }
                 },
                 "nodeType": "Mapping",
-                "src": "317:27:1",
+                "src": "427:27:1",
                 "typeDescriptions": {
                   "typeIdentifier": "t_mapping$_t_address_$_t_address_$",
                   "typeString": "mapping(address => address)"
                 },
                 "valueType": {
-                  "id": 400,
+                  "id": 411,
                   "name": "address",
                   "nodeType": "ElementaryTypeName",
-                  "src": "336:7:1",
+                  "src": "446:7:1",
                   "stateMutability": "nonpayable",
                   "typeDescriptions": {
                     "typeIdentifier": "t_address",
@@ -491,11 +684,11 @@
           },
           {
             "constant": false,
-            "id": 406,
+            "id": 417,
             "name": "allPairs",
             "nodeType": "VariableDeclaration",
-            "scope": 630,
-            "src": "366:25:1",
+            "scope": 641,
+            "src": "476:25:1",
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
@@ -504,20 +697,20 @@
             },
             "typeName": {
               "baseType": {
-                "id": 404,
+                "id": 415,
                 "name": "address",
                 "nodeType": "ElementaryTypeName",
-                "src": "366:7:1",
+                "src": "476:7:1",
                 "stateMutability": "nonpayable",
                 "typeDescriptions": {
                   "typeIdentifier": "t_address",
                   "typeString": "address"
                 }
               },
-              "id": 405,
+              "id": 416,
               "length": null,
               "nodeType": "ArrayTypeName",
-              "src": "366:9:1",
+              "src": "476:9:1",
               "typeDescriptions": {
                 "typeIdentifier": "t_array$_t_address_$dyn_storage_ptr",
                 "typeString": "address[]"
@@ -529,21 +722,21 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 416,
+            "id": 427,
             "name": "PairCreated",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 415,
+              "id": 426,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 408,
+                  "id": 419,
                   "indexed": true,
                   "name": "token0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 416,
-                  "src": "416:22:1",
+                  "scope": 427,
+                  "src": "526:22:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -551,10 +744,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 407,
+                    "id": 418,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "416:7:1",
+                    "src": "526:7:1",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -566,12 +759,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 410,
+                  "id": 421,
                   "indexed": true,
                   "name": "token1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 416,
-                  "src": "440:22:1",
+                  "scope": 427,
+                  "src": "550:22:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -579,10 +772,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 409,
+                    "id": 420,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "440:7:1",
+                    "src": "550:7:1",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -594,12 +787,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 412,
+                  "id": 423,
                   "indexed": false,
                   "name": "pair",
                   "nodeType": "VariableDeclaration",
-                  "scope": 416,
-                  "src": "464:12:1",
+                  "scope": 427,
+                  "src": "574:12:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -607,10 +800,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 411,
+                    "id": 422,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "464:7:1",
+                    "src": "574:7:1",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -622,12 +815,12 @@
                 },
                 {
                   "constant": false,
-                  "id": 414,
+                  "id": 425,
                   "indexed": false,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 416,
-                  "src": "478:4:1",
+                  "scope": 427,
+                  "src": "588:4:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -635,10 +828,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 413,
+                    "id": 424,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "478:4:1",
+                    "src": "588:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -648,32 +841,32 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "415:68:1"
+              "src": "525:68:1"
             },
-            "src": "398:86:1"
+            "src": "508:86:1"
           },
           {
             "body": {
-              "id": 425,
+              "id": 436,
               "nodeType": "Block",
-              "src": "531:43:1",
+              "src": "641:43:1",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 423,
+                    "id": 434,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 421,
+                      "id": 432,
                       "name": "feeToSetter",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 394,
-                      "src": "541:11:1",
+                      "src": "651:11:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -683,47 +876,47 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 422,
+                      "id": 433,
                       "name": "_feeToSetter",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 418,
-                      "src": "555:12:1",
+                      "referencedDeclaration": 429,
+                      "src": "665:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "541:26:1",
+                    "src": "651:26:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
                     }
                   },
-                  "id": 424,
+                  "id": 435,
                   "nodeType": "ExpressionStatement",
-                  "src": "541:26:1"
+                  "src": "651:26:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 426,
+            "id": 437,
             "implemented": true,
             "kind": "constructor",
             "modifiers": [],
             "name": "",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 419,
+              "id": 430,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 418,
+                  "id": 429,
                   "name": "_feeToSetter",
                   "nodeType": "VariableDeclaration",
-                  "scope": 426,
-                  "src": "502:20:1",
+                  "scope": 437,
+                  "src": "612:20:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -731,10 +924,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 417,
+                    "id": 428,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "502:7:1",
+                    "src": "612:7:1",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -745,43 +938,43 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "501:22:1"
+              "src": "611:22:1"
             },
             "returnParameters": {
-              "id": 420,
+              "id": 431,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "531:0:1"
+              "src": "641:0:1"
             },
-            "scope": 630,
-            "src": "490:84:1",
+            "scope": 641,
+            "src": "600:84:1",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           },
           {
             "body": {
-              "id": 434,
+              "id": 445,
               "nodeType": "Block",
-              "src": "635:39:1",
+              "src": "745:39:1",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
                     "expression": {
                       "argumentTypes": null,
-                      "id": 431,
+                      "id": 442,
                       "name": "allPairs",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 406,
-                      "src": "652:8:1",
+                      "referencedDeclaration": 417,
+                      "src": "762:8:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_array$_t_address_$dyn_storage",
                         "typeString": "address[] storage ref"
                       }
                     },
-                    "id": 432,
+                    "id": 443,
                     "isConstant": false,
                     "isLValue": true,
                     "isPure": false,
@@ -789,43 +982,43 @@
                     "memberName": "length",
                     "nodeType": "MemberAccess",
                     "referencedDeclaration": null,
-                    "src": "652:15:1",
+                    "src": "762:15:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
                     }
                   },
-                  "functionReturnParameters": 430,
-                  "id": 433,
+                  "functionReturnParameters": 441,
+                  "id": 444,
                   "nodeType": "Return",
-                  "src": "645:22:1"
+                  "src": "755:22:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 435,
+            "id": 446,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "allPairsLength",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 427,
+              "id": 438,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "603:2:1"
+              "src": "713:2:1"
             },
             "returnParameters": {
-              "id": 430,
+              "id": 441,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 429,
+                  "id": 440,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 435,
-                  "src": "629:4:1",
+                  "scope": 446,
+                  "src": "739:4:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -833,10 +1026,10 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 428,
+                    "id": 439,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
-                    "src": "629:4:1",
+                    "src": "739:4:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
@@ -846,19 +1039,19 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "628:6:1"
+              "src": "738:6:1"
             },
-            "scope": 630,
-            "src": "580:94:1",
+            "scope": 641,
+            "src": "690:94:1",
             "stateMutability": "view",
-            "superFunction": 1892,
+            "superFunction": 1903,
             "visibility": "external"
           },
           {
             "body": {
-              "id": 544,
+              "id": 555,
               "nodeType": "Block",
-              "src": "764:870:1",
+              "src": "873:870:1",
               "statements": [
                 {
                   "expression": {
@@ -870,19 +1063,19 @@
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         },
-                        "id": 447,
+                        "id": 458,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 445,
+                          "id": 456,
                           "name": "tokenA",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 437,
-                          "src": "782:6:1",
+                          "referencedDeclaration": 448,
+                          "src": "891:6:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -892,18 +1085,18 @@
                         "operator": "!=",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 446,
+                          "id": 457,
                           "name": "tokenB",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 439,
-                          "src": "792:6:1",
+                          "referencedDeclaration": 450,
+                          "src": "901:6:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
                           }
                         },
-                        "src": "782:16:1",
+                        "src": "891:16:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -912,14 +1105,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170466163746f72793a204944454e544943414c5f414444524553534553",
-                        "id": 448,
+                        "id": 459,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "800:36:1",
+                        "src": "909:36:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_cb681869b0bda04ddd0228715f4267a36b6867e9cac163e158c4f68b1183038f",
@@ -939,21 +1132,21 @@
                           "typeString": "literal_string \"DXswapFactory: IDENTICAL_ADDRESSES\""
                         }
                       ],
-                      "id": 444,
+                      "id": 455,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
-                      "src": "774:7:1",
+                      "referencedDeclaration": 2501,
+                      "src": "883:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 449,
+                    "id": 460,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -961,29 +1154,29 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "774:63:1",
+                    "src": "883:63:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 450,
+                  "id": 461,
                   "nodeType": "ExpressionStatement",
-                  "src": "774:63:1"
+                  "src": "883:63:1"
                 },
                 {
                   "assignments": [
-                    452,
-                    454
+                    463,
+                    465
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 452,
+                      "id": 463,
                       "name": "token0",
                       "nodeType": "VariableDeclaration",
-                      "scope": 544,
-                      "src": "848:14:1",
+                      "scope": 555,
+                      "src": "957:14:1",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -991,10 +1184,10 @@
                         "typeString": "address"
                       },
                       "typeName": {
-                        "id": 451,
+                        "id": 462,
                         "name": "address",
                         "nodeType": "ElementaryTypeName",
-                        "src": "848:7:1",
+                        "src": "957:7:1",
                         "stateMutability": "nonpayable",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -1006,11 +1199,11 @@
                     },
                     {
                       "constant": false,
-                      "id": 454,
+                      "id": 465,
                       "name": "token1",
                       "nodeType": "VariableDeclaration",
-                      "scope": 544,
-                      "src": "864:14:1",
+                      "scope": 555,
+                      "src": "973:14:1",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -1018,10 +1211,10 @@
                         "typeString": "address"
                       },
                       "typeName": {
-                        "id": 453,
+                        "id": 464,
                         "name": "address",
                         "nodeType": "ElementaryTypeName",
-                        "src": "864:7:1",
+                        "src": "973:7:1",
                         "stateMutability": "nonpayable",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -1032,7 +1225,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 465,
+                  "id": 476,
                   "initialValue": {
                     "argumentTypes": null,
                     "condition": {
@@ -1041,19 +1234,19 @@
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       },
-                      "id": 457,
+                      "id": 468,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftExpression": {
                         "argumentTypes": null,
-                        "id": 455,
+                        "id": 466,
                         "name": "tokenA",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 437,
-                        "src": "882:6:1",
+                        "referencedDeclaration": 448,
+                        "src": "991:6:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -1063,18 +1256,18 @@
                       "operator": "<",
                       "rightExpression": {
                         "argumentTypes": null,
-                        "id": 456,
+                        "id": 467,
                         "name": "tokenB",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 439,
-                        "src": "891:6:1",
+                        "referencedDeclaration": 450,
+                        "src": "1000:6:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         }
                       },
-                      "src": "882:15:1",
+                      "src": "991:15:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
@@ -1085,12 +1278,12 @@
                       "components": [
                         {
                           "argumentTypes": null,
-                          "id": 461,
+                          "id": 472,
                           "name": "tokenB",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 439,
-                          "src": "920:6:1",
+                          "referencedDeclaration": 450,
+                          "src": "1029:6:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -1098,49 +1291,49 @@
                         },
                         {
                           "argumentTypes": null,
-                          "id": 462,
+                          "id": 473,
                           "name": "tokenA",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 437,
-                          "src": "928:6:1",
+                          "referencedDeclaration": 448,
+                          "src": "1037:6:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
                           }
                         }
                       ],
-                      "id": 463,
+                      "id": 474,
                       "isConstant": false,
                       "isInlineArray": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "nodeType": "TupleExpression",
-                      "src": "919:16:1",
+                      "src": "1028:16:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_tuple$_t_address_$_t_address_$",
                         "typeString": "tuple(address,address)"
                       }
                     },
-                    "id": 464,
+                    "id": 475,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "nodeType": "Conditional",
-                    "src": "882:53:1",
+                    "src": "991:53:1",
                     "trueExpression": {
                       "argumentTypes": null,
                       "components": [
                         {
                           "argumentTypes": null,
-                          "id": 458,
+                          "id": 469,
                           "name": "tokenA",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 437,
-                          "src": "901:6:1",
+                          "referencedDeclaration": 448,
+                          "src": "1010:6:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -1148,26 +1341,26 @@
                         },
                         {
                           "argumentTypes": null,
-                          "id": 459,
+                          "id": 470,
                           "name": "tokenB",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 439,
-                          "src": "909:6:1",
+                          "referencedDeclaration": 450,
+                          "src": "1018:6:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
                           }
                         }
                       ],
-                      "id": 460,
+                      "id": 471,
                       "isConstant": false,
                       "isInlineArray": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "nodeType": "TupleExpression",
-                      "src": "900:16:1",
+                      "src": "1009:16:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_tuple$_t_address_$_t_address_$",
                         "typeString": "tuple(address,address)"
@@ -1179,7 +1372,7 @@
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "847:88:1"
+                  "src": "956:88:1"
                 },
                 {
                   "expression": {
@@ -1191,19 +1384,19 @@
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         },
-                        "id": 471,
+                        "id": 482,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 467,
+                          "id": 478,
                           "name": "token0",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 452,
-                          "src": "953:6:1",
+                          "referencedDeclaration": 463,
+                          "src": "1062:6:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -1217,14 +1410,14 @@
                             {
                               "argumentTypes": null,
                               "hexValue": "30",
-                              "id": 469,
+                              "id": 480,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
                               "kind": "number",
                               "lValueRequested": false,
                               "nodeType": "Literal",
-                              "src": "971:1:1",
+                              "src": "1080:1:1",
                               "subdenomination": null,
                               "typeDescriptions": {
                                 "typeIdentifier": "t_rational_0_by_1",
@@ -1240,20 +1433,20 @@
                                 "typeString": "int_const 0"
                               }
                             ],
-                            "id": 468,
+                            "id": 479,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "lValueRequested": false,
                             "nodeType": "ElementaryTypeNameExpression",
-                            "src": "963:7:1",
+                            "src": "1072:7:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_type$_t_address_$",
                               "typeString": "type(address)"
                             },
                             "typeName": "address"
                           },
-                          "id": 470,
+                          "id": 481,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -1261,13 +1454,13 @@
                           "lValueRequested": false,
                           "names": [],
                           "nodeType": "FunctionCall",
-                          "src": "963:10:1",
+                          "src": "1072:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address_payable",
                             "typeString": "address payable"
                           }
                         },
-                        "src": "953:20:1",
+                        "src": "1062:20:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -1276,14 +1469,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170466163746f72793a205a45524f5f41444452455353",
-                        "id": 472,
+                        "id": 483,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "975:29:1",
+                        "src": "1084:29:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_493420e2bff339e25055d7fb868796946f98638593a7338a1bca2623cfd24eea",
@@ -1303,21 +1496,21 @@
                           "typeString": "literal_string \"DXswapFactory: ZERO_ADDRESS\""
                         }
                       ],
-                      "id": 466,
+                      "id": 477,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
-                      "src": "945:7:1",
+                      "referencedDeclaration": 2501,
+                      "src": "1054:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 473,
+                    "id": 484,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1325,15 +1518,15 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "945:60:1",
+                    "src": "1054:60:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 474,
+                  "id": 485,
                   "nodeType": "ExpressionStatement",
-                  "src": "945:60:1"
+                  "src": "1054:60:1"
                 },
                 {
                   "expression": {
@@ -1345,7 +1538,7 @@
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         },
-                        "id": 484,
+                        "id": 495,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -1356,26 +1549,26 @@
                             "argumentTypes": null,
                             "baseExpression": {
                               "argumentTypes": null,
-                              "id": 476,
+                              "id": 487,
                               "name": "getPair",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 403,
-                              "src": "1023:7:1",
+                              "referencedDeclaration": 414,
+                              "src": "1132:7:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_address_$_t_address_$_$",
                                 "typeString": "mapping(address => mapping(address => address))"
                               }
                             },
-                            "id": 478,
+                            "id": 489,
                             "indexExpression": {
                               "argumentTypes": null,
-                              "id": 477,
+                              "id": 488,
                               "name": "token0",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 452,
-                              "src": "1031:6:1",
+                              "referencedDeclaration": 463,
+                              "src": "1140:6:1",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
                                 "typeString": "address"
@@ -1386,21 +1579,21 @@
                             "isPure": false,
                             "lValueRequested": false,
                             "nodeType": "IndexAccess",
-                            "src": "1023:15:1",
+                            "src": "1132:15:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_mapping$_t_address_$_t_address_$",
                               "typeString": "mapping(address => address)"
                             }
                           },
-                          "id": 480,
+                          "id": 491,
                           "indexExpression": {
                             "argumentTypes": null,
-                            "id": 479,
+                            "id": 490,
                             "name": "token1",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 454,
-                            "src": "1039:6:1",
+                            "referencedDeclaration": 465,
+                            "src": "1148:6:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
                               "typeString": "address"
@@ -1411,7 +1604,7 @@
                           "isPure": false,
                           "lValueRequested": false,
                           "nodeType": "IndexAccess",
-                          "src": "1023:23:1",
+                          "src": "1132:23:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -1425,14 +1618,14 @@
                             {
                               "argumentTypes": null,
                               "hexValue": "30",
-                              "id": 482,
+                              "id": 493,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
                               "kind": "number",
                               "lValueRequested": false,
                               "nodeType": "Literal",
-                              "src": "1058:1:1",
+                              "src": "1167:1:1",
                               "subdenomination": null,
                               "typeDescriptions": {
                                 "typeIdentifier": "t_rational_0_by_1",
@@ -1448,20 +1641,20 @@
                                 "typeString": "int_const 0"
                               }
                             ],
-                            "id": 481,
+                            "id": 492,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
                             "lValueRequested": false,
                             "nodeType": "ElementaryTypeNameExpression",
-                            "src": "1050:7:1",
+                            "src": "1159:7:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_type$_t_address_$",
                               "typeString": "type(address)"
                             },
                             "typeName": "address"
                           },
-                          "id": 483,
+                          "id": 494,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -1469,13 +1662,13 @@
                           "lValueRequested": false,
                           "names": [],
                           "nodeType": "FunctionCall",
-                          "src": "1050:10:1",
+                          "src": "1159:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address_payable",
                             "typeString": "address payable"
                           }
                         },
-                        "src": "1023:37:1",
+                        "src": "1132:37:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -1484,14 +1677,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170466163746f72793a20504149525f455849535453",
-                        "id": 485,
+                        "id": 496,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "1062:28:1",
+                        "src": "1171:28:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_022c06255a8f788e655247b585d4def08b8f1e84aafea832f94feacd7b3abd92",
@@ -1511,21 +1704,21 @@
                           "typeString": "literal_string \"DXswapFactory: PAIR_EXISTS\""
                         }
                       ],
-                      "id": 475,
+                      "id": 486,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
-                      "src": "1015:7:1",
+                      "referencedDeclaration": 2501,
+                      "src": "1124:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 486,
+                    "id": 497,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1533,28 +1726,28 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1015:76:1",
+                    "src": "1124:76:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 487,
+                  "id": 498,
                   "nodeType": "ExpressionStatement",
-                  "src": "1015:76:1"
+                  "src": "1124:76:1"
                 },
                 {
                   "assignments": [
-                    489
+                    500
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 489,
+                      "id": 500,
                       "name": "bytecode",
                       "nodeType": "VariableDeclaration",
-                      "scope": 544,
-                      "src": "1131:21:1",
+                      "scope": 555,
+                      "src": "1240:21:1",
                       "stateVariable": false,
                       "storageLocation": "memory",
                       "typeDescriptions": {
@@ -1562,10 +1755,10 @@
                         "typeString": "bytes"
                       },
                       "typeName": {
-                        "id": 488,
+                        "id": 499,
                         "name": "bytes",
                         "nodeType": "ElementaryTypeName",
-                        "src": "1131:5:1",
+                        "src": "1240:5:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes_storage_ptr",
                           "typeString": "bytes"
@@ -1575,7 +1768,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 494,
+                  "id": 505,
                   "initialValue": {
                     "argumentTypes": null,
                     "expression": {
@@ -1583,14 +1776,14 @@
                       "arguments": [
                         {
                           "argumentTypes": null,
-                          "id": 491,
+                          "id": 502,
                           "name": "DXswapPair",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1712,
-                          "src": "1160:10:1",
+                          "referencedDeclaration": 1723,
+                          "src": "1269:10:1",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_type$_t_contract$_DXswapPair_$1712_$",
+                            "typeIdentifier": "t_type$_t_contract$_DXswapPair_$1723_$",
                             "typeString": "type(contract DXswapPair)"
                           }
                         }
@@ -1598,22 +1791,22 @@
                       "expression": {
                         "argumentTypes": [
                           {
-                            "typeIdentifier": "t_type$_t_contract$_DXswapPair_$1712_$",
+                            "typeIdentifier": "t_type$_t_contract$_DXswapPair_$1723_$",
                             "typeString": "type(contract DXswapPair)"
                           }
                         ],
-                        "id": 490,
+                        "id": 501,
                         "name": "type",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 2499,
-                        "src": "1155:4:1",
+                        "referencedDeclaration": 2510,
+                        "src": "1264:4:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_function_metatype_pure$_t_address_$returns$__$",
                           "typeString": "function (address) pure"
                         }
                       },
-                      "id": 492,
+                      "id": 503,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
@@ -1621,13 +1814,13 @@
                       "lValueRequested": false,
                       "names": [],
                       "nodeType": "FunctionCall",
-                      "src": "1155:16:1",
+                      "src": "1264:16:1",
                       "typeDescriptions": {
-                        "typeIdentifier": "t_magic_meta_type_t_contract$_DXswapPair_$1712",
+                        "typeIdentifier": "t_magic_meta_type_t_contract$_DXswapPair_$1723",
                         "typeString": "type(contract DXswapPair)"
                       }
                     },
-                    "id": 493,
+                    "id": 504,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": true,
@@ -1635,27 +1828,27 @@
                     "memberName": "creationCode",
                     "nodeType": "MemberAccess",
                     "referencedDeclaration": null,
-                    "src": "1155:29:1",
+                    "src": "1264:29:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bytes_memory_ptr",
                       "typeString": "bytes memory"
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "1131:53:1"
+                  "src": "1240:53:1"
                 },
                 {
                   "assignments": [
-                    496
+                    507
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 496,
+                      "id": 507,
                       "name": "salt",
                       "nodeType": "VariableDeclaration",
-                      "scope": 544,
-                      "src": "1194:12:1",
+                      "scope": 555,
+                      "src": "1303:12:1",
                       "stateVariable": false,
                       "storageLocation": "default",
                       "typeDescriptions": {
@@ -1663,10 +1856,10 @@
                         "typeString": "bytes32"
                       },
                       "typeName": {
-                        "id": 495,
+                        "id": 506,
                         "name": "bytes32",
                         "nodeType": "ElementaryTypeName",
-                        "src": "1194:7:1",
+                        "src": "1303:7:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes32",
                           "typeString": "bytes32"
@@ -1676,7 +1869,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 504,
+                  "id": 515,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -1685,12 +1878,12 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 500,
+                            "id": 511,
                             "name": "token0",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 452,
-                            "src": "1236:6:1",
+                            "referencedDeclaration": 463,
+                            "src": "1345:6:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
                               "typeString": "address"
@@ -1698,12 +1891,12 @@
                           },
                           {
                             "argumentTypes": null,
-                            "id": 501,
+                            "id": 512,
                             "name": "token1",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 454,
-                            "src": "1244:6:1",
+                            "referencedDeclaration": 465,
+                            "src": "1353:6:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
                               "typeString": "address"
@@ -1723,18 +1916,18 @@
                           ],
                           "expression": {
                             "argumentTypes": null,
-                            "id": 498,
+                            "id": 509,
                             "name": "abi",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2473,
-                            "src": "1219:3:1",
+                            "referencedDeclaration": 2484,
+                            "src": "1328:3:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_abi",
                               "typeString": "abi"
                             }
                           },
-                          "id": 499,
+                          "id": 510,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -1742,13 +1935,13 @@
                           "memberName": "encodePacked",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": null,
-                          "src": "1219:16:1",
+                          "src": "1328:16:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_abiencodepacked_pure$__$returns$_t_bytes_memory_ptr_$",
                             "typeString": "function () pure returns (bytes memory)"
                           }
                         },
-                        "id": 502,
+                        "id": 513,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -1756,7 +1949,7 @@
                         "lValueRequested": false,
                         "names": [],
                         "nodeType": "FunctionCall",
-                        "src": "1219:32:1",
+                        "src": "1328:32:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bytes_memory_ptr",
                           "typeString": "bytes memory"
@@ -1770,18 +1963,18 @@
                           "typeString": "bytes memory"
                         }
                       ],
-                      "id": 497,
+                      "id": 508,
                       "name": "keccak256",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 2480,
-                      "src": "1209:9:1",
+                      "referencedDeclaration": 2491,
+                      "src": "1318:9:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
                         "typeString": "function (bytes memory) pure returns (bytes32)"
                       }
                     },
-                    "id": 503,
+                    "id": 514,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1789,58 +1982,58 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1209:43:1",
+                    "src": "1318:43:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bytes32",
                       "typeString": "bytes32"
                     }
                   },
                   "nodeType": "VariableDeclarationStatement",
-                  "src": "1194:58:1"
+                  "src": "1303:58:1"
                 },
                 {
                   "externalReferences": [
                     {
                       "pair": {
-                        "declaration": 442,
+                        "declaration": 453,
                         "isOffset": false,
                         "isSlot": false,
-                        "src": "1285:4:1",
+                        "src": "1394:4:1",
                         "valueSize": 1
                       }
                     },
                     {
                       "bytecode": {
-                        "declaration": 489,
+                        "declaration": 500,
                         "isOffset": false,
                         "isSlot": false,
-                        "src": "1329:8:1",
+                        "src": "1438:8:1",
                         "valueSize": 1
                       }
                     },
                     {
                       "salt": {
-                        "declaration": 496,
+                        "declaration": 507,
                         "isOffset": false,
                         "isSlot": false,
-                        "src": "1340:4:1",
+                        "src": "1449:4:1",
                         "valueSize": 1
                       }
                     },
                     {
                       "bytecode": {
-                        "declaration": 489,
+                        "declaration": 500,
                         "isOffset": false,
                         "isSlot": false,
-                        "src": "1308:8:1",
+                        "src": "1417:8:1",
                         "valueSize": 1
                       }
                     }
                   ],
-                  "id": 505,
+                  "id": 516,
                   "nodeType": "InlineAssembly",
                   "operations": "{\n    pair := create2(0, add(bytecode, 32), mload(bytecode), salt)\n}",
-                  "src": "1262:93:1"
+                  "src": "1371:93:1"
                 },
                 {
                   "expression": {
@@ -1848,12 +2041,12 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 510,
+                        "id": 521,
                         "name": "token0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 452,
-                        "src": "1393:6:1",
+                        "referencedDeclaration": 463,
+                        "src": "1502:6:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -1861,12 +2054,12 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 511,
+                        "id": 522,
                         "name": "token1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 454,
-                        "src": "1401:6:1",
+                        "referencedDeclaration": 465,
+                        "src": "1510:6:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -1889,12 +2082,12 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 507,
+                            "id": 518,
                             "name": "pair",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 442,
-                            "src": "1376:4:1",
+                            "referencedDeclaration": 453,
+                            "src": "1485:4:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
                               "typeString": "address"
@@ -1908,18 +2101,18 @@
                               "typeString": "address"
                             }
                           ],
-                          "id": 506,
+                          "id": 517,
                           "name": "IDXswapPair",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2176,
-                          "src": "1364:11:1",
+                          "referencedDeclaration": 2187,
+                          "src": "1473:11:1",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_type$_t_contract$_IDXswapPair_$2176_$",
+                            "typeIdentifier": "t_type$_t_contract$_IDXswapPair_$2187_$",
                             "typeString": "type(contract IDXswapPair)"
                           }
                         },
-                        "id": 508,
+                        "id": 519,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -1927,27 +2120,27 @@
                         "lValueRequested": false,
                         "names": [],
                         "nodeType": "FunctionCall",
-                        "src": "1364:17:1",
+                        "src": "1473:17:1",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_contract$_IDXswapPair_$2176",
+                          "typeIdentifier": "t_contract$_IDXswapPair_$2187",
                           "typeString": "contract IDXswapPair"
                         }
                       },
-                      "id": 509,
+                      "id": 520,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "memberName": "initialize",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 2170,
-                      "src": "1364:28:1",
+                      "referencedDeclaration": 2181,
+                      "src": "1473:28:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_external_nonpayable$_t_address_$_t_address_$returns$__$",
                         "typeString": "function (address,address) external"
                       }
                     },
-                    "id": 512,
+                    "id": 523,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1955,20 +2148,20 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1364:44:1",
+                    "src": "1473:44:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 513,
+                  "id": 524,
                   "nodeType": "ExpressionStatement",
-                  "src": "1364:44:1"
+                  "src": "1473:44:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 520,
+                    "id": 531,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1979,26 +2172,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 514,
+                          "id": 525,
                           "name": "getPair",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 403,
-                          "src": "1418:7:1",
+                          "referencedDeclaration": 414,
+                          "src": "1527:7:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_address_$_t_address_$_$",
                             "typeString": "mapping(address => mapping(address => address))"
                           }
                         },
-                        "id": 517,
+                        "id": 528,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 515,
+                          "id": 526,
                           "name": "token0",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 452,
-                          "src": "1426:6:1",
+                          "referencedDeclaration": 463,
+                          "src": "1535:6:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -2009,21 +2202,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1418:15:1",
+                        "src": "1527:15:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_address_$_t_address_$",
                           "typeString": "mapping(address => address)"
                         }
                       },
-                      "id": 518,
+                      "id": 529,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 516,
+                        "id": 527,
                         "name": "token1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 454,
-                        "src": "1434:6:1",
+                        "referencedDeclaration": 465,
+                        "src": "1543:6:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -2034,7 +2227,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1418:23:1",
+                      "src": "1527:23:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -2044,31 +2237,31 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 519,
+                      "id": 530,
                       "name": "pair",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 442,
-                      "src": "1444:4:1",
+                      "referencedDeclaration": 453,
+                      "src": "1553:4:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "1418:30:1",
+                    "src": "1527:30:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
                     }
                   },
-                  "id": 521,
+                  "id": 532,
                   "nodeType": "ExpressionStatement",
-                  "src": "1418:30:1"
+                  "src": "1527:30:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 528,
+                    "id": 539,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2079,26 +2272,26 @@
                         "argumentTypes": null,
                         "baseExpression": {
                           "argumentTypes": null,
-                          "id": 522,
+                          "id": 533,
                           "name": "getPair",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 403,
-                          "src": "1458:7:1",
+                          "referencedDeclaration": 414,
+                          "src": "1567:7:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_mapping$_t_address_$_t_mapping$_t_address_$_t_address_$_$",
                             "typeString": "mapping(address => mapping(address => address))"
                           }
                         },
-                        "id": 525,
+                        "id": 536,
                         "indexExpression": {
                           "argumentTypes": null,
-                          "id": 523,
+                          "id": 534,
                           "name": "token1",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 454,
-                          "src": "1466:6:1",
+                          "referencedDeclaration": 465,
+                          "src": "1575:6:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
@@ -2109,21 +2302,21 @@
                         "isPure": false,
                         "lValueRequested": false,
                         "nodeType": "IndexAccess",
-                        "src": "1458:15:1",
+                        "src": "1567:15:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_mapping$_t_address_$_t_address_$",
                           "typeString": "mapping(address => address)"
                         }
                       },
-                      "id": 526,
+                      "id": 537,
                       "indexExpression": {
                         "argumentTypes": null,
-                        "id": 524,
+                        "id": 535,
                         "name": "token0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 452,
-                        "src": "1474:6:1",
+                        "referencedDeclaration": 463,
+                        "src": "1583:6:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -2134,7 +2327,7 @@
                       "isPure": false,
                       "lValueRequested": true,
                       "nodeType": "IndexAccess",
-                      "src": "1458:23:1",
+                      "src": "1567:23:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -2144,26 +2337,26 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 527,
+                      "id": 538,
                       "name": "pair",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 442,
-                      "src": "1484:4:1",
+                      "referencedDeclaration": 453,
+                      "src": "1593:4:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "1458:30:1",
+                    "src": "1567:30:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
                     }
                   },
-                  "id": 529,
+                  "id": 540,
                   "nodeType": "ExpressionStatement",
-                  "src": "1458:30:1"
+                  "src": "1567:30:1"
                 },
                 {
                   "expression": {
@@ -2171,12 +2364,12 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 533,
+                        "id": 544,
                         "name": "pair",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 442,
-                        "src": "1557:4:1",
+                        "referencedDeclaration": 453,
+                        "src": "1666:4:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -2192,18 +2385,18 @@
                       ],
                       "expression": {
                         "argumentTypes": null,
-                        "id": 530,
+                        "id": 541,
                         "name": "allPairs",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 406,
-                        "src": "1543:8:1",
+                        "referencedDeclaration": 417,
+                        "src": "1652:8:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_array$_t_address_$dyn_storage",
                           "typeString": "address[] storage ref"
                         }
                       },
-                      "id": 532,
+                      "id": 543,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -2211,13 +2404,13 @@
                       "memberName": "push",
                       "nodeType": "MemberAccess",
                       "referencedDeclaration": null,
-                      "src": "1543:13:1",
+                      "src": "1652:13:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_arraypush_nonpayable$_t_address_$returns$_t_uint256_$",
                         "typeString": "function (address) returns (uint256)"
                       }
                     },
-                    "id": 534,
+                    "id": 545,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2225,15 +2418,15 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1543:19:1",
+                    "src": "1652:19:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
                     }
                   },
-                  "id": 535,
+                  "id": 546,
                   "nodeType": "ExpressionStatement",
-                  "src": "1543:19:1"
+                  "src": "1652:19:1"
                 },
                 {
                   "eventCall": {
@@ -2241,12 +2434,12 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 537,
+                        "id": 548,
                         "name": "token0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 452,
-                        "src": "1589:6:1",
+                        "referencedDeclaration": 463,
+                        "src": "1698:6:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -2254,12 +2447,12 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 538,
+                        "id": 549,
                         "name": "token1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 454,
-                        "src": "1597:6:1",
+                        "referencedDeclaration": 465,
+                        "src": "1706:6:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -2267,12 +2460,12 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 539,
+                        "id": 550,
                         "name": "pair",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 442,
-                        "src": "1605:4:1",
+                        "referencedDeclaration": 453,
+                        "src": "1714:4:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
@@ -2282,18 +2475,18 @@
                         "argumentTypes": null,
                         "expression": {
                           "argumentTypes": null,
-                          "id": 540,
+                          "id": 551,
                           "name": "allPairs",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 406,
-                          "src": "1611:8:1",
+                          "referencedDeclaration": 417,
+                          "src": "1720:8:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_array$_t_address_$dyn_storage",
                             "typeString": "address[] storage ref"
                           }
                         },
-                        "id": 541,
+                        "id": 552,
                         "isConstant": false,
                         "isLValue": true,
                         "isPure": false,
@@ -2301,7 +2494,7 @@
                         "memberName": "length",
                         "nodeType": "MemberAccess",
                         "referencedDeclaration": null,
-                        "src": "1611:15:1",
+                        "src": "1720:15:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
@@ -2327,20 +2520,20 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 536,
+                      "id": 547,
                       "name": "PairCreated",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        416
+                        427
                       ],
-                      "referencedDeclaration": 416,
-                      "src": "1577:11:1",
+                      "referencedDeclaration": 427,
+                      "src": "1686:11:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_address_$_t_address_$_t_uint256_$returns$__$",
                         "typeString": "function (address,address,address,uint256)"
                       }
                     },
-                    "id": 542,
+                    "id": 553,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2348,36 +2541,36 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1577:50:1",
+                    "src": "1686:50:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 543,
+                  "id": 554,
                   "nodeType": "EmitStatement",
-                  "src": "1572:55:1"
+                  "src": "1681:55:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 545,
+            "id": 556,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "createPair",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 440,
+              "id": 451,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 437,
+                  "id": 448,
                   "name": "tokenA",
                   "nodeType": "VariableDeclaration",
-                  "scope": 545,
-                  "src": "700:14:1",
+                  "scope": 556,
+                  "src": "809:14:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2385,10 +2578,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 436,
+                    "id": 447,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "700:7:1",
+                    "src": "809:7:1",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -2400,11 +2593,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 439,
+                  "id": 450,
                   "name": "tokenB",
                   "nodeType": "VariableDeclaration",
-                  "scope": 545,
-                  "src": "716:14:1",
+                  "scope": 556,
+                  "src": "825:14:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2412,10 +2605,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 438,
+                    "id": 449,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "716:7:1",
+                    "src": "825:7:1",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -2426,19 +2619,19 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "699:32:1"
+              "src": "808:32:1"
             },
             "returnParameters": {
-              "id": 443,
+              "id": 454,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 442,
+                  "id": 453,
                   "name": "pair",
                   "nodeType": "VariableDeclaration",
-                  "scope": 545,
-                  "src": "750:12:1",
+                  "scope": 556,
+                  "src": "859:12:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2446,10 +2639,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 441,
+                    "id": 452,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "750:7:1",
+                    "src": "859:7:1",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -2460,19 +2653,19 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "749:14:1"
+              "src": "858:14:1"
             },
-            "scope": 630,
-            "src": "680:954:1",
+            "scope": 641,
+            "src": "789:954:1",
             "stateMutability": "nonpayable",
-            "superFunction": 1901,
+            "superFunction": 1912,
             "visibility": "external"
           },
           {
             "body": {
-              "id": 562,
+              "id": 573,
               "nodeType": "Block",
-              "src": "1683:103:1",
+              "src": "1792:103:1",
               "statements": [
                 {
                   "expression": {
@@ -2484,7 +2677,7 @@
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         },
-                        "id": 554,
+                        "id": 565,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -2493,18 +2686,18 @@
                           "argumentTypes": null,
                           "expression": {
                             "argumentTypes": null,
-                            "id": 551,
+                            "id": 562,
                             "name": "msg",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2486,
-                            "src": "1701:3:1",
+                            "referencedDeclaration": 2497,
+                            "src": "1810:3:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_message",
                               "typeString": "msg"
                             }
                           },
-                          "id": 552,
+                          "id": 563,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -2512,7 +2705,7 @@
                           "memberName": "sender",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": null,
-                          "src": "1701:10:1",
+                          "src": "1810:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address_payable",
                             "typeString": "address payable"
@@ -2522,18 +2715,18 @@
                         "operator": "==",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 553,
+                          "id": 564,
                           "name": "feeToSetter",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 394,
-                          "src": "1715:11:1",
+                          "src": "1824:11:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
                           }
                         },
-                        "src": "1701:25:1",
+                        "src": "1810:25:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -2542,14 +2735,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170466163746f72793a20464f5242494444454e",
-                        "id": 555,
+                        "id": 566,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "1728:26:1",
+                        "src": "1837:26:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_717ccaa0cf96ff351721707fe290d0eeb6a5c76b10c19d2e4db54b6ae766cbdc",
@@ -2569,21 +2762,21 @@
                           "typeString": "literal_string \"DXswapFactory: FORBIDDEN\""
                         }
                       ],
-                      "id": 550,
+                      "id": 561,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
-                      "src": "1693:7:1",
+                      "referencedDeclaration": 2501,
+                      "src": "1802:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 556,
+                    "id": 567,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2591,32 +2784,32 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1693:62:1",
+                    "src": "1802:62:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 557,
+                  "id": 568,
                   "nodeType": "ExpressionStatement",
-                  "src": "1693:62:1"
+                  "src": "1802:62:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 560,
+                    "id": 571,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 558,
+                      "id": 569,
                       "name": "feeTo",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 392,
-                      "src": "1765:5:1",
+                      "src": "1874:5:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -2626,47 +2819,47 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 559,
+                      "id": 570,
                       "name": "_feeTo",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 547,
-                      "src": "1773:6:1",
+                      "referencedDeclaration": 558,
+                      "src": "1882:6:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "1765:14:1",
+                    "src": "1874:14:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
                     }
                   },
-                  "id": 561,
+                  "id": 572,
                   "nodeType": "ExpressionStatement",
-                  "src": "1765:14:1"
+                  "src": "1874:14:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 563,
+            "id": 574,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "setFeeTo",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 548,
+              "id": 559,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 547,
+                  "id": 558,
                   "name": "_feeTo",
                   "nodeType": "VariableDeclaration",
-                  "scope": 563,
-                  "src": "1658:14:1",
+                  "scope": 574,
+                  "src": "1767:14:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2674,10 +2867,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 546,
+                    "id": 557,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1658:7:1",
+                    "src": "1767:7:1",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -2688,25 +2881,25 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1657:16:1"
+              "src": "1766:16:1"
             },
             "returnParameters": {
-              "id": 549,
+              "id": 560,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1683:0:1"
+              "src": "1792:0:1"
             },
-            "scope": 630,
-            "src": "1640:146:1",
+            "scope": 641,
+            "src": "1749:146:1",
             "stateMutability": "nonpayable",
-            "superFunction": 1906,
+            "superFunction": 1917,
             "visibility": "external"
           },
           {
             "body": {
-              "id": 580,
+              "id": 591,
               "nodeType": "Block",
-              "src": "1847:115:1",
+              "src": "1956:115:1",
               "statements": [
                 {
                   "expression": {
@@ -2718,7 +2911,7 @@
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         },
-                        "id": 572,
+                        "id": 583,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -2727,18 +2920,18 @@
                           "argumentTypes": null,
                           "expression": {
                             "argumentTypes": null,
-                            "id": 569,
+                            "id": 580,
                             "name": "msg",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2486,
-                            "src": "1865:3:1",
+                            "referencedDeclaration": 2497,
+                            "src": "1974:3:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_message",
                               "typeString": "msg"
                             }
                           },
-                          "id": 570,
+                          "id": 581,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -2746,7 +2939,7 @@
                           "memberName": "sender",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": null,
-                          "src": "1865:10:1",
+                          "src": "1974:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address_payable",
                             "typeString": "address payable"
@@ -2756,18 +2949,18 @@
                         "operator": "==",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 571,
+                          "id": 582,
                           "name": "feeToSetter",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 394,
-                          "src": "1879:11:1",
+                          "src": "1988:11:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
                           }
                         },
-                        "src": "1865:25:1",
+                        "src": "1974:25:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -2776,14 +2969,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170466163746f72793a20464f5242494444454e",
-                        "id": 573,
+                        "id": 584,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "1892:26:1",
+                        "src": "2001:26:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_717ccaa0cf96ff351721707fe290d0eeb6a5c76b10c19d2e4db54b6ae766cbdc",
@@ -2803,21 +2996,21 @@
                           "typeString": "literal_string \"DXswapFactory: FORBIDDEN\""
                         }
                       ],
-                      "id": 568,
+                      "id": 579,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
-                      "src": "1857:7:1",
+                      "referencedDeclaration": 2501,
+                      "src": "1966:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 574,
+                    "id": 585,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2825,32 +3018,32 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "1857:62:1",
+                    "src": "1966:62:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 575,
+                  "id": 586,
                   "nodeType": "ExpressionStatement",
-                  "src": "1857:62:1"
+                  "src": "1966:62:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 578,
+                    "id": 589,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 576,
+                      "id": 587,
                       "name": "feeToSetter",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 394,
-                      "src": "1929:11:1",
+                      "src": "2038:11:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
@@ -2860,47 +3053,47 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 577,
+                      "id": 588,
                       "name": "_feeToSetter",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 565,
-                      "src": "1943:12:1",
+                      "referencedDeclaration": 576,
+                      "src": "2052:12:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       }
                     },
-                    "src": "1929:26:1",
+                    "src": "2038:26:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
                       "typeString": "address"
                     }
                   },
-                  "id": 579,
+                  "id": 590,
                   "nodeType": "ExpressionStatement",
-                  "src": "1929:26:1"
+                  "src": "2038:26:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 581,
+            "id": 592,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "setFeeToSetter",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 566,
+              "id": 577,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 565,
+                  "id": 576,
                   "name": "_feeToSetter",
                   "nodeType": "VariableDeclaration",
-                  "scope": 581,
-                  "src": "1816:20:1",
+                  "scope": 592,
+                  "src": "1925:20:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -2908,10 +3101,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 564,
+                    "id": 575,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1816:7:1",
+                    "src": "1925:7:1",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -2922,25 +3115,25 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1815:22:1"
+              "src": "1924:22:1"
             },
             "returnParameters": {
-              "id": 567,
+              "id": 578,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "1847:0:1"
+              "src": "1956:0:1"
             },
-            "scope": 630,
-            "src": "1792:170:1",
+            "scope": 641,
+            "src": "1901:170:1",
             "stateMutability": "nonpayable",
-            "superFunction": 1911,
+            "superFunction": 1922,
             "visibility": "external"
           },
           {
             "body": {
-              "id": 605,
+              "id": 616,
               "nodeType": "Block",
-              "src": "2036:215:1",
+              "src": "2145:215:1",
               "statements": [
                 {
                   "expression": {
@@ -2952,7 +3145,7 @@
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         },
-                        "id": 590,
+                        "id": 601,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -2961,18 +3154,18 @@
                           "argumentTypes": null,
                           "expression": {
                             "argumentTypes": null,
-                            "id": 587,
+                            "id": 598,
                             "name": "msg",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2486,
-                            "src": "2054:3:1",
+                            "referencedDeclaration": 2497,
+                            "src": "2163:3:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_message",
                               "typeString": "msg"
                             }
                           },
-                          "id": 588,
+                          "id": 599,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -2980,7 +3173,7 @@
                           "memberName": "sender",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": null,
-                          "src": "2054:10:1",
+                          "src": "2163:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address_payable",
                             "typeString": "address payable"
@@ -2990,18 +3183,18 @@
                         "operator": "==",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 589,
+                          "id": 600,
                           "name": "feeToSetter",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 394,
-                          "src": "2068:11:1",
+                          "src": "2177:11:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
                           }
                         },
-                        "src": "2054:25:1",
+                        "src": "2163:25:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -3010,14 +3203,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170466163746f72793a20464f5242494444454e",
-                        "id": 591,
+                        "id": 602,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "2081:26:1",
+                        "src": "2190:26:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_717ccaa0cf96ff351721707fe290d0eeb6a5c76b10c19d2e4db54b6ae766cbdc",
@@ -3037,21 +3230,21 @@
                           "typeString": "literal_string \"DXswapFactory: FORBIDDEN\""
                         }
                       ],
-                      "id": 586,
+                      "id": 597,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
-                      "src": "2046:7:1",
+                      "referencedDeclaration": 2501,
+                      "src": "2155:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 592,
+                    "id": 603,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3059,15 +3252,15 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2046:62:1",
+                    "src": "2155:62:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 593,
+                  "id": 604,
                   "nodeType": "ExpressionStatement",
-                  "src": "2046:62:1"
+                  "src": "2155:62:1"
                 },
                 {
                   "expression": {
@@ -3079,19 +3272,19 @@
                           "typeIdentifier": "t_uint8",
                           "typeString": "uint8"
                         },
-                        "id": 597,
+                        "id": 608,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 595,
+                          "id": 606,
                           "name": "_protocolFeeDenominator",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 583,
-                          "src": "2126:23:1",
+                          "referencedDeclaration": 594,
+                          "src": "2235:23:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint8",
                             "typeString": "uint8"
@@ -3102,14 +3295,14 @@
                         "rightExpression": {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 596,
+                          "id": 607,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
                           "kind": "number",
                           "lValueRequested": false,
                           "nodeType": "Literal",
-                          "src": "2152:1:1",
+                          "src": "2261:1:1",
                           "subdenomination": null,
                           "typeDescriptions": {
                             "typeIdentifier": "t_rational_0_by_1",
@@ -3117,7 +3310,7 @@
                           },
                           "value": "0"
                         },
-                        "src": "2126:27:1",
+                        "src": "2235:27:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -3126,14 +3319,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170466163746f72793a20464f5242494444454e5f464545",
-                        "id": 598,
+                        "id": 609,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "2155:30:1",
+                        "src": "2264:30:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_d237eed8c0391d29a2092c13cefce55bd5524dd63c6f05e53b8453f4ee6013b4",
@@ -3153,21 +3346,21 @@
                           "typeString": "literal_string \"DXswapFactory: FORBIDDEN_FEE\""
                         }
                       ],
-                      "id": 594,
+                      "id": 605,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
-                      "src": "2118:7:1",
+                      "referencedDeclaration": 2501,
+                      "src": "2227:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 599,
+                    "id": 610,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3175,32 +3368,32 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2118:68:1",
+                    "src": "2227:68:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 600,
+                  "id": 611,
                   "nodeType": "ExpressionStatement",
-                  "src": "2118:68:1"
+                  "src": "2227:68:1"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 603,
+                    "id": 614,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 601,
+                      "id": 612,
                       "name": "protocolFeeDenominator",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
                       "referencedDeclaration": 397,
-                      "src": "2196:22:1",
+                      "src": "2305:22:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint8",
                         "typeString": "uint8"
@@ -3210,47 +3403,47 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 602,
+                      "id": 613,
                       "name": "_protocolFeeDenominator",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 583,
-                      "src": "2221:23:1",
+                      "referencedDeclaration": 594,
+                      "src": "2330:23:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint8",
                         "typeString": "uint8"
                       }
                     },
-                    "src": "2196:48:1",
+                    "src": "2305:48:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint8",
                       "typeString": "uint8"
                     }
                   },
-                  "id": 604,
+                  "id": 615,
                   "nodeType": "ExpressionStatement",
-                  "src": "2196:48:1"
+                  "src": "2305:48:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 606,
+            "id": 617,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "setProtocolFee",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 584,
+              "id": 595,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 583,
+                  "id": 594,
                   "name": "_protocolFeeDenominator",
                   "nodeType": "VariableDeclaration",
-                  "scope": 606,
-                  "src": "1996:29:1",
+                  "scope": 617,
+                  "src": "2105:29:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -3258,10 +3451,10 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 582,
+                    "id": 593,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
-                    "src": "1996:5:1",
+                    "src": "2105:5:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint8",
                       "typeString": "uint8"
@@ -3271,25 +3464,25 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "1995:31:1"
+              "src": "2104:31:1"
             },
             "returnParameters": {
-              "id": 585,
+              "id": 596,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "2036:0:1"
+              "src": "2145:0:1"
             },
-            "scope": 630,
-            "src": "1972:279:1",
+            "scope": 641,
+            "src": "2081:279:1",
             "stateMutability": "nonpayable",
-            "superFunction": 1916,
+            "superFunction": 1927,
             "visibility": "external"
           },
           {
             "body": {
-              "id": 628,
+              "id": 639,
               "nodeType": "Block",
-              "src": "2321:128:1",
+              "src": "2430:128:1",
               "statements": [
                 {
                   "expression": {
@@ -3301,7 +3494,7 @@
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         },
-                        "id": 617,
+                        "id": 628,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -3310,18 +3503,18 @@
                           "argumentTypes": null,
                           "expression": {
                             "argumentTypes": null,
-                            "id": 614,
+                            "id": 625,
                             "name": "msg",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2486,
-                            "src": "2339:3:1",
+                            "referencedDeclaration": 2497,
+                            "src": "2448:3:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_message",
                               "typeString": "msg"
                             }
                           },
-                          "id": 615,
+                          "id": 626,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -3329,7 +3522,7 @@
                           "memberName": "sender",
                           "nodeType": "MemberAccess",
                           "referencedDeclaration": null,
-                          "src": "2339:10:1",
+                          "src": "2448:10:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address_payable",
                             "typeString": "address payable"
@@ -3339,18 +3532,18 @@
                         "operator": "==",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 616,
+                          "id": 627,
                           "name": "feeToSetter",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
                           "referencedDeclaration": 394,
-                          "src": "2353:11:1",
+                          "src": "2462:11:1",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
                             "typeString": "address"
                           }
                         },
-                        "src": "2339:25:1",
+                        "src": "2448:25:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
@@ -3359,14 +3552,14 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170466163746f72793a20464f5242494444454e",
-                        "id": 618,
+                        "id": 629,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
                         "kind": "string",
                         "lValueRequested": false,
                         "nodeType": "Literal",
-                        "src": "2366:26:1",
+                        "src": "2475:26:1",
                         "subdenomination": null,
                         "typeDescriptions": {
                           "typeIdentifier": "t_stringliteral_717ccaa0cf96ff351721707fe290d0eeb6a5c76b10c19d2e4db54b6ae766cbdc",
@@ -3386,21 +3579,21 @@
                           "typeString": "literal_string \"DXswapFactory: FORBIDDEN\""
                         }
                       ],
-                      "id": 613,
+                      "id": 624,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
-                      "src": "2331:7:1",
+                      "referencedDeclaration": 2501,
+                      "src": "2440:7:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 619,
+                    "id": 630,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3408,15 +3601,15 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2331:62:1",
+                    "src": "2440:62:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 620,
+                  "id": 631,
                   "nodeType": "ExpressionStatement",
-                  "src": "2331:62:1"
+                  "src": "2440:62:1"
                 },
                 {
                   "expression": {
@@ -3424,12 +3617,12 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 625,
+                        "id": 636,
                         "name": "_swapFee",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 610,
-                        "src": "2433:8:1",
+                        "referencedDeclaration": 621,
+                        "src": "2542:8:1",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint8",
                           "typeString": "uint8"
@@ -3448,12 +3641,12 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 622,
+                            "id": 633,
                             "name": "_pair",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 608,
-                            "src": "2415:5:1",
+                            "referencedDeclaration": 619,
+                            "src": "2524:5:1",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
                               "typeString": "address"
@@ -3467,18 +3660,18 @@
                               "typeString": "address"
                             }
                           ],
-                          "id": 621,
+                          "id": 632,
                           "name": "IDXswapPair",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2176,
-                          "src": "2403:11:1",
+                          "referencedDeclaration": 2187,
+                          "src": "2512:11:1",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_type$_t_contract$_IDXswapPair_$2176_$",
+                            "typeIdentifier": "t_type$_t_contract$_IDXswapPair_$2187_$",
                             "typeString": "type(contract IDXswapPair)"
                           }
                         },
-                        "id": 623,
+                        "id": 634,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -3486,27 +3679,27 @@
                         "lValueRequested": false,
                         "names": [],
                         "nodeType": "FunctionCall",
-                        "src": "2403:18:1",
+                        "src": "2512:18:1",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_contract$_IDXswapPair_$2176",
+                          "typeIdentifier": "t_contract$_IDXswapPair_$2187",
                           "typeString": "contract IDXswapPair"
                         }
                       },
-                      "id": 624,
+                      "id": 635,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "memberName": "setSwapFee",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 2175,
-                      "src": "2403:29:1",
+                      "referencedDeclaration": 2186,
+                      "src": "2512:29:1",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_external_nonpayable$_t_uint8_$returns$__$",
                         "typeString": "function (uint8) external"
                       }
                     },
-                    "id": 626,
+                    "id": 637,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3514,36 +3707,36 @@
                     "lValueRequested": false,
                     "names": [],
                     "nodeType": "FunctionCall",
-                    "src": "2403:39:1",
+                    "src": "2512:39:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_tuple$__$",
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 627,
+                  "id": 638,
                   "nodeType": "ExpressionStatement",
-                  "src": "2403:39:1"
+                  "src": "2512:39:1"
                 }
               ]
             },
             "documentation": null,
-            "id": 629,
+            "id": 640,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "setSwapFee",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 611,
+              "id": 622,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 608,
+                  "id": 619,
                   "name": "_pair",
                   "nodeType": "VariableDeclaration",
-                  "scope": 629,
-                  "src": "2281:13:1",
+                  "scope": 640,
+                  "src": "2390:13:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -3551,10 +3744,10 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 607,
+                    "id": 618,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2281:7:1",
+                    "src": "2390:7:1",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -3566,11 +3759,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 610,
+                  "id": 621,
                   "name": "_swapFee",
                   "nodeType": "VariableDeclaration",
-                  "scope": 629,
-                  "src": "2296:14:1",
+                  "scope": 640,
+                  "src": "2405:14:1",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -3578,10 +3771,10 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 609,
+                    "id": 620,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
-                    "src": "2296:5:1",
+                    "src": "2405:5:1",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint8",
                       "typeString": "uint8"
@@ -3591,29 +3784,29 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "2280:31:1"
+              "src": "2389:31:1"
             },
             "returnParameters": {
-              "id": 612,
+              "id": 623,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "2321:0:1"
+              "src": "2430:0:1"
             },
-            "scope": 630,
-            "src": "2261:188:1",
+            "scope": 641,
+            "src": "2370:188:1",
             "stateMutability": "nonpayable",
-            "superFunction": 1923,
+            "superFunction": 1934,
             "visibility": "external"
           }
         ],
-        "scope": 631,
-        "src": "96:2355:1"
+        "scope": 642,
+        "src": "96:2464:1"
       }
     ],
-    "src": "0:2452:1"
+    "src": "0:2561:1"
   },
-  "bytecode": "0x60806040526001805460ff60a01b1916600560a01b17905534801561002357600080fd5b50604051612ecd380380612ecd8339818101604052602081101561004657600080fd5b5051600180546001600160a01b0319166001600160a01b03909216919091179055612e57806100766000396000f3fe608060405234801561001057600080fd5b50600436106100a95760003560e01c80634e91f811116100715780634e91f81114610146578063574f2ba314610166578063a2e74af614610180578063c9c65396146101a6578063e6a43905146101d4578063f46901ed14610202576100a9565b8063017e7e58146100ae578063094b7415146100d25780631519c024146100da5780631e3dd18b1461010b5780632ff7042a14610128575b600080fd5b6100b6610228565b604080516001600160a01b039092168252519081900360200190f35b6100b6610237565b610109600480360360408110156100f057600080fd5b5080356001600160a01b0316906020013560ff16610246565b005b6100b66004803603602081101561012157600080fd5b5035610306565b61013061032d565b6040805160ff9092168252519081900360200190f35b6101096004803603602081101561015c57600080fd5b503560ff1661033d565b61016e61040f565b60408051918252519081900360200190f35b6101096004803603602081101561019657600080fd5b50356001600160a01b0316610415565b6100b6600480360360408110156101bc57600080fd5b506001600160a01b0381358116916020013516610491565b6100b6600480360360408110156101ea57600080fd5b506001600160a01b03813581169160200135166107b3565b6101096004803603602081101561021857600080fd5b50356001600160a01b03166107d9565b6000546001600160a01b031681565b6001546001600160a01b031681565b6001546001600160a01b031633146102a0576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b6040805163649d222f60e01b815260ff8316600482015290516001600160a01b0384169163649d222f91602480830192600092919082900301818387803b1580156102ea57600080fd5b505af11580156102fe573d6000803e3d6000fd5b505050505050565b6003818154811061031357fe5b6000918252602090912001546001600160a01b0316905081565b600154600160a01b900460ff1681565b6001546001600160a01b03163314610397576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b60008160ff16116103ef576040805162461bcd60e51b815260206004820152601c60248201527f445873776170466163746f72793a20464f5242494444454e5f46454500000000604482015290519081900360640190fd5b6001805460ff909216600160a01b0260ff60a01b19909216919091179055565b60035490565b6001546001600160a01b0316331461046f576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b600180546001600160a01b0319166001600160a01b0392909216919091179055565b6000816001600160a01b0316836001600160a01b031614156104e45760405162461bcd60e51b8152600401808060200182810382526022815260200180612e016022913960400191505060405180910390fd5b600080836001600160a01b0316856001600160a01b03161061050757838561050a565b84845b90925090506001600160a01b03821661056a576040805162461bcd60e51b815260206004820152601b60248201527f445873776170466163746f72793a205a45524f5f414444524553530000000000604482015290519081900360640190fd5b6001600160a01b038281166000908152600260209081526040808320858516845290915290205416156105e4576040805162461bcd60e51b815260206004820152601a60248201527f445873776170466163746f72793a20504149525f455849535453000000000000604482015290519081900360640190fd5b6060604051806020016105f690610855565b6020820181038252601f19601f8201166040525090506000838360405160200180836001600160a01b03166001600160a01b031660601b8152601401826001600160a01b03166001600160a01b031660601b815260140192505050604051602081830303815290604052805190602001209050808251602084016000f56040805163485cc95560e01b81526001600160a01b038781166004830152868116602483015291519297509087169163485cc9559160448082019260009290919082900301818387803b1580156106c957600080fd5b505af11580156106dd573d6000803e3d6000fd5b505050506001600160a01b0384811660008181526002602081815260408084208987168086529083528185208054978d166001600160a01b031998891681179091559383528185208686528352818520805488168517905560038054600181018255958190527fc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b90950180549097168417909655925483519283529082015281517f0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9929181900390910190a35050505092915050565b60026020908152600092835260408084209091529082529020546001600160a01b031681565b6001546001600160a01b03163314610833576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b600080546001600160a01b0319166001600160a01b0392909216919091179055565b61259e806108638339019056fe6080604052600c805460ff1916601e1790556001600d5534801561002257600080fd5b50604051469080605261254c8239604080519182900360520182208282018252600683526504458737761760d41b6020938401528151808301835260018152603160f81b908401528151808401919091527f3649d708a7abf9e212d0a587955ead4123223014b2e46201dfb587457cbd4591818301527fc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6606082015260808101949094523060a0808601919091528151808603909101815260c09094019052825192019190912060035550600580546001600160a01b0319163317905561243e8061010e6000396000f3fe608060405234801561001057600080fd5b50600436106101cf5760003560e01c8063649d222f11610104578063a9059cbb116100a2578063d21220a711610071578063d21220a714610582578063d505accf1461058a578063dd62ed3e146105db578063fff6cae914610609576101cf565b8063a9059cbb14610520578063ba9a7a561461054c578063bc25cf7714610554578063c45a01551461057a576101cf565b80637464fc3d116100de5780637464fc3d146104ab5780637ecebe00146104b357806389afcb44146104d957806395d89b4114610518576101cf565b8063649d222f1461043f5780636a6278421461045f57806370a0823114610485576101cf565b806330adf81f11610171578063485cc9551161014b578063485cc955146103f957806354cf2aeb146104275780635909c0d51461042f5780635a3d549314610437576101cf565b806330adf81f146103cb578063313ce567146103d35780633644e515146103f1576101cf565b8063095ea7b3116101ad578063095ea7b3146103175780630dfe16811461035757806318160ddd1461037b57806323b872dd14610395576101cf565b8063022c0d9f146101d457806306fdde03146102625780630902f1ac146102df575b600080fd5b610260600480360360808110156101ea57600080fd5b8135916020810135916001600160a01b03604083013516919081019060808101606082013564010000000081111561022157600080fd5b82018360208201111561023357600080fd5b8035906020019184600183028401116401000000008311171561025557600080fd5b509092509050610611565b005b61026a610b6d565b6040805160208082528351818301528351919283929083019185019080838360005b838110156102a457818101518382015260200161028c565b50505050905090810190601f1680156102d15780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6102e7610b8f565b604080516001600160701b03948516815292909316602083015263ffffffff168183015290519081900360600190f35b6103436004803603604081101561032d57600080fd5b506001600160a01b038135169060200135610bb9565b604080519115158252519081900360200190f35b61035f610bd0565b604080516001600160a01b039092168252519081900360200190f35b610383610bdf565b60408051918252519081900360200190f35b610343600480360360608110156103ab57600080fd5b506001600160a01b03813581169160208101359091169060400135610be5565b610383610c7f565b6103db610ca3565b6040805160ff9092168252519081900360200190f35b610383610ca8565b6102606004803603604081101561040f57600080fd5b506001600160a01b0381358116916020013516610cae565b6103db610d33565b610383610d3c565b610383610d42565b6102606004803603602081101561045557600080fd5b503560ff16610d48565b6103836004803603602081101561047557600080fd5b50356001600160a01b0316610e0d565b6103836004803603602081101561049b57600080fd5b50356001600160a01b031661110e565b610383611120565b610383600480360360208110156104c957600080fd5b50356001600160a01b0316611126565b6104ff600480360360208110156104ef57600080fd5b50356001600160a01b0316611138565b6040805192835260208301919091528051918290030190f35b61026a6114df565b6103436004803603604081101561053657600080fd5b506001600160a01b0381351690602001356114fe565b61038361150b565b6102606004803603602081101561056a57600080fd5b50356001600160a01b0316611511565b61035f61167d565b61035f61168c565b610260600480360360e08110156105a057600080fd5b506001600160a01b03813581169160208101359091169060408101359060608101359060ff6080820135169060a08101359060c0013561169b565b610383600480360360408110156105f157600080fd5b506001600160a01b038135811691602001351661189f565b6102606118bc565b600d5460011461065d576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55841515806106705750600084115b6106ab5760405162461bcd60e51b81526004018080602001828103825260268152602001806123966026913960400191505060405180910390fd5b6000806106b6610b8f565b5091509150816001600160701b0316871080156106db5750806001600160701b031686105b6107165760405162461bcd60e51b81526004018080602001828103825260228152602001806123746022913960400191505060405180910390fd5b60065460075460009182916001600160a01b039182169190811690891682148015906107545750806001600160a01b0316896001600160a01b031614155b61079e576040805162461bcd60e51b8152602060048201526016602482015275445873776170506169723a20494e56414c49445f544f60501b604482015290519081900360640190fd5b8a156107af576107af828a8d611a1f565b89156107c0576107c0818a8c611a1f565b861561087b57886001600160a01b03166378b94ae6338d8d8c8c6040518663ffffffff1660e01b815260040180866001600160a01b03166001600160a01b03168152602001858152602001848152602001806020018281038252848482818152602001925080828437600081840152601f19601f8201169050808301925050509650505050505050600060405180830381600087803b15801561086257600080fd5b505af1158015610876573d6000803e3d6000fd5b505050505b604080516370a0823160e01b815230600482015290516001600160a01b038416916370a08231916024808301926020929190829003018186803b1580156108c157600080fd5b505afa1580156108d5573d6000803e3d6000fd5b505050506040513d60208110156108eb57600080fd5b5051604080516370a0823160e01b815230600482015290519195506001600160a01b038316916370a0823191602480820192602092909190829003018186803b15801561093757600080fd5b505afa15801561094b573d6000803e3d6000fd5b505050506040513d602081101561096157600080fd5b5051925060009150506001600160701b0385168a90038311610984576000610993565b89856001600160701b03160383035b9050600089856001600160701b03160383116109b05760006109bf565b89856001600160701b03160383035b905060008211806109d05750600081115b610a0b5760405162461bcd60e51b81526004018080602001828103825260258152602001806123bc6025913960400191505060405180910390fd5b600c5460ff1615610afb57600c54600090610a5290610a3490859060ff1663ffffffff611bb916565b610a468761271063ffffffff611bb916565b9063ffffffff611c1c16565b600c54909150600090610a7390610a3490859060ff1663ffffffff611bb916565b9050610aa56305f5e100610a996001600160701b038b8116908b1663ffffffff611bb916565b9063ffffffff611bb916565b610ab5838363ffffffff611bb916565b1015610af8576040805162461bcd60e51b815260206004820152600d60248201526c445873776170506169723a204b60981b604482015290519081900360640190fd5b50505b610b0784848888611c6c565b60408051838152602081018390528082018d9052606081018c905290516001600160a01b038b169133917fd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d8229181900360800190a350506001600d55505050505050505050565b6040518060400160405280600681526020016504458737761760d41b81525081565b6008546001600160701b0380821692600160701b830490911691600160e01b900463ffffffff1690565b6000610bc6338484611e32565b5060015b92915050565b6006546001600160a01b031681565b60005481565b6001600160a01b038316600090815260026020908152604080832033845290915281205460001914610c6a576001600160a01b0384166000908152600260209081526040808320338452909152902054610c45908363ffffffff611c1c16565b6001600160a01b03851660009081526002602090815260408083203384529091529020555b610c75848484611e94565b5060019392505050565b7f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c981565b601281565b60035481565b6005546001600160a01b03163314610d05576040805162461bcd60e51b8152602060048201526015602482015274222c39bbb0b82830b4b91d102327a92124a22222a760591b604482015290519081900360640190fd5b600680546001600160a01b039384166001600160a01b03199182161790915560078054929093169116179055565b600c5460ff1681565b60095481565b600a5481565b6005546001600160a01b03163314610d9e576040805162461bcd60e51b81526020600482015260146024820152732ab734b9bbb0b82b191d102327a92124a22222a760611b604482015290519081900360640190fd5b601e8160ff161115610df7576040805162461bcd60e51b815260206004820152601860248201527f556e697377617056323a20464f5242494444454e5f4645450000000000000000604482015290519081900360640190fd5b600c805460ff191660ff92909216919091179055565b6000600d54600114610e5b576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d81905580610e6b610b8f565b50600654604080516370a0823160e01b815230600482015290519395509193506000926001600160a01b03909116916370a08231916024808301926020929190829003018186803b158015610ebf57600080fd5b505afa158015610ed3573d6000803e3d6000fd5b505050506040513d6020811015610ee957600080fd5b5051600754604080516370a0823160e01b815230600482015290519293506000926001600160a01b03909216916370a0823191602480820192602092909190829003018186803b158015610f3c57600080fd5b505afa158015610f50573d6000803e3d6000fd5b505050506040513d6020811015610f6657600080fd5b505190506000610f85836001600160701b03871663ffffffff611c1c16565b90506000610fa2836001600160701b03871663ffffffff611c1c16565b90506000610fb08787611f4e565b60005490915080610fed57610fd96103e8610a46610fd4878763ffffffff611bb916565b612126565b9850610fe860006103e8612178565b61103c565b6110396001600160701b03891661100a868463ffffffff611bb916565b8161101157fe5b046001600160701b03891661102c868563ffffffff611bb916565b8161103357fe5b0461220e565b98505b6000891161107b5760405162461bcd60e51b815260040180806020018281038252602981526020018061234b6029913960400191505060405180910390fd5b6110858a8a612178565b61109186868a8a611c6c565b81156110c1576008546110bd906001600160701b0380821691600160701b90041663ffffffff611bb916565b600b555b6040805185815260208101859052815133927f4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f928290030190a250506001600d5550949695505050505050565b60016020526000908152604090205481565b600b5481565b60046020526000908152604090205481565b600080600d54600114611187576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d81905580611197610b8f565b50600654600754604080516370a0823160e01b815230600482015290519496509294506001600160a01b039182169391169160009184916370a08231916024808301926020929190829003018186803b1580156111f357600080fd5b505afa158015611207573d6000803e3d6000fd5b505050506040513d602081101561121d57600080fd5b5051604080516370a0823160e01b815230600482015290519192506000916001600160a01b038516916370a08231916024808301926020929190829003018186803b15801561126b57600080fd5b505afa15801561127f573d6000803e3d6000fd5b505050506040513d602081101561129557600080fd5b5051306000908152600160205260408120549192506112b48888611f4e565b600054909150806112cb848763ffffffff611bb916565b816112d257fe5b049a50806112e6848663ffffffff611bb916565b816112ed57fe5b04995060008b118015611300575060008a115b61133b5760405162461bcd60e51b81526004018080602001828103825260298152602001806123e16029913960400191505060405180910390fd5b6113453084612226565b611350878d8d611a1f565b61135b868d8c611a1f565b604080516370a0823160e01b815230600482015290516001600160a01b038916916370a08231916024808301926020929190829003018186803b1580156113a157600080fd5b505afa1580156113b5573d6000803e3d6000fd5b505050506040513d60208110156113cb57600080fd5b5051604080516370a0823160e01b815230600482015290519196506001600160a01b038816916370a0823191602480820192602092909190829003018186803b15801561141757600080fd5b505afa15801561142b573d6000803e3d6000fd5b505050506040513d602081101561144157600080fd5b5051935061145185858b8b611c6c565b81156114815760085461147d906001600160701b0380821691600160701b90041663ffffffff611bb916565b600b555b604080518c8152602081018c905281516001600160a01b038f169233927fdccd412f0b1252819cb1fd330b93224ca42612892bb3f4f789976e6d81936496929081900390910190a35050505050505050506001600d81905550915091565b6040518060400160405280600381526020016244585360e81b81525081565b6000610bc6338484611e94565b6103e881565b600d5460011461155d576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55600654600754600854604080516370a0823160e01b815230600482015290516001600160a01b03948516949093169261160c9285928792611607926001600160701b03169185916370a0823191602480820192602092909190829003018186803b1580156115cf57600080fd5b505afa1580156115e3573d6000803e3d6000fd5b505050506040513d60208110156115f957600080fd5b50519063ffffffff611c1c16565b611a1f565b600854604080516370a0823160e01b81523060048201529051611673928492879261160792600160701b90046001600160701b0316916001600160a01b038616916370a0823191602480820192602092909190829003018186803b1580156115cf57600080fd5b50506001600d5550565b6005546001600160a01b031681565b6007546001600160a01b031681565b428410156116e7576040805162461bcd60e51b815260206004820152601460248201527311161cddd85c115490cc8c0e881156141254915160621b604482015290519081900360640190fd5b6003546001600160a01b0380891660008181526004602090815260408083208054600180820190925582517f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c98186015280840196909652958d166060860152608085018c905260a085019590955260c08085018b90528151808603909101815260e08501825280519083012061190160f01b6101008601526101028501969096526101228085019690965280518085039096018652610142840180825286519683019690962095839052610162840180825286905260ff89166101828501526101a284018890526101c28401879052519193926101e280820193601f1981019281900390910190855afa158015611802573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b038116158015906118385750886001600160a01b0316816001600160a01b0316145b611889576040805162461bcd60e51b815260206004820152601e60248201527f44587377617045524332303a20494e56414c49445f5349474e41545552450000604482015290519081900360640190fd5b611894898989611e32565b505050505050505050565b600260209081526000928352604080842090915290825290205481565b600d54600114611908576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55600654604080516370a0823160e01b81523060048201529051611a18926001600160a01b0316916370a08231916024808301926020929190829003018186803b15801561195957600080fd5b505afa15801561196d573d6000803e3d6000fd5b505050506040513d602081101561198357600080fd5b5051600754604080516370a0823160e01b815230600482015290516001600160a01b03909216916370a0823191602480820192602092909190829003018186803b1580156119d057600080fd5b505afa1580156119e4573d6000803e3d6000fd5b505050506040513d60208110156119fa57600080fd5b50516008546001600160701b0380821691600160701b900416611c6c565b6001600d55565b604080518082018252601981527f7472616e7366657228616464726573732c75696e74323536290000000000000060209182015281516001600160a01b0385811660248301526044808301869052845180840390910181526064909201845291810180516001600160e01b031663a9059cbb60e01b1781529251815160009460609489169392918291908083835b60208310611acc5780518252601f199092019160209182019101611aad565b6001836020036101000a0380198251168184511680821785525050505050509050019150506000604051808303816000865af19150503d8060008114611b2e576040519150601f19603f3d011682016040523d82523d6000602084013e611b33565b606091505b5091509150818015611b61575080511580611b615750808060200190516020811015611b5e57600080fd5b50515b611bb2576040805162461bcd60e51b815260206004820152601b60248201527f445873776170506169723a205452414e534645525f4641494c45440000000000604482015290519081900360640190fd5b5050505050565b6000811580611bd457505080820282828281611bd157fe5b04145b610bca576040805162461bcd60e51b815260206004820152601460248201527364732d6d6174682d6d756c2d6f766572666c6f7760601b604482015290519081900360640190fd5b80820382811115610bca576040805162461bcd60e51b815260206004820152601560248201527464732d6d6174682d7375622d756e646572666c6f7760581b604482015290519081900360640190fd5b6001600160701b038411801590611c8a57506001600160701b038311155b611cd2576040805162461bcd60e51b8152602060048201526014602482015273445873776170506169723a204f564552464c4f5760601b604482015290519081900360640190fd5b60085463ffffffff42811691600160e01b90048116820390811615801590611d0257506001600160701b03841615155b8015611d1657506001600160701b03831615155b15611d87578063ffffffff16611d4485611d2f866122c4565b6001600160e01b03169063ffffffff6122d616565b600980546001600160e01b03929092169290920201905563ffffffff8116611d6f84611d2f876122c4565b600a80546001600160e01b0392909216929092020190555b600880546dffffffffffffffffffffffffffff19166001600160701b03888116919091176dffffffffffffffffffffffffffff60701b1916600160701b8883168102919091176001600160e01b0316600160e01b63ffffffff871602179283905560408051848416815291909304909116602082015281517f1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1929181900390910190a1505050505050565b6001600160a01b03808416600081815260026020908152604080832094871680845294825291829020859055815185815291517f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b9259281900390910190a3505050565b6001600160a01b038316600090815260016020526040902054611ebd908263ffffffff611c1c16565b6001600160a01b038085166000908152600160205260408082209390935590841681522054611ef2908263ffffffff6122fb16565b6001600160a01b0380841660008181526001602090815260409182902094909455805185815290519193928716927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef92918290030190a3505050565b600080600560009054906101000a90046001600160a01b03166001600160a01b031663017e7e586040518163ffffffff1660e01b815260040160206040518083038186803b158015611f9f57600080fd5b505afa158015611fb3573d6000803e3d6000fd5b505050506040513d6020811015611fc957600080fd5b5051600554604080516317fb821560e11b815290519293506000926001600160a01b0390921691632ff7042a91600480820192602092909190829003018186803b15801561201657600080fd5b505afa15801561202a573d6000803e3d6000fd5b505050506040513d602081101561204057600080fd5b5051600b546001600160a01b03841615801595509192509061211157801561210c576000612083610fd46001600160701b0389811690891663ffffffff611bb916565b9050600061209083612126565b9050808211156121095760006120be6120af848463ffffffff611c1c16565b6000549063ffffffff611bb916565b905060006120e5836120d98660ff8a1663ffffffff611bb916565b9063ffffffff6122fb16565b905060008183816120f257fe5b0490508015612105576121058882612178565b5050505b50505b61211d565b801561211d576000600b555b50505092915050565b60006003821115612169575080600160028204015b818110156121635780915060028182858161215257fe5b04018161215b57fe5b04905061213b565b50612173565b8115612173575060015b919050565b60005461218b908263ffffffff6122fb16565b60009081556001600160a01b0383168152600160205260409020546121b6908263ffffffff6122fb16565b6001600160a01b03831660008181526001602090815260408083209490945583518581529351929391927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9281900390910190a35050565b600081831061221d578161221f565b825b9392505050565b6001600160a01b03821660009081526001602052604090205461224f908263ffffffff611c1c16565b6001600160a01b0383166000908152600160205260408120919091555461227c908263ffffffff611c1c16565b60009081556040805183815290516001600160a01b038516917fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef919081900360200190a35050565b6001600160701b0316600160701b0290565b60006001600160701b0382166001600160e01b038416816122f357fe5b049392505050565b80820182811015610bca576040805162461bcd60e51b815260206004820152601460248201527364732d6d6174682d6164642d6f766572666c6f7760601b604482015290519081900360640190fdfe445873776170506169723a20494e53554646494349454e545f4c49515549444954595f4d494e544544445873776170506169723a20494e53554646494349454e545f4c4951554944495459445873776170506169723a20494e53554646494349454e545f4f55545055545f414d4f554e54445873776170506169723a20494e53554646494349454e545f494e5055545f414d4f554e54445873776170506169723a20494e53554646494349454e545f4c49515549444954595f4255524e4544a265627a7a723158204414f4546c1e72cfac1d316a481eff81257924cd834e99dcc36be6eee601896564736f6c63430005100032454950373132446f6d61696e28737472696e67206e616d652c737472696e672076657273696f6e2c75696e7432353620636861696e49642c6164647265737320766572696679696e67436f6e747261637429445873776170466163746f72793a204944454e544943414c5f414444524553534553a265627a7a72315820a6d83e1d0e8b912ba01bdc939865caf9874f37436f3208fde23242de19cb9f7264736f6c63430005100032",
-  "deployedBytecode": "0x608060405234801561001057600080fd5b50600436106100a95760003560e01c80634e91f811116100715780634e91f81114610146578063574f2ba314610166578063a2e74af614610180578063c9c65396146101a6578063e6a43905146101d4578063f46901ed14610202576100a9565b8063017e7e58146100ae578063094b7415146100d25780631519c024146100da5780631e3dd18b1461010b5780632ff7042a14610128575b600080fd5b6100b6610228565b604080516001600160a01b039092168252519081900360200190f35b6100b6610237565b610109600480360360408110156100f057600080fd5b5080356001600160a01b0316906020013560ff16610246565b005b6100b66004803603602081101561012157600080fd5b5035610306565b61013061032d565b6040805160ff9092168252519081900360200190f35b6101096004803603602081101561015c57600080fd5b503560ff1661033d565b61016e61040f565b60408051918252519081900360200190f35b6101096004803603602081101561019657600080fd5b50356001600160a01b0316610415565b6100b6600480360360408110156101bc57600080fd5b506001600160a01b0381358116916020013516610491565b6100b6600480360360408110156101ea57600080fd5b506001600160a01b03813581169160200135166107b3565b6101096004803603602081101561021857600080fd5b50356001600160a01b03166107d9565b6000546001600160a01b031681565b6001546001600160a01b031681565b6001546001600160a01b031633146102a0576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b6040805163649d222f60e01b815260ff8316600482015290516001600160a01b0384169163649d222f91602480830192600092919082900301818387803b1580156102ea57600080fd5b505af11580156102fe573d6000803e3d6000fd5b505050505050565b6003818154811061031357fe5b6000918252602090912001546001600160a01b0316905081565b600154600160a01b900460ff1681565b6001546001600160a01b03163314610397576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b60008160ff16116103ef576040805162461bcd60e51b815260206004820152601c60248201527f445873776170466163746f72793a20464f5242494444454e5f46454500000000604482015290519081900360640190fd5b6001805460ff909216600160a01b0260ff60a01b19909216919091179055565b60035490565b6001546001600160a01b0316331461046f576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b600180546001600160a01b0319166001600160a01b0392909216919091179055565b6000816001600160a01b0316836001600160a01b031614156104e45760405162461bcd60e51b8152600401808060200182810382526022815260200180612e016022913960400191505060405180910390fd5b600080836001600160a01b0316856001600160a01b03161061050757838561050a565b84845b90925090506001600160a01b03821661056a576040805162461bcd60e51b815260206004820152601b60248201527f445873776170466163746f72793a205a45524f5f414444524553530000000000604482015290519081900360640190fd5b6001600160a01b038281166000908152600260209081526040808320858516845290915290205416156105e4576040805162461bcd60e51b815260206004820152601a60248201527f445873776170466163746f72793a20504149525f455849535453000000000000604482015290519081900360640190fd5b6060604051806020016105f690610855565b6020820181038252601f19601f8201166040525090506000838360405160200180836001600160a01b03166001600160a01b031660601b8152601401826001600160a01b03166001600160a01b031660601b815260140192505050604051602081830303815290604052805190602001209050808251602084016000f56040805163485cc95560e01b81526001600160a01b038781166004830152868116602483015291519297509087169163485cc9559160448082019260009290919082900301818387803b1580156106c957600080fd5b505af11580156106dd573d6000803e3d6000fd5b505050506001600160a01b0384811660008181526002602081815260408084208987168086529083528185208054978d166001600160a01b031998891681179091559383528185208686528352818520805488168517905560038054600181018255958190527fc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b90950180549097168417909655925483519283529082015281517f0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9929181900390910190a35050505092915050565b60026020908152600092835260408084209091529082529020546001600160a01b031681565b6001546001600160a01b03163314610833576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b600080546001600160a01b0319166001600160a01b0392909216919091179055565b61259e806108638339019056fe6080604052600c805460ff1916601e1790556001600d5534801561002257600080fd5b50604051469080605261254c8239604080519182900360520182208282018252600683526504458737761760d41b6020938401528151808301835260018152603160f81b908401528151808401919091527f3649d708a7abf9e212d0a587955ead4123223014b2e46201dfb587457cbd4591818301527fc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6606082015260808101949094523060a0808601919091528151808603909101815260c09094019052825192019190912060035550600580546001600160a01b0319163317905561243e8061010e6000396000f3fe608060405234801561001057600080fd5b50600436106101cf5760003560e01c8063649d222f11610104578063a9059cbb116100a2578063d21220a711610071578063d21220a714610582578063d505accf1461058a578063dd62ed3e146105db578063fff6cae914610609576101cf565b8063a9059cbb14610520578063ba9a7a561461054c578063bc25cf7714610554578063c45a01551461057a576101cf565b80637464fc3d116100de5780637464fc3d146104ab5780637ecebe00146104b357806389afcb44146104d957806395d89b4114610518576101cf565b8063649d222f1461043f5780636a6278421461045f57806370a0823114610485576101cf565b806330adf81f11610171578063485cc9551161014b578063485cc955146103f957806354cf2aeb146104275780635909c0d51461042f5780635a3d549314610437576101cf565b806330adf81f146103cb578063313ce567146103d35780633644e515146103f1576101cf565b8063095ea7b3116101ad578063095ea7b3146103175780630dfe16811461035757806318160ddd1461037b57806323b872dd14610395576101cf565b8063022c0d9f146101d457806306fdde03146102625780630902f1ac146102df575b600080fd5b610260600480360360808110156101ea57600080fd5b8135916020810135916001600160a01b03604083013516919081019060808101606082013564010000000081111561022157600080fd5b82018360208201111561023357600080fd5b8035906020019184600183028401116401000000008311171561025557600080fd5b509092509050610611565b005b61026a610b6d565b6040805160208082528351818301528351919283929083019185019080838360005b838110156102a457818101518382015260200161028c565b50505050905090810190601f1680156102d15780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6102e7610b8f565b604080516001600160701b03948516815292909316602083015263ffffffff168183015290519081900360600190f35b6103436004803603604081101561032d57600080fd5b506001600160a01b038135169060200135610bb9565b604080519115158252519081900360200190f35b61035f610bd0565b604080516001600160a01b039092168252519081900360200190f35b610383610bdf565b60408051918252519081900360200190f35b610343600480360360608110156103ab57600080fd5b506001600160a01b03813581169160208101359091169060400135610be5565b610383610c7f565b6103db610ca3565b6040805160ff9092168252519081900360200190f35b610383610ca8565b6102606004803603604081101561040f57600080fd5b506001600160a01b0381358116916020013516610cae565b6103db610d33565b610383610d3c565b610383610d42565b6102606004803603602081101561045557600080fd5b503560ff16610d48565b6103836004803603602081101561047557600080fd5b50356001600160a01b0316610e0d565b6103836004803603602081101561049b57600080fd5b50356001600160a01b031661110e565b610383611120565b610383600480360360208110156104c957600080fd5b50356001600160a01b0316611126565b6104ff600480360360208110156104ef57600080fd5b50356001600160a01b0316611138565b6040805192835260208301919091528051918290030190f35b61026a6114df565b6103436004803603604081101561053657600080fd5b506001600160a01b0381351690602001356114fe565b61038361150b565b6102606004803603602081101561056a57600080fd5b50356001600160a01b0316611511565b61035f61167d565b61035f61168c565b610260600480360360e08110156105a057600080fd5b506001600160a01b03813581169160208101359091169060408101359060608101359060ff6080820135169060a08101359060c0013561169b565b610383600480360360408110156105f157600080fd5b506001600160a01b038135811691602001351661189f565b6102606118bc565b600d5460011461065d576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55841515806106705750600084115b6106ab5760405162461bcd60e51b81526004018080602001828103825260268152602001806123966026913960400191505060405180910390fd5b6000806106b6610b8f565b5091509150816001600160701b0316871080156106db5750806001600160701b031686105b6107165760405162461bcd60e51b81526004018080602001828103825260228152602001806123746022913960400191505060405180910390fd5b60065460075460009182916001600160a01b039182169190811690891682148015906107545750806001600160a01b0316896001600160a01b031614155b61079e576040805162461bcd60e51b8152602060048201526016602482015275445873776170506169723a20494e56414c49445f544f60501b604482015290519081900360640190fd5b8a156107af576107af828a8d611a1f565b89156107c0576107c0818a8c611a1f565b861561087b57886001600160a01b03166378b94ae6338d8d8c8c6040518663ffffffff1660e01b815260040180866001600160a01b03166001600160a01b03168152602001858152602001848152602001806020018281038252848482818152602001925080828437600081840152601f19601f8201169050808301925050509650505050505050600060405180830381600087803b15801561086257600080fd5b505af1158015610876573d6000803e3d6000fd5b505050505b604080516370a0823160e01b815230600482015290516001600160a01b038416916370a08231916024808301926020929190829003018186803b1580156108c157600080fd5b505afa1580156108d5573d6000803e3d6000fd5b505050506040513d60208110156108eb57600080fd5b5051604080516370a0823160e01b815230600482015290519195506001600160a01b038316916370a0823191602480820192602092909190829003018186803b15801561093757600080fd5b505afa15801561094b573d6000803e3d6000fd5b505050506040513d602081101561096157600080fd5b5051925060009150506001600160701b0385168a90038311610984576000610993565b89856001600160701b03160383035b9050600089856001600160701b03160383116109b05760006109bf565b89856001600160701b03160383035b905060008211806109d05750600081115b610a0b5760405162461bcd60e51b81526004018080602001828103825260258152602001806123bc6025913960400191505060405180910390fd5b600c5460ff1615610afb57600c54600090610a5290610a3490859060ff1663ffffffff611bb916565b610a468761271063ffffffff611bb916565b9063ffffffff611c1c16565b600c54909150600090610a7390610a3490859060ff1663ffffffff611bb916565b9050610aa56305f5e100610a996001600160701b038b8116908b1663ffffffff611bb916565b9063ffffffff611bb916565b610ab5838363ffffffff611bb916565b1015610af8576040805162461bcd60e51b815260206004820152600d60248201526c445873776170506169723a204b60981b604482015290519081900360640190fd5b50505b610b0784848888611c6c565b60408051838152602081018390528082018d9052606081018c905290516001600160a01b038b169133917fd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d8229181900360800190a350506001600d55505050505050505050565b6040518060400160405280600681526020016504458737761760d41b81525081565b6008546001600160701b0380821692600160701b830490911691600160e01b900463ffffffff1690565b6000610bc6338484611e32565b5060015b92915050565b6006546001600160a01b031681565b60005481565b6001600160a01b038316600090815260026020908152604080832033845290915281205460001914610c6a576001600160a01b0384166000908152600260209081526040808320338452909152902054610c45908363ffffffff611c1c16565b6001600160a01b03851660009081526002602090815260408083203384529091529020555b610c75848484611e94565b5060019392505050565b7f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c981565b601281565b60035481565b6005546001600160a01b03163314610d05576040805162461bcd60e51b8152602060048201526015602482015274222c39bbb0b82830b4b91d102327a92124a22222a760591b604482015290519081900360640190fd5b600680546001600160a01b039384166001600160a01b03199182161790915560078054929093169116179055565b600c5460ff1681565b60095481565b600a5481565b6005546001600160a01b03163314610d9e576040805162461bcd60e51b81526020600482015260146024820152732ab734b9bbb0b82b191d102327a92124a22222a760611b604482015290519081900360640190fd5b601e8160ff161115610df7576040805162461bcd60e51b815260206004820152601860248201527f556e697377617056323a20464f5242494444454e5f4645450000000000000000604482015290519081900360640190fd5b600c805460ff191660ff92909216919091179055565b6000600d54600114610e5b576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d81905580610e6b610b8f565b50600654604080516370a0823160e01b815230600482015290519395509193506000926001600160a01b03909116916370a08231916024808301926020929190829003018186803b158015610ebf57600080fd5b505afa158015610ed3573d6000803e3d6000fd5b505050506040513d6020811015610ee957600080fd5b5051600754604080516370a0823160e01b815230600482015290519293506000926001600160a01b03909216916370a0823191602480820192602092909190829003018186803b158015610f3c57600080fd5b505afa158015610f50573d6000803e3d6000fd5b505050506040513d6020811015610f6657600080fd5b505190506000610f85836001600160701b03871663ffffffff611c1c16565b90506000610fa2836001600160701b03871663ffffffff611c1c16565b90506000610fb08787611f4e565b60005490915080610fed57610fd96103e8610a46610fd4878763ffffffff611bb916565b612126565b9850610fe860006103e8612178565b61103c565b6110396001600160701b03891661100a868463ffffffff611bb916565b8161101157fe5b046001600160701b03891661102c868563ffffffff611bb916565b8161103357fe5b0461220e565b98505b6000891161107b5760405162461bcd60e51b815260040180806020018281038252602981526020018061234b6029913960400191505060405180910390fd5b6110858a8a612178565b61109186868a8a611c6c565b81156110c1576008546110bd906001600160701b0380821691600160701b90041663ffffffff611bb916565b600b555b6040805185815260208101859052815133927f4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f928290030190a250506001600d5550949695505050505050565b60016020526000908152604090205481565b600b5481565b60046020526000908152604090205481565b600080600d54600114611187576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d81905580611197610b8f565b50600654600754604080516370a0823160e01b815230600482015290519496509294506001600160a01b039182169391169160009184916370a08231916024808301926020929190829003018186803b1580156111f357600080fd5b505afa158015611207573d6000803e3d6000fd5b505050506040513d602081101561121d57600080fd5b5051604080516370a0823160e01b815230600482015290519192506000916001600160a01b038516916370a08231916024808301926020929190829003018186803b15801561126b57600080fd5b505afa15801561127f573d6000803e3d6000fd5b505050506040513d602081101561129557600080fd5b5051306000908152600160205260408120549192506112b48888611f4e565b600054909150806112cb848763ffffffff611bb916565b816112d257fe5b049a50806112e6848663ffffffff611bb916565b816112ed57fe5b04995060008b118015611300575060008a115b61133b5760405162461bcd60e51b81526004018080602001828103825260298152602001806123e16029913960400191505060405180910390fd5b6113453084612226565b611350878d8d611a1f565b61135b868d8c611a1f565b604080516370a0823160e01b815230600482015290516001600160a01b038916916370a08231916024808301926020929190829003018186803b1580156113a157600080fd5b505afa1580156113b5573d6000803e3d6000fd5b505050506040513d60208110156113cb57600080fd5b5051604080516370a0823160e01b815230600482015290519196506001600160a01b038816916370a0823191602480820192602092909190829003018186803b15801561141757600080fd5b505afa15801561142b573d6000803e3d6000fd5b505050506040513d602081101561144157600080fd5b5051935061145185858b8b611c6c565b81156114815760085461147d906001600160701b0380821691600160701b90041663ffffffff611bb916565b600b555b604080518c8152602081018c905281516001600160a01b038f169233927fdccd412f0b1252819cb1fd330b93224ca42612892bb3f4f789976e6d81936496929081900390910190a35050505050505050506001600d81905550915091565b6040518060400160405280600381526020016244585360e81b81525081565b6000610bc6338484611e94565b6103e881565b600d5460011461155d576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55600654600754600854604080516370a0823160e01b815230600482015290516001600160a01b03948516949093169261160c9285928792611607926001600160701b03169185916370a0823191602480820192602092909190829003018186803b1580156115cf57600080fd5b505afa1580156115e3573d6000803e3d6000fd5b505050506040513d60208110156115f957600080fd5b50519063ffffffff611c1c16565b611a1f565b600854604080516370a0823160e01b81523060048201529051611673928492879261160792600160701b90046001600160701b0316916001600160a01b038616916370a0823191602480820192602092909190829003018186803b1580156115cf57600080fd5b50506001600d5550565b6005546001600160a01b031681565b6007546001600160a01b031681565b428410156116e7576040805162461bcd60e51b815260206004820152601460248201527311161cddd85c115490cc8c0e881156141254915160621b604482015290519081900360640190fd5b6003546001600160a01b0380891660008181526004602090815260408083208054600180820190925582517f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c98186015280840196909652958d166060860152608085018c905260a085019590955260c08085018b90528151808603909101815260e08501825280519083012061190160f01b6101008601526101028501969096526101228085019690965280518085039096018652610142840180825286519683019690962095839052610162840180825286905260ff89166101828501526101a284018890526101c28401879052519193926101e280820193601f1981019281900390910190855afa158015611802573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b038116158015906118385750886001600160a01b0316816001600160a01b0316145b611889576040805162461bcd60e51b815260206004820152601e60248201527f44587377617045524332303a20494e56414c49445f5349474e41545552450000604482015290519081900360640190fd5b611894898989611e32565b505050505050505050565b600260209081526000928352604080842090915290825290205481565b600d54600114611908576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55600654604080516370a0823160e01b81523060048201529051611a18926001600160a01b0316916370a08231916024808301926020929190829003018186803b15801561195957600080fd5b505afa15801561196d573d6000803e3d6000fd5b505050506040513d602081101561198357600080fd5b5051600754604080516370a0823160e01b815230600482015290516001600160a01b03909216916370a0823191602480820192602092909190829003018186803b1580156119d057600080fd5b505afa1580156119e4573d6000803e3d6000fd5b505050506040513d60208110156119fa57600080fd5b50516008546001600160701b0380821691600160701b900416611c6c565b6001600d55565b604080518082018252601981527f7472616e7366657228616464726573732c75696e74323536290000000000000060209182015281516001600160a01b0385811660248301526044808301869052845180840390910181526064909201845291810180516001600160e01b031663a9059cbb60e01b1781529251815160009460609489169392918291908083835b60208310611acc5780518252601f199092019160209182019101611aad565b6001836020036101000a0380198251168184511680821785525050505050509050019150506000604051808303816000865af19150503d8060008114611b2e576040519150601f19603f3d011682016040523d82523d6000602084013e611b33565b606091505b5091509150818015611b61575080511580611b615750808060200190516020811015611b5e57600080fd5b50515b611bb2576040805162461bcd60e51b815260206004820152601b60248201527f445873776170506169723a205452414e534645525f4641494c45440000000000604482015290519081900360640190fd5b5050505050565b6000811580611bd457505080820282828281611bd157fe5b04145b610bca576040805162461bcd60e51b815260206004820152601460248201527364732d6d6174682d6d756c2d6f766572666c6f7760601b604482015290519081900360640190fd5b80820382811115610bca576040805162461bcd60e51b815260206004820152601560248201527464732d6d6174682d7375622d756e646572666c6f7760581b604482015290519081900360640190fd5b6001600160701b038411801590611c8a57506001600160701b038311155b611cd2576040805162461bcd60e51b8152602060048201526014602482015273445873776170506169723a204f564552464c4f5760601b604482015290519081900360640190fd5b60085463ffffffff42811691600160e01b90048116820390811615801590611d0257506001600160701b03841615155b8015611d1657506001600160701b03831615155b15611d87578063ffffffff16611d4485611d2f866122c4565b6001600160e01b03169063ffffffff6122d616565b600980546001600160e01b03929092169290920201905563ffffffff8116611d6f84611d2f876122c4565b600a80546001600160e01b0392909216929092020190555b600880546dffffffffffffffffffffffffffff19166001600160701b03888116919091176dffffffffffffffffffffffffffff60701b1916600160701b8883168102919091176001600160e01b0316600160e01b63ffffffff871602179283905560408051848416815291909304909116602082015281517f1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1929181900390910190a1505050505050565b6001600160a01b03808416600081815260026020908152604080832094871680845294825291829020859055815185815291517f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b9259281900390910190a3505050565b6001600160a01b038316600090815260016020526040902054611ebd908263ffffffff611c1c16565b6001600160a01b038085166000908152600160205260408082209390935590841681522054611ef2908263ffffffff6122fb16565b6001600160a01b0380841660008181526001602090815260409182902094909455805185815290519193928716927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef92918290030190a3505050565b600080600560009054906101000a90046001600160a01b03166001600160a01b031663017e7e586040518163ffffffff1660e01b815260040160206040518083038186803b158015611f9f57600080fd5b505afa158015611fb3573d6000803e3d6000fd5b505050506040513d6020811015611fc957600080fd5b5051600554604080516317fb821560e11b815290519293506000926001600160a01b0390921691632ff7042a91600480820192602092909190829003018186803b15801561201657600080fd5b505afa15801561202a573d6000803e3d6000fd5b505050506040513d602081101561204057600080fd5b5051600b546001600160a01b03841615801595509192509061211157801561210c576000612083610fd46001600160701b0389811690891663ffffffff611bb916565b9050600061209083612126565b9050808211156121095760006120be6120af848463ffffffff611c1c16565b6000549063ffffffff611bb916565b905060006120e5836120d98660ff8a1663ffffffff611bb916565b9063ffffffff6122fb16565b905060008183816120f257fe5b0490508015612105576121058882612178565b5050505b50505b61211d565b801561211d576000600b555b50505092915050565b60006003821115612169575080600160028204015b818110156121635780915060028182858161215257fe5b04018161215b57fe5b04905061213b565b50612173565b8115612173575060015b919050565b60005461218b908263ffffffff6122fb16565b60009081556001600160a01b0383168152600160205260409020546121b6908263ffffffff6122fb16565b6001600160a01b03831660008181526001602090815260408083209490945583518581529351929391927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9281900390910190a35050565b600081831061221d578161221f565b825b9392505050565b6001600160a01b03821660009081526001602052604090205461224f908263ffffffff611c1c16565b6001600160a01b0383166000908152600160205260408120919091555461227c908263ffffffff611c1c16565b60009081556040805183815290516001600160a01b038516917fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef919081900360200190a35050565b6001600160701b0316600160701b0290565b60006001600160701b0382166001600160e01b038416816122f357fe5b049392505050565b80820182811015610bca576040805162461bcd60e51b815260206004820152601460248201527364732d6d6174682d6164642d6f766572666c6f7760601b604482015290519081900360640190fdfe445873776170506169723a20494e53554646494349454e545f4c49515549444954595f4d494e544544445873776170506169723a20494e53554646494349454e545f4c4951554944495459445873776170506169723a20494e53554646494349454e545f4f55545055545f414d4f554e54445873776170506169723a20494e53554646494349454e545f494e5055545f414d4f554e54445873776170506169723a20494e53554646494349454e545f4c49515549444954595f4255524e4544a265627a7a723158204414f4546c1e72cfac1d316a481eff81257924cd834e99dcc36be6eee601896564736f6c63430005100032454950373132446f6d61696e28737472696e67206e616d652c737472696e672076657273696f6e2c75696e7432353620636861696e49642c6164647265737320766572696679696e67436f6e747261637429445873776170466163746f72793a204944454e544943414c5f414444524553534553a265627a7a72315820a6d83e1d0e8b912ba01bdc939865caf9874f37436f3208fde23242de19cb9f7264736f6c63430005100032",
+  "bytecode": "0x60806040526001805460ff60a01b1916600560a01b17905534801561002357600080fd5b50604051612f73380380612f738339818101604052602081101561004657600080fd5b5051600180546001600160a01b0319166001600160a01b03909216919091179055612efd806100766000396000f3fe608060405234801561001057600080fd5b50600436106100b45760003560e01c8063574f2ba311610071578063574f2ba3146101715780635855a25a1461018b578063a2e74af614610193578063c9c65396146101b9578063e6a43905146101e7578063f46901ed14610215576100b4565b8063017e7e58146100b9578063094b7415146100dd5780631519c024146100e55780631e3dd18b146101165780632ff7042a146101335780634e91f81114610151575b600080fd5b6100c161023b565b604080516001600160a01b039092168252519081900360200190f35b6100c161024a565b610114600480360360408110156100fb57600080fd5b5080356001600160a01b0316906020013560ff16610259565b005b6100c16004803603602081101561012c57600080fd5b5035610319565b61013b610340565b6040805160ff9092168252519081900360200190f35b6101146004803603602081101561016757600080fd5b503560ff16610350565b610179610422565b60408051918252519081900360200190f35b610179610428565b610114600480360360208110156101a957600080fd5b50356001600160a01b03166104bb565b6100c1600480360360408110156101cf57600080fd5b506001600160a01b0381358116916020013516610537565b6100c1600480360360408110156101fd57600080fd5b506001600160a01b0381358116916020013516610859565b6101146004803603602081101561022b57600080fd5b50356001600160a01b031661087f565b6000546001600160a01b031681565b6001546001600160a01b031681565b6001546001600160a01b031633146102b3576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b6040805163649d222f60e01b815260ff8316600482015290516001600160a01b0384169163649d222f91602480830192600092919082900301818387803b1580156102fd57600080fd5b505af1158015610311573d6000803e3d6000fd5b505050505050565b6003818154811061032657fe5b6000918252602090912001546001600160a01b0316905081565b600154600160a01b900460ff1681565b6001546001600160a01b031633146103aa576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b60008160ff1611610402576040805162461bcd60e51b815260206004820152601c60248201527f445873776170466163746f72793a20464f5242494444454e5f46454500000000604482015290519081900360640190fd5b6001805460ff909216600160a01b0260ff60a01b19909216919091179055565b60035490565b604051610437602082016108fb565b6020820181038252601f19601f820116604052506040516020018082805190602001908083835b6020831061047d5780518252601f19909201916020918201910161045e565b6001836020036101000a0380198251168184511680821785525050505050509050019150506040516020818303038152906040528051906020012081565b6001546001600160a01b03163314610515576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b600180546001600160a01b0319166001600160a01b0392909216919091179055565b6000816001600160a01b0316836001600160a01b0316141561058a5760405162461bcd60e51b8152600401808060200182810382526022815260200180612ea76022913960400191505060405180910390fd5b600080836001600160a01b0316856001600160a01b0316106105ad5783856105b0565b84845b90925090506001600160a01b038216610610576040805162461bcd60e51b815260206004820152601b60248201527f445873776170466163746f72793a205a45524f5f414444524553530000000000604482015290519081900360640190fd5b6001600160a01b0382811660009081526002602090815260408083208585168452909152902054161561068a576040805162461bcd60e51b815260206004820152601a60248201527f445873776170466163746f72793a20504149525f455849535453000000000000604482015290519081900360640190fd5b60606040518060200161069c906108fb565b6020820181038252601f19601f8201166040525090506000838360405160200180836001600160a01b03166001600160a01b031660601b8152601401826001600160a01b03166001600160a01b031660601b815260140192505050604051602081830303815290604052805190602001209050808251602084016000f56040805163485cc95560e01b81526001600160a01b038781166004830152868116602483015291519297509087169163485cc9559160448082019260009290919082900301818387803b15801561076f57600080fd5b505af1158015610783573d6000803e3d6000fd5b505050506001600160a01b0384811660008181526002602081815260408084208987168086529083528185208054978d166001600160a01b031998891681179091559383528185208686528352818520805488168517905560038054600181018255958190527fc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b90950180549097168417909655925483519283529082015281517f0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9929181900390910190a35050505092915050565b60026020908152600092835260408084209091529082529020546001600160a01b031681565b6001546001600160a01b031633146108d9576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b600080546001600160a01b0319166001600160a01b0392909216919091179055565b61259e806109098339019056fe6080604052600c805460ff1916601e1790556001600d5534801561002257600080fd5b50604051469080605261254c8239604080519182900360520182208282018252600683526504458737761760d41b6020938401528151808301835260018152603160f81b908401528151808401919091527f3649d708a7abf9e212d0a587955ead4123223014b2e46201dfb587457cbd4591818301527fc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6606082015260808101949094523060a0808601919091528151808603909101815260c09094019052825192019190912060035550600580546001600160a01b0319163317905561243e8061010e6000396000f3fe608060405234801561001057600080fd5b50600436106101cf5760003560e01c8063649d222f11610104578063a9059cbb116100a2578063d21220a711610071578063d21220a714610582578063d505accf1461058a578063dd62ed3e146105db578063fff6cae914610609576101cf565b8063a9059cbb14610520578063ba9a7a561461054c578063bc25cf7714610554578063c45a01551461057a576101cf565b80637464fc3d116100de5780637464fc3d146104ab5780637ecebe00146104b357806389afcb44146104d957806395d89b4114610518576101cf565b8063649d222f1461043f5780636a6278421461045f57806370a0823114610485576101cf565b806330adf81f11610171578063485cc9551161014b578063485cc955146103f957806354cf2aeb146104275780635909c0d51461042f5780635a3d549314610437576101cf565b806330adf81f146103cb578063313ce567146103d35780633644e515146103f1576101cf565b8063095ea7b3116101ad578063095ea7b3146103175780630dfe16811461035757806318160ddd1461037b57806323b872dd14610395576101cf565b8063022c0d9f146101d457806306fdde03146102625780630902f1ac146102df575b600080fd5b610260600480360360808110156101ea57600080fd5b8135916020810135916001600160a01b03604083013516919081019060808101606082013564010000000081111561022157600080fd5b82018360208201111561023357600080fd5b8035906020019184600183028401116401000000008311171561025557600080fd5b509092509050610611565b005b61026a610b6d565b6040805160208082528351818301528351919283929083019185019080838360005b838110156102a457818101518382015260200161028c565b50505050905090810190601f1680156102d15780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6102e7610b8f565b604080516001600160701b03948516815292909316602083015263ffffffff168183015290519081900360600190f35b6103436004803603604081101561032d57600080fd5b506001600160a01b038135169060200135610bb9565b604080519115158252519081900360200190f35b61035f610bd0565b604080516001600160a01b039092168252519081900360200190f35b610383610bdf565b60408051918252519081900360200190f35b610343600480360360608110156103ab57600080fd5b506001600160a01b03813581169160208101359091169060400135610be5565b610383610c7f565b6103db610ca3565b6040805160ff9092168252519081900360200190f35b610383610ca8565b6102606004803603604081101561040f57600080fd5b506001600160a01b0381358116916020013516610cae565b6103db610d33565b610383610d3c565b610383610d42565b6102606004803603602081101561045557600080fd5b503560ff16610d48565b6103836004803603602081101561047557600080fd5b50356001600160a01b0316610e0d565b6103836004803603602081101561049b57600080fd5b50356001600160a01b031661110e565b610383611120565b610383600480360360208110156104c957600080fd5b50356001600160a01b0316611126565b6104ff600480360360208110156104ef57600080fd5b50356001600160a01b0316611138565b6040805192835260208301919091528051918290030190f35b61026a6114df565b6103436004803603604081101561053657600080fd5b506001600160a01b0381351690602001356114fe565b61038361150b565b6102606004803603602081101561056a57600080fd5b50356001600160a01b0316611511565b61035f61167d565b61035f61168c565b610260600480360360e08110156105a057600080fd5b506001600160a01b03813581169160208101359091169060408101359060608101359060ff6080820135169060a08101359060c0013561169b565b610383600480360360408110156105f157600080fd5b506001600160a01b038135811691602001351661189f565b6102606118bc565b600d5460011461065d576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55841515806106705750600084115b6106ab5760405162461bcd60e51b81526004018080602001828103825260268152602001806123966026913960400191505060405180910390fd5b6000806106b6610b8f565b5091509150816001600160701b0316871080156106db5750806001600160701b031686105b6107165760405162461bcd60e51b81526004018080602001828103825260228152602001806123746022913960400191505060405180910390fd5b60065460075460009182916001600160a01b039182169190811690891682148015906107545750806001600160a01b0316896001600160a01b031614155b61079e576040805162461bcd60e51b8152602060048201526016602482015275445873776170506169723a20494e56414c49445f544f60501b604482015290519081900360640190fd5b8a156107af576107af828a8d611a1f565b89156107c0576107c0818a8c611a1f565b861561087b57886001600160a01b03166378b94ae6338d8d8c8c6040518663ffffffff1660e01b815260040180866001600160a01b03166001600160a01b03168152602001858152602001848152602001806020018281038252848482818152602001925080828437600081840152601f19601f8201169050808301925050509650505050505050600060405180830381600087803b15801561086257600080fd5b505af1158015610876573d6000803e3d6000fd5b505050505b604080516370a0823160e01b815230600482015290516001600160a01b038416916370a08231916024808301926020929190829003018186803b1580156108c157600080fd5b505afa1580156108d5573d6000803e3d6000fd5b505050506040513d60208110156108eb57600080fd5b5051604080516370a0823160e01b815230600482015290519195506001600160a01b038316916370a0823191602480820192602092909190829003018186803b15801561093757600080fd5b505afa15801561094b573d6000803e3d6000fd5b505050506040513d602081101561096157600080fd5b5051925060009150506001600160701b0385168a90038311610984576000610993565b89856001600160701b03160383035b9050600089856001600160701b03160383116109b05760006109bf565b89856001600160701b03160383035b905060008211806109d05750600081115b610a0b5760405162461bcd60e51b81526004018080602001828103825260258152602001806123bc6025913960400191505060405180910390fd5b600c5460ff1615610afb57600c54600090610a5290610a3490859060ff1663ffffffff611bb916565b610a468761271063ffffffff611bb916565b9063ffffffff611c1c16565b600c54909150600090610a7390610a3490859060ff1663ffffffff611bb916565b9050610aa56305f5e100610a996001600160701b038b8116908b1663ffffffff611bb916565b9063ffffffff611bb916565b610ab5838363ffffffff611bb916565b1015610af8576040805162461bcd60e51b815260206004820152600d60248201526c445873776170506169723a204b60981b604482015290519081900360640190fd5b50505b610b0784848888611c6c565b60408051838152602081018390528082018d9052606081018c905290516001600160a01b038b169133917fd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d8229181900360800190a350506001600d55505050505050505050565b6040518060400160405280600681526020016504458737761760d41b81525081565b6008546001600160701b0380821692600160701b830490911691600160e01b900463ffffffff1690565b6000610bc6338484611e32565b5060015b92915050565b6006546001600160a01b031681565b60005481565b6001600160a01b038316600090815260026020908152604080832033845290915281205460001914610c6a576001600160a01b0384166000908152600260209081526040808320338452909152902054610c45908363ffffffff611c1c16565b6001600160a01b03851660009081526002602090815260408083203384529091529020555b610c75848484611e94565b5060019392505050565b7f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c981565b601281565b60035481565b6005546001600160a01b03163314610d05576040805162461bcd60e51b8152602060048201526015602482015274222c39bbb0b82830b4b91d102327a92124a22222a760591b604482015290519081900360640190fd5b600680546001600160a01b039384166001600160a01b03199182161790915560078054929093169116179055565b600c5460ff1681565b60095481565b600a5481565b6005546001600160a01b03163314610d9e576040805162461bcd60e51b81526020600482015260146024820152732ab734b9bbb0b82b191d102327a92124a22222a760611b604482015290519081900360640190fd5b601e8160ff161115610df7576040805162461bcd60e51b815260206004820152601860248201527f556e697377617056323a20464f5242494444454e5f4645450000000000000000604482015290519081900360640190fd5b600c805460ff191660ff92909216919091179055565b6000600d54600114610e5b576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d81905580610e6b610b8f565b50600654604080516370a0823160e01b815230600482015290519395509193506000926001600160a01b03909116916370a08231916024808301926020929190829003018186803b158015610ebf57600080fd5b505afa158015610ed3573d6000803e3d6000fd5b505050506040513d6020811015610ee957600080fd5b5051600754604080516370a0823160e01b815230600482015290519293506000926001600160a01b03909216916370a0823191602480820192602092909190829003018186803b158015610f3c57600080fd5b505afa158015610f50573d6000803e3d6000fd5b505050506040513d6020811015610f6657600080fd5b505190506000610f85836001600160701b03871663ffffffff611c1c16565b90506000610fa2836001600160701b03871663ffffffff611c1c16565b90506000610fb08787611f4e565b60005490915080610fed57610fd96103e8610a46610fd4878763ffffffff611bb916565b612126565b9850610fe860006103e8612178565b61103c565b6110396001600160701b03891661100a868463ffffffff611bb916565b8161101157fe5b046001600160701b03891661102c868563ffffffff611bb916565b8161103357fe5b0461220e565b98505b6000891161107b5760405162461bcd60e51b815260040180806020018281038252602981526020018061234b6029913960400191505060405180910390fd5b6110858a8a612178565b61109186868a8a611c6c565b81156110c1576008546110bd906001600160701b0380821691600160701b90041663ffffffff611bb916565b600b555b6040805185815260208101859052815133927f4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f928290030190a250506001600d5550949695505050505050565b60016020526000908152604090205481565b600b5481565b60046020526000908152604090205481565b600080600d54600114611187576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d81905580611197610b8f565b50600654600754604080516370a0823160e01b815230600482015290519496509294506001600160a01b039182169391169160009184916370a08231916024808301926020929190829003018186803b1580156111f357600080fd5b505afa158015611207573d6000803e3d6000fd5b505050506040513d602081101561121d57600080fd5b5051604080516370a0823160e01b815230600482015290519192506000916001600160a01b038516916370a08231916024808301926020929190829003018186803b15801561126b57600080fd5b505afa15801561127f573d6000803e3d6000fd5b505050506040513d602081101561129557600080fd5b5051306000908152600160205260408120549192506112b48888611f4e565b600054909150806112cb848763ffffffff611bb916565b816112d257fe5b049a50806112e6848663ffffffff611bb916565b816112ed57fe5b04995060008b118015611300575060008a115b61133b5760405162461bcd60e51b81526004018080602001828103825260298152602001806123e16029913960400191505060405180910390fd5b6113453084612226565b611350878d8d611a1f565b61135b868d8c611a1f565b604080516370a0823160e01b815230600482015290516001600160a01b038916916370a08231916024808301926020929190829003018186803b1580156113a157600080fd5b505afa1580156113b5573d6000803e3d6000fd5b505050506040513d60208110156113cb57600080fd5b5051604080516370a0823160e01b815230600482015290519196506001600160a01b038816916370a0823191602480820192602092909190829003018186803b15801561141757600080fd5b505afa15801561142b573d6000803e3d6000fd5b505050506040513d602081101561144157600080fd5b5051935061145185858b8b611c6c565b81156114815760085461147d906001600160701b0380821691600160701b90041663ffffffff611bb916565b600b555b604080518c8152602081018c905281516001600160a01b038f169233927fdccd412f0b1252819cb1fd330b93224ca42612892bb3f4f789976e6d81936496929081900390910190a35050505050505050506001600d81905550915091565b6040518060400160405280600381526020016244585360e81b81525081565b6000610bc6338484611e94565b6103e881565b600d5460011461155d576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55600654600754600854604080516370a0823160e01b815230600482015290516001600160a01b03948516949093169261160c9285928792611607926001600160701b03169185916370a0823191602480820192602092909190829003018186803b1580156115cf57600080fd5b505afa1580156115e3573d6000803e3d6000fd5b505050506040513d60208110156115f957600080fd5b50519063ffffffff611c1c16565b611a1f565b600854604080516370a0823160e01b81523060048201529051611673928492879261160792600160701b90046001600160701b0316916001600160a01b038616916370a0823191602480820192602092909190829003018186803b1580156115cf57600080fd5b50506001600d5550565b6005546001600160a01b031681565b6007546001600160a01b031681565b428410156116e7576040805162461bcd60e51b815260206004820152601460248201527311161cddd85c115490cc8c0e881156141254915160621b604482015290519081900360640190fd5b6003546001600160a01b0380891660008181526004602090815260408083208054600180820190925582517f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c98186015280840196909652958d166060860152608085018c905260a085019590955260c08085018b90528151808603909101815260e08501825280519083012061190160f01b6101008601526101028501969096526101228085019690965280518085039096018652610142840180825286519683019690962095839052610162840180825286905260ff89166101828501526101a284018890526101c28401879052519193926101e280820193601f1981019281900390910190855afa158015611802573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b038116158015906118385750886001600160a01b0316816001600160a01b0316145b611889576040805162461bcd60e51b815260206004820152601e60248201527f44587377617045524332303a20494e56414c49445f5349474e41545552450000604482015290519081900360640190fd5b611894898989611e32565b505050505050505050565b600260209081526000928352604080842090915290825290205481565b600d54600114611908576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55600654604080516370a0823160e01b81523060048201529051611a18926001600160a01b0316916370a08231916024808301926020929190829003018186803b15801561195957600080fd5b505afa15801561196d573d6000803e3d6000fd5b505050506040513d602081101561198357600080fd5b5051600754604080516370a0823160e01b815230600482015290516001600160a01b03909216916370a0823191602480820192602092909190829003018186803b1580156119d057600080fd5b505afa1580156119e4573d6000803e3d6000fd5b505050506040513d60208110156119fa57600080fd5b50516008546001600160701b0380821691600160701b900416611c6c565b6001600d55565b604080518082018252601981527f7472616e7366657228616464726573732c75696e74323536290000000000000060209182015281516001600160a01b0385811660248301526044808301869052845180840390910181526064909201845291810180516001600160e01b031663a9059cbb60e01b1781529251815160009460609489169392918291908083835b60208310611acc5780518252601f199092019160209182019101611aad565b6001836020036101000a0380198251168184511680821785525050505050509050019150506000604051808303816000865af19150503d8060008114611b2e576040519150601f19603f3d011682016040523d82523d6000602084013e611b33565b606091505b5091509150818015611b61575080511580611b615750808060200190516020811015611b5e57600080fd5b50515b611bb2576040805162461bcd60e51b815260206004820152601b60248201527f445873776170506169723a205452414e534645525f4641494c45440000000000604482015290519081900360640190fd5b5050505050565b6000811580611bd457505080820282828281611bd157fe5b04145b610bca576040805162461bcd60e51b815260206004820152601460248201527364732d6d6174682d6d756c2d6f766572666c6f7760601b604482015290519081900360640190fd5b80820382811115610bca576040805162461bcd60e51b815260206004820152601560248201527464732d6d6174682d7375622d756e646572666c6f7760581b604482015290519081900360640190fd5b6001600160701b038411801590611c8a57506001600160701b038311155b611cd2576040805162461bcd60e51b8152602060048201526014602482015273445873776170506169723a204f564552464c4f5760601b604482015290519081900360640190fd5b60085463ffffffff42811691600160e01b90048116820390811615801590611d0257506001600160701b03841615155b8015611d1657506001600160701b03831615155b15611d87578063ffffffff16611d4485611d2f866122c4565b6001600160e01b03169063ffffffff6122d616565b600980546001600160e01b03929092169290920201905563ffffffff8116611d6f84611d2f876122c4565b600a80546001600160e01b0392909216929092020190555b600880546dffffffffffffffffffffffffffff19166001600160701b03888116919091176dffffffffffffffffffffffffffff60701b1916600160701b8883168102919091176001600160e01b0316600160e01b63ffffffff871602179283905560408051848416815291909304909116602082015281517f1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1929181900390910190a1505050505050565b6001600160a01b03808416600081815260026020908152604080832094871680845294825291829020859055815185815291517f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b9259281900390910190a3505050565b6001600160a01b038316600090815260016020526040902054611ebd908263ffffffff611c1c16565b6001600160a01b038085166000908152600160205260408082209390935590841681522054611ef2908263ffffffff6122fb16565b6001600160a01b0380841660008181526001602090815260409182902094909455805185815290519193928716927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef92918290030190a3505050565b600080600560009054906101000a90046001600160a01b03166001600160a01b031663017e7e586040518163ffffffff1660e01b815260040160206040518083038186803b158015611f9f57600080fd5b505afa158015611fb3573d6000803e3d6000fd5b505050506040513d6020811015611fc957600080fd5b5051600554604080516317fb821560e11b815290519293506000926001600160a01b0390921691632ff7042a91600480820192602092909190829003018186803b15801561201657600080fd5b505afa15801561202a573d6000803e3d6000fd5b505050506040513d602081101561204057600080fd5b5051600b546001600160a01b03841615801595509192509061211157801561210c576000612083610fd46001600160701b0389811690891663ffffffff611bb916565b9050600061209083612126565b9050808211156121095760006120be6120af848463ffffffff611c1c16565b6000549063ffffffff611bb916565b905060006120e5836120d98660ff8a1663ffffffff611bb916565b9063ffffffff6122fb16565b905060008183816120f257fe5b0490508015612105576121058882612178565b5050505b50505b61211d565b801561211d576000600b555b50505092915050565b60006003821115612169575080600160028204015b818110156121635780915060028182858161215257fe5b04018161215b57fe5b04905061213b565b50612173565b8115612173575060015b919050565b60005461218b908263ffffffff6122fb16565b60009081556001600160a01b0383168152600160205260409020546121b6908263ffffffff6122fb16565b6001600160a01b03831660008181526001602090815260408083209490945583518581529351929391927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9281900390910190a35050565b600081831061221d578161221f565b825b9392505050565b6001600160a01b03821660009081526001602052604090205461224f908263ffffffff611c1c16565b6001600160a01b0383166000908152600160205260408120919091555461227c908263ffffffff611c1c16565b60009081556040805183815290516001600160a01b038516917fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef919081900360200190a35050565b6001600160701b0316600160701b0290565b60006001600160701b0382166001600160e01b038416816122f357fe5b049392505050565b80820182811015610bca576040805162461bcd60e51b815260206004820152601460248201527364732d6d6174682d6164642d6f766572666c6f7760601b604482015290519081900360640190fdfe445873776170506169723a20494e53554646494349454e545f4c49515549444954595f4d494e544544445873776170506169723a20494e53554646494349454e545f4c4951554944495459445873776170506169723a20494e53554646494349454e545f4f55545055545f414d4f554e54445873776170506169723a20494e53554646494349454e545f494e5055545f414d4f554e54445873776170506169723a20494e53554646494349454e545f4c49515549444954595f4255524e4544a265627a7a723158204414f4546c1e72cfac1d316a481eff81257924cd834e99dcc36be6eee601896564736f6c63430005100032454950373132446f6d61696e28737472696e67206e616d652c737472696e672076657273696f6e2c75696e7432353620636861696e49642c6164647265737320766572696679696e67436f6e747261637429445873776170466163746f72793a204944454e544943414c5f414444524553534553a265627a7a72315820cc8587ffb90db68251e0163e1874c3e8ae99550fda49c3f9aeac3735f68638fa64736f6c63430005100032",
+  "deployedBytecode": "0x608060405234801561001057600080fd5b50600436106100b45760003560e01c8063574f2ba311610071578063574f2ba3146101715780635855a25a1461018b578063a2e74af614610193578063c9c65396146101b9578063e6a43905146101e7578063f46901ed14610215576100b4565b8063017e7e58146100b9578063094b7415146100dd5780631519c024146100e55780631e3dd18b146101165780632ff7042a146101335780634e91f81114610151575b600080fd5b6100c161023b565b604080516001600160a01b039092168252519081900360200190f35b6100c161024a565b610114600480360360408110156100fb57600080fd5b5080356001600160a01b0316906020013560ff16610259565b005b6100c16004803603602081101561012c57600080fd5b5035610319565b61013b610340565b6040805160ff9092168252519081900360200190f35b6101146004803603602081101561016757600080fd5b503560ff16610350565b610179610422565b60408051918252519081900360200190f35b610179610428565b610114600480360360208110156101a957600080fd5b50356001600160a01b03166104bb565b6100c1600480360360408110156101cf57600080fd5b506001600160a01b0381358116916020013516610537565b6100c1600480360360408110156101fd57600080fd5b506001600160a01b0381358116916020013516610859565b6101146004803603602081101561022b57600080fd5b50356001600160a01b031661087f565b6000546001600160a01b031681565b6001546001600160a01b031681565b6001546001600160a01b031633146102b3576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b6040805163649d222f60e01b815260ff8316600482015290516001600160a01b0384169163649d222f91602480830192600092919082900301818387803b1580156102fd57600080fd5b505af1158015610311573d6000803e3d6000fd5b505050505050565b6003818154811061032657fe5b6000918252602090912001546001600160a01b0316905081565b600154600160a01b900460ff1681565b6001546001600160a01b031633146103aa576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b60008160ff1611610402576040805162461bcd60e51b815260206004820152601c60248201527f445873776170466163746f72793a20464f5242494444454e5f46454500000000604482015290519081900360640190fd5b6001805460ff909216600160a01b0260ff60a01b19909216919091179055565b60035490565b604051610437602082016108fb565b6020820181038252601f19601f820116604052506040516020018082805190602001908083835b6020831061047d5780518252601f19909201916020918201910161045e565b6001836020036101000a0380198251168184511680821785525050505050509050019150506040516020818303038152906040528051906020012081565b6001546001600160a01b03163314610515576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b600180546001600160a01b0319166001600160a01b0392909216919091179055565b6000816001600160a01b0316836001600160a01b0316141561058a5760405162461bcd60e51b8152600401808060200182810382526022815260200180612ea76022913960400191505060405180910390fd5b600080836001600160a01b0316856001600160a01b0316106105ad5783856105b0565b84845b90925090506001600160a01b038216610610576040805162461bcd60e51b815260206004820152601b60248201527f445873776170466163746f72793a205a45524f5f414444524553530000000000604482015290519081900360640190fd5b6001600160a01b0382811660009081526002602090815260408083208585168452909152902054161561068a576040805162461bcd60e51b815260206004820152601a60248201527f445873776170466163746f72793a20504149525f455849535453000000000000604482015290519081900360640190fd5b60606040518060200161069c906108fb565b6020820181038252601f19601f8201166040525090506000838360405160200180836001600160a01b03166001600160a01b031660601b8152601401826001600160a01b03166001600160a01b031660601b815260140192505050604051602081830303815290604052805190602001209050808251602084016000f56040805163485cc95560e01b81526001600160a01b038781166004830152868116602483015291519297509087169163485cc9559160448082019260009290919082900301818387803b15801561076f57600080fd5b505af1158015610783573d6000803e3d6000fd5b505050506001600160a01b0384811660008181526002602081815260408084208987168086529083528185208054978d166001600160a01b031998891681179091559383528185208686528352818520805488168517905560038054600181018255958190527fc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b90950180549097168417909655925483519283529082015281517f0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9929181900390910190a35050505092915050565b60026020908152600092835260408084209091529082529020546001600160a01b031681565b6001546001600160a01b031633146108d9576040805162461bcd60e51b8152602060048201526018602482015277222c39bbb0b82330b1ba37b93c9d102327a92124a22222a760411b604482015290519081900360640190fd5b600080546001600160a01b0319166001600160a01b0392909216919091179055565b61259e806109098339019056fe6080604052600c805460ff1916601e1790556001600d5534801561002257600080fd5b50604051469080605261254c8239604080519182900360520182208282018252600683526504458737761760d41b6020938401528151808301835260018152603160f81b908401528151808401919091527f3649d708a7abf9e212d0a587955ead4123223014b2e46201dfb587457cbd4591818301527fc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6606082015260808101949094523060a0808601919091528151808603909101815260c09094019052825192019190912060035550600580546001600160a01b0319163317905561243e8061010e6000396000f3fe608060405234801561001057600080fd5b50600436106101cf5760003560e01c8063649d222f11610104578063a9059cbb116100a2578063d21220a711610071578063d21220a714610582578063d505accf1461058a578063dd62ed3e146105db578063fff6cae914610609576101cf565b8063a9059cbb14610520578063ba9a7a561461054c578063bc25cf7714610554578063c45a01551461057a576101cf565b80637464fc3d116100de5780637464fc3d146104ab5780637ecebe00146104b357806389afcb44146104d957806395d89b4114610518576101cf565b8063649d222f1461043f5780636a6278421461045f57806370a0823114610485576101cf565b806330adf81f11610171578063485cc9551161014b578063485cc955146103f957806354cf2aeb146104275780635909c0d51461042f5780635a3d549314610437576101cf565b806330adf81f146103cb578063313ce567146103d35780633644e515146103f1576101cf565b8063095ea7b3116101ad578063095ea7b3146103175780630dfe16811461035757806318160ddd1461037b57806323b872dd14610395576101cf565b8063022c0d9f146101d457806306fdde03146102625780630902f1ac146102df575b600080fd5b610260600480360360808110156101ea57600080fd5b8135916020810135916001600160a01b03604083013516919081019060808101606082013564010000000081111561022157600080fd5b82018360208201111561023357600080fd5b8035906020019184600183028401116401000000008311171561025557600080fd5b509092509050610611565b005b61026a610b6d565b6040805160208082528351818301528351919283929083019185019080838360005b838110156102a457818101518382015260200161028c565b50505050905090810190601f1680156102d15780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b6102e7610b8f565b604080516001600160701b03948516815292909316602083015263ffffffff168183015290519081900360600190f35b6103436004803603604081101561032d57600080fd5b506001600160a01b038135169060200135610bb9565b604080519115158252519081900360200190f35b61035f610bd0565b604080516001600160a01b039092168252519081900360200190f35b610383610bdf565b60408051918252519081900360200190f35b610343600480360360608110156103ab57600080fd5b506001600160a01b03813581169160208101359091169060400135610be5565b610383610c7f565b6103db610ca3565b6040805160ff9092168252519081900360200190f35b610383610ca8565b6102606004803603604081101561040f57600080fd5b506001600160a01b0381358116916020013516610cae565b6103db610d33565b610383610d3c565b610383610d42565b6102606004803603602081101561045557600080fd5b503560ff16610d48565b6103836004803603602081101561047557600080fd5b50356001600160a01b0316610e0d565b6103836004803603602081101561049b57600080fd5b50356001600160a01b031661110e565b610383611120565b610383600480360360208110156104c957600080fd5b50356001600160a01b0316611126565b6104ff600480360360208110156104ef57600080fd5b50356001600160a01b0316611138565b6040805192835260208301919091528051918290030190f35b61026a6114df565b6103436004803603604081101561053657600080fd5b506001600160a01b0381351690602001356114fe565b61038361150b565b6102606004803603602081101561056a57600080fd5b50356001600160a01b0316611511565b61035f61167d565b61035f61168c565b610260600480360360e08110156105a057600080fd5b506001600160a01b03813581169160208101359091169060408101359060608101359060ff6080820135169060a08101359060c0013561169b565b610383600480360360408110156105f157600080fd5b506001600160a01b038135811691602001351661189f565b6102606118bc565b600d5460011461065d576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55841515806106705750600084115b6106ab5760405162461bcd60e51b81526004018080602001828103825260268152602001806123966026913960400191505060405180910390fd5b6000806106b6610b8f565b5091509150816001600160701b0316871080156106db5750806001600160701b031686105b6107165760405162461bcd60e51b81526004018080602001828103825260228152602001806123746022913960400191505060405180910390fd5b60065460075460009182916001600160a01b039182169190811690891682148015906107545750806001600160a01b0316896001600160a01b031614155b61079e576040805162461bcd60e51b8152602060048201526016602482015275445873776170506169723a20494e56414c49445f544f60501b604482015290519081900360640190fd5b8a156107af576107af828a8d611a1f565b89156107c0576107c0818a8c611a1f565b861561087b57886001600160a01b03166378b94ae6338d8d8c8c6040518663ffffffff1660e01b815260040180866001600160a01b03166001600160a01b03168152602001858152602001848152602001806020018281038252848482818152602001925080828437600081840152601f19601f8201169050808301925050509650505050505050600060405180830381600087803b15801561086257600080fd5b505af1158015610876573d6000803e3d6000fd5b505050505b604080516370a0823160e01b815230600482015290516001600160a01b038416916370a08231916024808301926020929190829003018186803b1580156108c157600080fd5b505afa1580156108d5573d6000803e3d6000fd5b505050506040513d60208110156108eb57600080fd5b5051604080516370a0823160e01b815230600482015290519195506001600160a01b038316916370a0823191602480820192602092909190829003018186803b15801561093757600080fd5b505afa15801561094b573d6000803e3d6000fd5b505050506040513d602081101561096157600080fd5b5051925060009150506001600160701b0385168a90038311610984576000610993565b89856001600160701b03160383035b9050600089856001600160701b03160383116109b05760006109bf565b89856001600160701b03160383035b905060008211806109d05750600081115b610a0b5760405162461bcd60e51b81526004018080602001828103825260258152602001806123bc6025913960400191505060405180910390fd5b600c5460ff1615610afb57600c54600090610a5290610a3490859060ff1663ffffffff611bb916565b610a468761271063ffffffff611bb916565b9063ffffffff611c1c16565b600c54909150600090610a7390610a3490859060ff1663ffffffff611bb916565b9050610aa56305f5e100610a996001600160701b038b8116908b1663ffffffff611bb916565b9063ffffffff611bb916565b610ab5838363ffffffff611bb916565b1015610af8576040805162461bcd60e51b815260206004820152600d60248201526c445873776170506169723a204b60981b604482015290519081900360640190fd5b50505b610b0784848888611c6c565b60408051838152602081018390528082018d9052606081018c905290516001600160a01b038b169133917fd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d8229181900360800190a350506001600d55505050505050505050565b6040518060400160405280600681526020016504458737761760d41b81525081565b6008546001600160701b0380821692600160701b830490911691600160e01b900463ffffffff1690565b6000610bc6338484611e32565b5060015b92915050565b6006546001600160a01b031681565b60005481565b6001600160a01b038316600090815260026020908152604080832033845290915281205460001914610c6a576001600160a01b0384166000908152600260209081526040808320338452909152902054610c45908363ffffffff611c1c16565b6001600160a01b03851660009081526002602090815260408083203384529091529020555b610c75848484611e94565b5060019392505050565b7f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c981565b601281565b60035481565b6005546001600160a01b03163314610d05576040805162461bcd60e51b8152602060048201526015602482015274222c39bbb0b82830b4b91d102327a92124a22222a760591b604482015290519081900360640190fd5b600680546001600160a01b039384166001600160a01b03199182161790915560078054929093169116179055565b600c5460ff1681565b60095481565b600a5481565b6005546001600160a01b03163314610d9e576040805162461bcd60e51b81526020600482015260146024820152732ab734b9bbb0b82b191d102327a92124a22222a760611b604482015290519081900360640190fd5b601e8160ff161115610df7576040805162461bcd60e51b815260206004820152601860248201527f556e697377617056323a20464f5242494444454e5f4645450000000000000000604482015290519081900360640190fd5b600c805460ff191660ff92909216919091179055565b6000600d54600114610e5b576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d81905580610e6b610b8f565b50600654604080516370a0823160e01b815230600482015290519395509193506000926001600160a01b03909116916370a08231916024808301926020929190829003018186803b158015610ebf57600080fd5b505afa158015610ed3573d6000803e3d6000fd5b505050506040513d6020811015610ee957600080fd5b5051600754604080516370a0823160e01b815230600482015290519293506000926001600160a01b03909216916370a0823191602480820192602092909190829003018186803b158015610f3c57600080fd5b505afa158015610f50573d6000803e3d6000fd5b505050506040513d6020811015610f6657600080fd5b505190506000610f85836001600160701b03871663ffffffff611c1c16565b90506000610fa2836001600160701b03871663ffffffff611c1c16565b90506000610fb08787611f4e565b60005490915080610fed57610fd96103e8610a46610fd4878763ffffffff611bb916565b612126565b9850610fe860006103e8612178565b61103c565b6110396001600160701b03891661100a868463ffffffff611bb916565b8161101157fe5b046001600160701b03891661102c868563ffffffff611bb916565b8161103357fe5b0461220e565b98505b6000891161107b5760405162461bcd60e51b815260040180806020018281038252602981526020018061234b6029913960400191505060405180910390fd5b6110858a8a612178565b61109186868a8a611c6c565b81156110c1576008546110bd906001600160701b0380821691600160701b90041663ffffffff611bb916565b600b555b6040805185815260208101859052815133927f4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f928290030190a250506001600d5550949695505050505050565b60016020526000908152604090205481565b600b5481565b60046020526000908152604090205481565b600080600d54600114611187576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d81905580611197610b8f565b50600654600754604080516370a0823160e01b815230600482015290519496509294506001600160a01b039182169391169160009184916370a08231916024808301926020929190829003018186803b1580156111f357600080fd5b505afa158015611207573d6000803e3d6000fd5b505050506040513d602081101561121d57600080fd5b5051604080516370a0823160e01b815230600482015290519192506000916001600160a01b038516916370a08231916024808301926020929190829003018186803b15801561126b57600080fd5b505afa15801561127f573d6000803e3d6000fd5b505050506040513d602081101561129557600080fd5b5051306000908152600160205260408120549192506112b48888611f4e565b600054909150806112cb848763ffffffff611bb916565b816112d257fe5b049a50806112e6848663ffffffff611bb916565b816112ed57fe5b04995060008b118015611300575060008a115b61133b5760405162461bcd60e51b81526004018080602001828103825260298152602001806123e16029913960400191505060405180910390fd5b6113453084612226565b611350878d8d611a1f565b61135b868d8c611a1f565b604080516370a0823160e01b815230600482015290516001600160a01b038916916370a08231916024808301926020929190829003018186803b1580156113a157600080fd5b505afa1580156113b5573d6000803e3d6000fd5b505050506040513d60208110156113cb57600080fd5b5051604080516370a0823160e01b815230600482015290519196506001600160a01b038816916370a0823191602480820192602092909190829003018186803b15801561141757600080fd5b505afa15801561142b573d6000803e3d6000fd5b505050506040513d602081101561144157600080fd5b5051935061145185858b8b611c6c565b81156114815760085461147d906001600160701b0380821691600160701b90041663ffffffff611bb916565b600b555b604080518c8152602081018c905281516001600160a01b038f169233927fdccd412f0b1252819cb1fd330b93224ca42612892bb3f4f789976e6d81936496929081900390910190a35050505050505050506001600d81905550915091565b6040518060400160405280600381526020016244585360e81b81525081565b6000610bc6338484611e94565b6103e881565b600d5460011461155d576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55600654600754600854604080516370a0823160e01b815230600482015290516001600160a01b03948516949093169261160c9285928792611607926001600160701b03169185916370a0823191602480820192602092909190829003018186803b1580156115cf57600080fd5b505afa1580156115e3573d6000803e3d6000fd5b505050506040513d60208110156115f957600080fd5b50519063ffffffff611c1c16565b611a1f565b600854604080516370a0823160e01b81523060048201529051611673928492879261160792600160701b90046001600160701b0316916001600160a01b038616916370a0823191602480820192602092909190829003018186803b1580156115cf57600080fd5b50506001600d5550565b6005546001600160a01b031681565b6007546001600160a01b031681565b428410156116e7576040805162461bcd60e51b815260206004820152601460248201527311161cddd85c115490cc8c0e881156141254915160621b604482015290519081900360640190fd5b6003546001600160a01b0380891660008181526004602090815260408083208054600180820190925582517f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c98186015280840196909652958d166060860152608085018c905260a085019590955260c08085018b90528151808603909101815260e08501825280519083012061190160f01b6101008601526101028501969096526101228085019690965280518085039096018652610142840180825286519683019690962095839052610162840180825286905260ff89166101828501526101a284018890526101c28401879052519193926101e280820193601f1981019281900390910190855afa158015611802573d6000803e3d6000fd5b5050604051601f1901519150506001600160a01b038116158015906118385750886001600160a01b0316816001600160a01b0316145b611889576040805162461bcd60e51b815260206004820152601e60248201527f44587377617045524332303a20494e56414c49445f5349474e41545552450000604482015290519081900360640190fd5b611894898989611e32565b505050505050505050565b600260209081526000928352604080842090915290825290205481565b600d54600114611908576040805162461bcd60e51b815260206004820152601260248201527111161cddd85c14185a5c8e881313d0d2d15160721b604482015290519081900360640190fd5b6000600d55600654604080516370a0823160e01b81523060048201529051611a18926001600160a01b0316916370a08231916024808301926020929190829003018186803b15801561195957600080fd5b505afa15801561196d573d6000803e3d6000fd5b505050506040513d602081101561198357600080fd5b5051600754604080516370a0823160e01b815230600482015290516001600160a01b03909216916370a0823191602480820192602092909190829003018186803b1580156119d057600080fd5b505afa1580156119e4573d6000803e3d6000fd5b505050506040513d60208110156119fa57600080fd5b50516008546001600160701b0380821691600160701b900416611c6c565b6001600d55565b604080518082018252601981527f7472616e7366657228616464726573732c75696e74323536290000000000000060209182015281516001600160a01b0385811660248301526044808301869052845180840390910181526064909201845291810180516001600160e01b031663a9059cbb60e01b1781529251815160009460609489169392918291908083835b60208310611acc5780518252601f199092019160209182019101611aad565b6001836020036101000a0380198251168184511680821785525050505050509050019150506000604051808303816000865af19150503d8060008114611b2e576040519150601f19603f3d011682016040523d82523d6000602084013e611b33565b606091505b5091509150818015611b61575080511580611b615750808060200190516020811015611b5e57600080fd5b50515b611bb2576040805162461bcd60e51b815260206004820152601b60248201527f445873776170506169723a205452414e534645525f4641494c45440000000000604482015290519081900360640190fd5b5050505050565b6000811580611bd457505080820282828281611bd157fe5b04145b610bca576040805162461bcd60e51b815260206004820152601460248201527364732d6d6174682d6d756c2d6f766572666c6f7760601b604482015290519081900360640190fd5b80820382811115610bca576040805162461bcd60e51b815260206004820152601560248201527464732d6d6174682d7375622d756e646572666c6f7760581b604482015290519081900360640190fd5b6001600160701b038411801590611c8a57506001600160701b038311155b611cd2576040805162461bcd60e51b8152602060048201526014602482015273445873776170506169723a204f564552464c4f5760601b604482015290519081900360640190fd5b60085463ffffffff42811691600160e01b90048116820390811615801590611d0257506001600160701b03841615155b8015611d1657506001600160701b03831615155b15611d87578063ffffffff16611d4485611d2f866122c4565b6001600160e01b03169063ffffffff6122d616565b600980546001600160e01b03929092169290920201905563ffffffff8116611d6f84611d2f876122c4565b600a80546001600160e01b0392909216929092020190555b600880546dffffffffffffffffffffffffffff19166001600160701b03888116919091176dffffffffffffffffffffffffffff60701b1916600160701b8883168102919091176001600160e01b0316600160e01b63ffffffff871602179283905560408051848416815291909304909116602082015281517f1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1929181900390910190a1505050505050565b6001600160a01b03808416600081815260026020908152604080832094871680845294825291829020859055815185815291517f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b9259281900390910190a3505050565b6001600160a01b038316600090815260016020526040902054611ebd908263ffffffff611c1c16565b6001600160a01b038085166000908152600160205260408082209390935590841681522054611ef2908263ffffffff6122fb16565b6001600160a01b0380841660008181526001602090815260409182902094909455805185815290519193928716927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef92918290030190a3505050565b600080600560009054906101000a90046001600160a01b03166001600160a01b031663017e7e586040518163ffffffff1660e01b815260040160206040518083038186803b158015611f9f57600080fd5b505afa158015611fb3573d6000803e3d6000fd5b505050506040513d6020811015611fc957600080fd5b5051600554604080516317fb821560e11b815290519293506000926001600160a01b0390921691632ff7042a91600480820192602092909190829003018186803b15801561201657600080fd5b505afa15801561202a573d6000803e3d6000fd5b505050506040513d602081101561204057600080fd5b5051600b546001600160a01b03841615801595509192509061211157801561210c576000612083610fd46001600160701b0389811690891663ffffffff611bb916565b9050600061209083612126565b9050808211156121095760006120be6120af848463ffffffff611c1c16565b6000549063ffffffff611bb916565b905060006120e5836120d98660ff8a1663ffffffff611bb916565b9063ffffffff6122fb16565b905060008183816120f257fe5b0490508015612105576121058882612178565b5050505b50505b61211d565b801561211d576000600b555b50505092915050565b60006003821115612169575080600160028204015b818110156121635780915060028182858161215257fe5b04018161215b57fe5b04905061213b565b50612173565b8115612173575060015b919050565b60005461218b908263ffffffff6122fb16565b60009081556001600160a01b0383168152600160205260409020546121b6908263ffffffff6122fb16565b6001600160a01b03831660008181526001602090815260408083209490945583518581529351929391927fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9281900390910190a35050565b600081831061221d578161221f565b825b9392505050565b6001600160a01b03821660009081526001602052604090205461224f908263ffffffff611c1c16565b6001600160a01b0383166000908152600160205260408120919091555461227c908263ffffffff611c1c16565b60009081556040805183815290516001600160a01b038516917fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef919081900360200190a35050565b6001600160701b0316600160701b0290565b60006001600160701b0382166001600160e01b038416816122f357fe5b049392505050565b80820182811015610bca576040805162461bcd60e51b815260206004820152601460248201527364732d6d6174682d6164642d6f766572666c6f7760601b604482015290519081900360640190fdfe445873776170506169723a20494e53554646494349454e545f4c49515549444954595f4d494e544544445873776170506169723a20494e53554646494349454e545f4c4951554944495459445873776170506169723a20494e53554646494349454e545f4f55545055545f414d4f554e54445873776170506169723a20494e53554646494349454e545f494e5055545f414d4f554e54445873776170506169723a20494e53554646494349454e545f4c49515549444954595f4255524e4544a265627a7a723158204414f4546c1e72cfac1d316a481eff81257924cd834e99dcc36be6eee601896564736f6c63430005100032454950373132446f6d61696e28737472696e67206e616d652c737472696e672076657273696f6e2c75696e7432353620636861696e49642c6164647265737320766572696679696e67436f6e747261637429445873776170466163746f72793a204944454e544943414c5f414444524553534553a265627a7a72315820cc8587ffb90db68251e0163e1874c3e8ae99550fda49c3f9aeac3735f68638fa64736f6c63430005100032",
   "compiler": {
     "name": "solc",
     "version": "0.5.16+commit.9c3226ce.Linux.g++",

--- a/build/contracts/DXswapFactory.json
+++ b/build/contracts/DXswapFactory.json
@@ -3815,5 +3815,13 @@
       "runs": 200
     },
     "evmVersion": "istanbul"
+  },
+  "networks": {
+    "42": {
+      "links": {},
+      "events": {},
+      "address": "0x93F860a4810c2172C897B369260E3Ecc20a9e83f",
+      "updated_at": 1592848874899
+    }
   }
 }

--- a/build/contracts/DXswapPair.json
+++ b/build/contracts/DXswapPair.json
@@ -752,14 +752,14 @@
     "absolutePath": "contracts/DXswapPair.sol",
     "exportedSymbols": {
       "DXswapPair": [
-        1712
+        1723
       ]
     },
-    "id": 1713,
+    "id": 1724,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 632,
+        "id": 643,
         "literals": [
           "solidity",
           "=",
@@ -772,10 +772,10 @@
       {
         "absolutePath": "contracts/interfaces/IDXswapPair.sol",
         "file": "./interfaces/IDXswapPair.sol",
-        "id": 633,
+        "id": 644,
         "nodeType": "ImportDirective",
-        "scope": 1713,
-        "sourceUnit": 2177,
+        "scope": 1724,
+        "sourceUnit": 2188,
         "src": "26:38:2",
         "symbolAliases": [],
         "unitAlias": ""
@@ -783,9 +783,9 @@
       {
         "absolutePath": "contracts/DXswapERC20.sol",
         "file": "./DXswapERC20.sol",
-        "id": 634,
+        "id": 645,
         "nodeType": "ImportDirective",
-        "scope": 1713,
+        "scope": 1724,
         "sourceUnit": 385,
         "src": "65:27:2",
         "symbolAliases": [],
@@ -794,10 +794,10 @@
       {
         "absolutePath": "contracts/libraries/Math.sol",
         "file": "./libraries/Math.sol",
-        "id": 635,
+        "id": 646,
         "nodeType": "ImportDirective",
-        "scope": 1713,
-        "sourceUnit": 2337,
+        "scope": 1724,
+        "sourceUnit": 2348,
         "src": "93:30:2",
         "symbolAliases": [],
         "unitAlias": ""
@@ -805,10 +805,10 @@
       {
         "absolutePath": "contracts/libraries/UQ112x112.sol",
         "file": "./libraries/UQ112x112.sol",
-        "id": 636,
+        "id": 647,
         "nodeType": "ImportDirective",
-        "scope": 1713,
-        "sourceUnit": 2454,
+        "scope": 1724,
+        "sourceUnit": 2465,
         "src": "124:35:2",
         "symbolAliases": [],
         "unitAlias": ""
@@ -816,10 +816,10 @@
       {
         "absolutePath": "contracts/interfaces/IERC20.sol",
         "file": "./interfaces/IERC20.sol",
-        "id": 637,
+        "id": 648,
         "nodeType": "ImportDirective",
-        "scope": 1713,
-        "sourceUnit": 2261,
+        "scope": 1724,
+        "sourceUnit": 2272,
         "src": "160:33:2",
         "symbolAliases": [],
         "unitAlias": ""
@@ -827,10 +827,10 @@
       {
         "absolutePath": "contracts/interfaces/IDXswapFactory.sol",
         "file": "./interfaces/IDXswapFactory.sol",
-        "id": 638,
+        "id": 649,
         "nodeType": "ImportDirective",
-        "scope": 1713,
-        "sourceUnit": 1925,
+        "scope": 1724,
+        "sourceUnit": 1936,
         "src": "194:41:2",
         "symbolAliases": [],
         "unitAlias": ""
@@ -838,10 +838,10 @@
       {
         "absolutePath": "contracts/interfaces/IDXswapCallee.sol",
         "file": "./interfaces/IDXswapCallee.sol",
-        "id": 639,
+        "id": 650,
         "nodeType": "ImportDirective",
-        "scope": 1713,
-        "sourceUnit": 1727,
+        "scope": 1724,
+        "sourceUnit": 1738,
         "src": "236:40:2",
         "symbolAliases": [],
         "unitAlias": ""
@@ -852,17 +852,17 @@
             "arguments": null,
             "baseName": {
               "contractScope": null,
-              "id": 640,
+              "id": 651,
               "name": "IDXswapPair",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 2176,
+              "referencedDeclaration": 2187,
               "src": "301:11:2",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_IDXswapPair_$2176",
+                "typeIdentifier": "t_contract$_IDXswapPair_$2187",
                 "typeString": "contract IDXswapPair"
               }
             },
-            "id": 641,
+            "id": 652,
             "nodeType": "InheritanceSpecifier",
             "src": "301:11:2"
           },
@@ -870,7 +870,7 @@
             "arguments": null,
             "baseName": {
               "contractScope": null,
-              "id": 642,
+              "id": 653,
               "name": "DXswapERC20",
               "nodeType": "UserDefinedTypeName",
               "referencedDeclaration": 384,
@@ -880,47 +880,47 @@
                 "typeString": "contract DXswapERC20"
               }
             },
-            "id": 643,
+            "id": 654,
             "nodeType": "InheritanceSpecifier",
             "src": "314:11:2"
           }
         ],
         "contractDependencies": [
           384,
-          1844,
-          2176
+          1855,
+          2187
         ],
         "contractKind": "contract",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 1712,
+        "id": 1723,
         "linearizedBaseContracts": [
-          1712,
+          1723,
           384,
-          1844,
-          2176
+          1855,
+          2187
         ],
         "name": "DXswapPair",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
-            "id": 646,
+            "id": 657,
             "libraryName": {
               "contractScope": null,
-              "id": 644,
+              "id": 655,
               "name": "SafeMath",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 2411,
+              "referencedDeclaration": 2422,
               "src": "338:8:2",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_SafeMath_$2411",
+                "typeIdentifier": "t_contract$_SafeMath_$2422",
                 "typeString": "library SafeMath"
               }
             },
             "nodeType": "UsingForDirective",
             "src": "332:25:2",
             "typeName": {
-              "id": 645,
+              "id": 656,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
               "src": "352:4:2",
@@ -931,23 +931,23 @@
             }
           },
           {
-            "id": 649,
+            "id": 660,
             "libraryName": {
               "contractScope": null,
-              "id": 647,
+              "id": 658,
               "name": "UQ112x112",
               "nodeType": "UserDefinedTypeName",
-              "referencedDeclaration": 2453,
+              "referencedDeclaration": 2464,
               "src": "368:9:2",
               "typeDescriptions": {
-                "typeIdentifier": "t_contract$_UQ112x112_$2453",
+                "typeIdentifier": "t_contract$_UQ112x112_$2464",
                 "typeString": "library UQ112x112"
               }
             },
             "nodeType": "UsingForDirective",
             "src": "362:28:2",
             "typeName": {
-              "id": 648,
+              "id": 659,
               "name": "uint224",
               "nodeType": "ElementaryTypeName",
               "src": "382:7:2",
@@ -959,10 +959,10 @@
           },
           {
             "constant": true,
-            "id": 654,
+            "id": 665,
             "name": "MINIMUM_LIQUIDITY",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "396:46:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -971,7 +971,7 @@
               "typeString": "uint256"
             },
             "typeName": {
-              "id": 650,
+              "id": 661,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
               "src": "396:4:2",
@@ -986,7 +986,7 @@
                 "typeIdentifier": "t_rational_1000_by_1",
                 "typeString": "int_const 1000"
               },
-              "id": 653,
+              "id": 664,
               "isConstant": false,
               "isLValue": false,
               "isPure": true,
@@ -994,7 +994,7 @@
               "leftExpression": {
                 "argumentTypes": null,
                 "hexValue": "3130",
-                "id": 651,
+                "id": 662,
                 "isConstant": false,
                 "isLValue": false,
                 "isPure": true,
@@ -1014,7 +1014,7 @@
               "rightExpression": {
                 "argumentTypes": null,
                 "hexValue": "33",
-                "id": 652,
+                "id": 663,
                 "isConstant": false,
                 "isLValue": false,
                 "isPure": true,
@@ -1039,10 +1039,10 @@
           },
           {
             "constant": true,
-            "id": 663,
+            "id": 674,
             "name": "SELECTOR",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "448:88:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1051,7 +1051,7 @@
               "typeString": "bytes4"
             },
             "typeName": {
-              "id": 655,
+              "id": 666,
               "name": "bytes4",
               "nodeType": "ElementaryTypeName",
               "src": "448:6:2",
@@ -1072,7 +1072,7 @@
                         {
                           "argumentTypes": null,
                           "hexValue": "7472616e7366657228616464726573732c75696e7432353629",
-                          "id": 659,
+                          "id": 670,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -1095,7 +1095,7 @@
                             "typeString": "literal_string \"transfer(address,uint256)\""
                           }
                         ],
-                        "id": 658,
+                        "id": 669,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -1108,7 +1108,7 @@
                         },
                         "typeName": "bytes"
                       },
-                      "id": 660,
+                      "id": 671,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
@@ -1130,18 +1130,18 @@
                         "typeString": "bytes memory"
                       }
                     ],
-                    "id": 657,
+                    "id": 668,
                     "name": "keccak256",
                     "nodeType": "Identifier",
                     "overloadedDeclarations": [],
-                    "referencedDeclaration": 2480,
+                    "referencedDeclaration": 2491,
                     "src": "490:9:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
                       "typeString": "function (bytes memory) pure returns (bytes32)"
                     }
                   },
-                  "id": 661,
+                  "id": 672,
                   "isConstant": false,
                   "isLValue": false,
                   "isPure": true,
@@ -1163,7 +1163,7 @@
                     "typeString": "bytes32"
                   }
                 ],
-                "id": 656,
+                "id": 667,
                 "isConstant": false,
                 "isLValue": false,
                 "isPure": true,
@@ -1176,7 +1176,7 @@
                 },
                 "typeName": "bytes4"
               },
-              "id": 662,
+              "id": 673,
               "isConstant": false,
               "isLValue": false,
               "isPure": true,
@@ -1194,10 +1194,10 @@
           },
           {
             "constant": false,
-            "id": 665,
+            "id": 676,
             "name": "factory",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "543:22:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1206,7 +1206,7 @@
               "typeString": "address"
             },
             "typeName": {
-              "id": 664,
+              "id": 675,
               "name": "address",
               "nodeType": "ElementaryTypeName",
               "src": "543:7:2",
@@ -1221,10 +1221,10 @@
           },
           {
             "constant": false,
-            "id": 667,
+            "id": 678,
             "name": "token0",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "571:21:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1233,7 +1233,7 @@
               "typeString": "address"
             },
             "typeName": {
-              "id": 666,
+              "id": 677,
               "name": "address",
               "nodeType": "ElementaryTypeName",
               "src": "571:7:2",
@@ -1248,10 +1248,10 @@
           },
           {
             "constant": false,
-            "id": 669,
+            "id": 680,
             "name": "token1",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "598:21:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1260,7 +1260,7 @@
               "typeString": "address"
             },
             "typeName": {
-              "id": 668,
+              "id": 679,
               "name": "address",
               "nodeType": "ElementaryTypeName",
               "src": "598:7:2",
@@ -1275,10 +1275,10 @@
           },
           {
             "constant": false,
-            "id": 671,
+            "id": 682,
             "name": "reserve0",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "626:24:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1287,7 +1287,7 @@
               "typeString": "uint112"
             },
             "typeName": {
-              "id": 670,
+              "id": 681,
               "name": "uint112",
               "nodeType": "ElementaryTypeName",
               "src": "626:7:2",
@@ -1301,10 +1301,10 @@
           },
           {
             "constant": false,
-            "id": 673,
+            "id": 684,
             "name": "reserve1",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "722:24:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1313,7 +1313,7 @@
               "typeString": "uint112"
             },
             "typeName": {
-              "id": 672,
+              "id": 683,
               "name": "uint112",
               "nodeType": "ElementaryTypeName",
               "src": "722:7:2",
@@ -1327,10 +1327,10 @@
           },
           {
             "constant": false,
-            "id": 675,
+            "id": 686,
             "name": "blockTimestampLast",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "818:34:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1339,7 +1339,7 @@
               "typeString": "uint32"
             },
             "typeName": {
-              "id": 674,
+              "id": 685,
               "name": "uint32",
               "nodeType": "ElementaryTypeName",
               "src": "818:6:2",
@@ -1353,10 +1353,10 @@
           },
           {
             "constant": false,
-            "id": 677,
+            "id": 688,
             "name": "price0CumulativeLast",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "915:32:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1365,7 +1365,7 @@
               "typeString": "uint256"
             },
             "typeName": {
-              "id": 676,
+              "id": 687,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
               "src": "915:4:2",
@@ -1379,10 +1379,10 @@
           },
           {
             "constant": false,
-            "id": 679,
+            "id": 690,
             "name": "price1CumulativeLast",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "953:32:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1391,7 +1391,7 @@
               "typeString": "uint256"
             },
             "typeName": {
-              "id": 678,
+              "id": 689,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
               "src": "953:4:2",
@@ -1405,10 +1405,10 @@
           },
           {
             "constant": false,
-            "id": 681,
+            "id": 692,
             "name": "kLast",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "991:17:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1417,7 +1417,7 @@
               "typeString": "uint256"
             },
             "typeName": {
-              "id": 680,
+              "id": 691,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
               "src": "991:4:2",
@@ -1431,10 +1431,10 @@
           },
           {
             "constant": false,
-            "id": 684,
+            "id": 695,
             "name": "swapFee",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "1094:25:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1443,7 +1443,7 @@
               "typeString": "uint8"
             },
             "typeName": {
-              "id": 682,
+              "id": 693,
               "name": "uint8",
               "nodeType": "ElementaryTypeName",
               "src": "1094:5:2",
@@ -1455,7 +1455,7 @@
             "value": {
               "argumentTypes": null,
               "hexValue": "3330",
-              "id": 683,
+              "id": 694,
               "isConstant": false,
               "isLValue": false,
               "isPure": true,
@@ -1474,10 +1474,10 @@
           },
           {
             "constant": false,
-            "id": 687,
+            "id": 698,
             "name": "unlocked",
             "nodeType": "VariableDeclaration",
-            "scope": 1712,
+            "scope": 1723,
             "src": "1158:25:2",
             "stateVariable": true,
             "storageLocation": "default",
@@ -1486,7 +1486,7 @@
               "typeString": "uint256"
             },
             "typeName": {
-              "id": 685,
+              "id": 696,
               "name": "uint",
               "nodeType": "ElementaryTypeName",
               "src": "1158:4:2",
@@ -1498,7 +1498,7 @@
             "value": {
               "argumentTypes": null,
               "hexValue": "31",
-              "id": 686,
+              "id": 697,
               "isConstant": false,
               "isLValue": false,
               "isPure": true,
@@ -1517,7 +1517,7 @@
           },
           {
             "body": {
-              "id": 705,
+              "id": 716,
               "nodeType": "Block",
               "src": "1205:116:2",
               "statements": [
@@ -1531,18 +1531,18 @@
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         },
-                        "id": 692,
+                        "id": 703,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 690,
+                          "id": 701,
                           "name": "unlocked",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 687,
+                          "referencedDeclaration": 698,
                           "src": "1223:8:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -1554,7 +1554,7 @@
                         "rightExpression": {
                           "argumentTypes": null,
                           "hexValue": "31",
-                          "id": 691,
+                          "id": 702,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -1578,7 +1578,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170506169723a204c4f434b4544",
-                        "id": 693,
+                        "id": 704,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -1605,21 +1605,21 @@
                           "typeString": "literal_string \"DXswapPair: LOCKED\""
                         }
                       ],
-                      "id": 689,
+                      "id": 700,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "1215:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 694,
+                    "id": 705,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -1633,25 +1633,25 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 695,
+                  "id": 706,
                   "nodeType": "ExpressionStatement",
                   "src": "1215:44:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 698,
+                    "id": 709,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 696,
+                      "id": 707,
                       "name": "unlocked",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 687,
+                      "referencedDeclaration": 698,
                       "src": "1269:8:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
@@ -1663,7 +1663,7 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "30",
-                      "id": 697,
+                      "id": 708,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
@@ -1684,30 +1684,30 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 699,
+                  "id": 710,
                   "nodeType": "ExpressionStatement",
                   "src": "1269:12:2"
                 },
                 {
-                  "id": 700,
+                  "id": 711,
                   "nodeType": "PlaceholderStatement",
                   "src": "1291:1:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 703,
+                    "id": 714,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 701,
+                      "id": 712,
                       "name": "unlocked",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 687,
+                      "referencedDeclaration": 698,
                       "src": "1302:8:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
@@ -1719,7 +1719,7 @@
                     "rightHandSide": {
                       "argumentTypes": null,
                       "hexValue": "31",
-                      "id": 702,
+                      "id": 713,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
@@ -1740,18 +1740,18 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 704,
+                  "id": 715,
                   "nodeType": "ExpressionStatement",
                   "src": "1302:12:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 706,
+            "id": 717,
             "name": "lock",
             "nodeType": "ModifierDefinition",
             "parameters": {
-              "id": 688,
+              "id": 699,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1202:2:2"
@@ -1761,25 +1761,25 @@
           },
           {
             "body": {
-              "id": 727,
+              "id": 738,
               "nodeType": "Block",
               "src": "1437:117:2",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 717,
+                    "id": 728,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 715,
+                      "id": 726,
                       "name": "_reserve0",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 709,
+                      "referencedDeclaration": 720,
                       "src": "1447:9:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint112",
@@ -1790,11 +1790,11 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 716,
+                      "id": 727,
                       "name": "reserve0",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 671,
+                      "referencedDeclaration": 682,
                       "src": "1459:8:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint112",
@@ -1807,25 +1807,25 @@
                       "typeString": "uint112"
                     }
                   },
-                  "id": 718,
+                  "id": 729,
                   "nodeType": "ExpressionStatement",
                   "src": "1447:20:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 721,
+                    "id": 732,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 719,
+                      "id": 730,
                       "name": "_reserve1",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 711,
+                      "referencedDeclaration": 722,
                       "src": "1477:9:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint112",
@@ -1836,11 +1836,11 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 720,
+                      "id": 731,
                       "name": "reserve1",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 673,
+                      "referencedDeclaration": 684,
                       "src": "1489:8:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint112",
@@ -1853,25 +1853,25 @@
                       "typeString": "uint112"
                     }
                   },
-                  "id": 722,
+                  "id": 733,
                   "nodeType": "ExpressionStatement",
                   "src": "1477:20:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 725,
+                    "id": 736,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 723,
+                      "id": 734,
                       "name": "_blockTimestampLast",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 713,
+                      "referencedDeclaration": 724,
                       "src": "1507:19:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint32",
@@ -1882,11 +1882,11 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 724,
+                      "id": 735,
                       "name": "blockTimestampLast",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 675,
+                      "referencedDeclaration": 686,
                       "src": "1529:18:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint32",
@@ -1899,35 +1899,35 @@
                       "typeString": "uint32"
                     }
                   },
-                  "id": 726,
+                  "id": 737,
                   "nodeType": "ExpressionStatement",
                   "src": "1507:40:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 728,
+            "id": 739,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "getReserves",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 707,
+              "id": 718,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1347:2:2"
             },
             "returnParameters": {
-              "id": 714,
+              "id": 725,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 709,
+                  "id": 720,
                   "name": "_reserve0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 728,
+                  "scope": 739,
                   "src": "1371:17:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1936,7 +1936,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 708,
+                    "id": 719,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "1371:7:2",
@@ -1950,10 +1950,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 711,
+                  "id": 722,
                   "name": "_reserve1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 728,
+                  "scope": 739,
                   "src": "1390:17:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1962,7 +1962,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 710,
+                    "id": 721,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "1390:7:2",
@@ -1976,10 +1976,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 713,
+                  "id": 724,
                   "name": "_blockTimestampLast",
                   "nodeType": "VariableDeclaration",
-                  "scope": 728,
+                  "scope": 739,
                   "src": "1409:26:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1988,7 +1988,7 @@
                     "typeString": "uint32"
                   },
                   "typeName": {
-                    "id": 712,
+                    "id": 723,
                     "name": "uint32",
                     "nodeType": "ElementaryTypeName",
                     "src": "1409:6:2",
@@ -2003,30 +2003,30 @@
               ],
               "src": "1370:66:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "1327:227:2",
             "stateMutability": "view",
-            "superFunction": 2108,
+            "superFunction": 2119,
             "visibility": "public"
           },
           {
             "body": {
-              "id": 769,
+              "id": 780,
               "nodeType": "Block",
               "src": "1630:215:2",
               "statements": [
                 {
                   "assignments": [
-                    738,
-                    740
+                    749,
+                    751
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 738,
+                      "id": 749,
                       "name": "success",
                       "nodeType": "VariableDeclaration",
-                      "scope": 769,
+                      "scope": 780,
                       "src": "1641:12:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -2035,7 +2035,7 @@
                         "typeString": "bool"
                       },
                       "typeName": {
-                        "id": 737,
+                        "id": 748,
                         "name": "bool",
                         "nodeType": "ElementaryTypeName",
                         "src": "1641:4:2",
@@ -2049,10 +2049,10 @@
                     },
                     {
                       "constant": false,
-                      "id": 740,
+                      "id": 751,
                       "name": "data",
                       "nodeType": "VariableDeclaration",
-                      "scope": 769,
+                      "scope": 780,
                       "src": "1655:17:2",
                       "stateVariable": false,
                       "storageLocation": "memory",
@@ -2061,7 +2061,7 @@
                         "typeString": "bytes"
                       },
                       "typeName": {
-                        "id": 739,
+                        "id": 750,
                         "name": "bytes",
                         "nodeType": "ElementaryTypeName",
                         "src": "1655:5:2",
@@ -2074,7 +2074,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 750,
+                  "id": 761,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -2083,11 +2083,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 745,
+                            "id": 756,
                             "name": "SELECTOR",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 663,
+                            "referencedDeclaration": 674,
                             "src": "1710:8:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_bytes4",
@@ -2096,11 +2096,11 @@
                           },
                           {
                             "argumentTypes": null,
-                            "id": 746,
+                            "id": 757,
                             "name": "to",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 732,
+                            "referencedDeclaration": 743,
                             "src": "1720:2:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
@@ -2109,11 +2109,11 @@
                           },
                           {
                             "argumentTypes": null,
-                            "id": 747,
+                            "id": 758,
                             "name": "value",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 734,
+                            "referencedDeclaration": 745,
                             "src": "1724:5:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -2138,18 +2138,18 @@
                           ],
                           "expression": {
                             "argumentTypes": null,
-                            "id": 743,
+                            "id": 754,
                             "name": "abi",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2473,
+                            "referencedDeclaration": 2484,
                             "src": "1687:3:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_abi",
                               "typeString": "abi"
                             }
                           },
-                          "id": 744,
+                          "id": 755,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -2163,7 +2163,7 @@
                             "typeString": "function (bytes4) pure returns (bytes memory)"
                           }
                         },
-                        "id": 748,
+                        "id": 759,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -2187,18 +2187,18 @@
                       ],
                       "expression": {
                         "argumentTypes": null,
-                        "id": 741,
+                        "id": 752,
                         "name": "token",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 730,
+                        "referencedDeclaration": 741,
                         "src": "1676:5:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         }
                       },
-                      "id": 742,
+                      "id": 753,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -2212,7 +2212,7 @@
                         "typeString": "function (bytes memory) payable returns (bool,bytes memory)"
                       }
                     },
-                    "id": 749,
+                    "id": 760,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2239,18 +2239,18 @@
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
                         },
-                        "id": 765,
+                        "id": 776,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 752,
+                          "id": 763,
                           "name": "success",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 738,
+                          "referencedDeclaration": 749,
                           "src": "1749:7:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_bool",
@@ -2268,7 +2268,7 @@
                                 "typeIdentifier": "t_bool",
                                 "typeString": "bool"
                               },
-                              "id": 763,
+                              "id": 774,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -2279,7 +2279,7 @@
                                   "typeIdentifier": "t_uint256",
                                   "typeString": "uint256"
                                 },
-                                "id": 756,
+                                "id": 767,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
@@ -2288,18 +2288,18 @@
                                   "argumentTypes": null,
                                   "expression": {
                                     "argumentTypes": null,
-                                    "id": 753,
+                                    "id": 764,
                                     "name": "data",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 740,
+                                    "referencedDeclaration": 751,
                                     "src": "1761:4:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_bytes_memory_ptr",
                                       "typeString": "bytes memory"
                                     }
                                   },
-                                  "id": 754,
+                                  "id": 765,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
@@ -2318,7 +2318,7 @@
                                 "rightExpression": {
                                   "argumentTypes": null,
                                   "hexValue": "30",
-                                  "id": 755,
+                                  "id": 766,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": true,
@@ -2346,11 +2346,11 @@
                                 "arguments": [
                                   {
                                     "argumentTypes": null,
-                                    "id": 759,
+                                    "id": 770,
                                     "name": "data",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 740,
+                                    "referencedDeclaration": 751,
                                     "src": "1792:4:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_bytes_memory_ptr",
@@ -2362,7 +2362,7 @@
                                     "components": [
                                       {
                                         "argumentTypes": null,
-                                        "id": 760,
+                                        "id": 771,
                                         "isConstant": false,
                                         "isLValue": false,
                                         "isPure": true,
@@ -2376,7 +2376,7 @@
                                         "typeName": "bool"
                                       }
                                     ],
-                                    "id": 761,
+                                    "id": 772,
                                     "isConstant": false,
                                     "isInlineArray": false,
                                     "isLValue": false,
@@ -2403,18 +2403,18 @@
                                   ],
                                   "expression": {
                                     "argumentTypes": null,
-                                    "id": 757,
+                                    "id": 768,
                                     "name": "abi",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 2473,
+                                    "referencedDeclaration": 2484,
                                     "src": "1781:3:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_magic_abi",
                                       "typeString": "abi"
                                     }
                                   },
-                                  "id": 758,
+                                  "id": 769,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": true,
@@ -2428,7 +2428,7 @@
                                     "typeString": "function () pure"
                                   }
                                 },
-                                "id": 762,
+                                "id": 773,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
@@ -2449,7 +2449,7 @@
                               }
                             }
                           ],
-                          "id": 764,
+                          "id": 775,
                           "isConstant": false,
                           "isInlineArray": false,
                           "isLValue": false,
@@ -2471,7 +2471,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170506169723a205452414e534645525f4641494c4544",
-                        "id": 766,
+                        "id": 777,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -2498,21 +2498,21 @@
                           "typeString": "literal_string \"DXswapPair: TRANSFER_FAILED\""
                         }
                       ],
-                      "id": 751,
+                      "id": 762,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "1741:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 767,
+                    "id": 778,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -2526,29 +2526,29 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 768,
+                  "id": 779,
                   "nodeType": "ExpressionStatement",
                   "src": "1741:97:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 770,
+            "id": 781,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "_safeTransfer",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 735,
+              "id": 746,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 730,
+                  "id": 741,
                   "name": "token",
                   "nodeType": "VariableDeclaration",
-                  "scope": 770,
+                  "scope": 781,
                   "src": "1583:13:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2557,7 +2557,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 729,
+                    "id": 740,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1583:7:2",
@@ -2572,10 +2572,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 732,
+                  "id": 743,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 770,
+                  "scope": 781,
                   "src": "1598:10:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2584,7 +2584,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 731,
+                    "id": 742,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1598:7:2",
@@ -2599,10 +2599,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 734,
+                  "id": 745,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 770,
+                  "scope": 781,
                   "src": "1610:10:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2611,7 +2611,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 733,
+                    "id": 744,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1610:4:2",
@@ -2627,12 +2627,12 @@
               "src": "1582:39:2"
             },
             "returnParameters": {
-              "id": 736,
+              "id": 747,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1630:0:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "1560:285:2",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -2641,20 +2641,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 778,
+            "id": 789,
             "name": "Mint",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 777,
+              "id": 788,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 772,
+                  "id": 783,
                   "indexed": true,
                   "name": "sender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 778,
+                  "scope": 789,
                   "src": "1862:22:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2663,7 +2663,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 771,
+                    "id": 782,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1862:7:2",
@@ -2678,11 +2678,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 774,
+                  "id": 785,
                   "indexed": false,
                   "name": "amount0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 778,
+                  "scope": 789,
                   "src": "1886:12:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2691,7 +2691,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 773,
+                    "id": 784,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1886:4:2",
@@ -2705,11 +2705,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 776,
+                  "id": 787,
                   "indexed": false,
                   "name": "amount1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 778,
+                  "scope": 789,
                   "src": "1900:12:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2718,7 +2718,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 775,
+                    "id": 786,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1900:4:2",
@@ -2738,20 +2738,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 788,
+            "id": 799,
             "name": "Burn",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 787,
+              "id": 798,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 780,
+                  "id": 791,
                   "indexed": true,
                   "name": "sender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 788,
+                  "scope": 799,
                   "src": "1930:22:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2760,7 +2760,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 779,
+                    "id": 790,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1930:7:2",
@@ -2775,11 +2775,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 782,
+                  "id": 793,
                   "indexed": false,
                   "name": "amount0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 788,
+                  "scope": 799,
                   "src": "1954:12:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2788,7 +2788,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 781,
+                    "id": 792,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1954:4:2",
@@ -2802,11 +2802,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 784,
+                  "id": 795,
                   "indexed": false,
                   "name": "amount1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 788,
+                  "scope": 799,
                   "src": "1968:12:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2815,7 +2815,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 783,
+                    "id": 794,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1968:4:2",
@@ -2829,11 +2829,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 786,
+                  "id": 797,
                   "indexed": true,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 788,
+                  "scope": 799,
                   "src": "1982:18:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2842,7 +2842,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 785,
+                    "id": 796,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1982:7:2",
@@ -2863,20 +2863,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 802,
+            "id": 813,
             "name": "Swap",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 801,
+              "id": 812,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 790,
+                  "id": 801,
                   "indexed": true,
                   "name": "sender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 802,
+                  "scope": 813,
                   "src": "2027:22:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2885,7 +2885,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 789,
+                    "id": 800,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "2027:7:2",
@@ -2900,11 +2900,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 792,
+                  "id": 803,
                   "indexed": false,
                   "name": "amount0In",
                   "nodeType": "VariableDeclaration",
-                  "scope": 802,
+                  "scope": 813,
                   "src": "2059:14:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2913,7 +2913,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 791,
+                    "id": 802,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2059:4:2",
@@ -2927,11 +2927,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 794,
+                  "id": 805,
                   "indexed": false,
                   "name": "amount1In",
                   "nodeType": "VariableDeclaration",
-                  "scope": 802,
+                  "scope": 813,
                   "src": "2083:14:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2940,7 +2940,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 793,
+                    "id": 804,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2083:4:2",
@@ -2954,11 +2954,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 796,
+                  "id": 807,
                   "indexed": false,
                   "name": "amount0Out",
                   "nodeType": "VariableDeclaration",
-                  "scope": 802,
+                  "scope": 813,
                   "src": "2107:15:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2967,7 +2967,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 795,
+                    "id": 806,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2107:4:2",
@@ -2981,11 +2981,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 798,
+                  "id": 809,
                   "indexed": false,
                   "name": "amount1Out",
                   "nodeType": "VariableDeclaration",
-                  "scope": 802,
+                  "scope": 813,
                   "src": "2132:15:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2994,7 +2994,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 797,
+                    "id": 808,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2132:4:2",
@@ -3008,11 +3008,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 800,
+                  "id": 811,
                   "indexed": true,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 802,
+                  "scope": 813,
                   "src": "2157:18:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3021,7 +3021,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 799,
+                    "id": 810,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "2157:7:2",
@@ -3042,20 +3042,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 808,
+            "id": 819,
             "name": "Sync",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 807,
+              "id": 818,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 804,
+                  "id": 815,
                   "indexed": false,
                   "name": "reserve0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 808,
+                  "scope": 819,
                   "src": "2198:16:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3064,7 +3064,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 803,
+                    "id": 814,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "2198:7:2",
@@ -3078,11 +3078,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 806,
+                  "id": 817,
                   "indexed": false,
                   "name": "reserve1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 808,
+                  "scope": 819,
                   "src": "2216:16:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3091,7 +3091,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 805,
+                    "id": 816,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "2216:7:2",
@@ -3110,25 +3110,25 @@
           },
           {
             "body": {
-              "id": 816,
+              "id": 827,
               "nodeType": "Block",
               "src": "2261:37:2",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 814,
+                    "id": 825,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 811,
+                      "id": 822,
                       "name": "factory",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 665,
+                      "referencedDeclaration": 676,
                       "src": "2271:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
@@ -3141,18 +3141,18 @@
                       "argumentTypes": null,
                       "expression": {
                         "argumentTypes": null,
-                        "id": 812,
+                        "id": 823,
                         "name": "msg",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 2486,
+                        "referencedDeclaration": 2497,
                         "src": "2281:3:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_magic_message",
                           "typeString": "msg"
                         }
                       },
-                      "id": 813,
+                      "id": 824,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -3172,32 +3172,32 @@
                       "typeString": "address"
                     }
                   },
-                  "id": 815,
+                  "id": 826,
                   "nodeType": "ExpressionStatement",
                   "src": "2271:20:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 817,
+            "id": 828,
             "implemented": true,
             "kind": "constructor",
             "modifiers": [],
             "name": "",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 809,
+              "id": 820,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2251:2:2"
             },
             "returnParameters": {
-              "id": 810,
+              "id": 821,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2261:0:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "2240:58:2",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -3205,7 +3205,7 @@
           },
           {
             "body": {
-              "id": 840,
+              "id": 851,
               "nodeType": "Block",
               "src": "2423:144:2",
               "statements": [
@@ -3219,7 +3219,7 @@
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         },
-                        "id": 828,
+                        "id": 839,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -3228,18 +3228,18 @@
                           "argumentTypes": null,
                           "expression": {
                             "argumentTypes": null,
-                            "id": 825,
+                            "id": 836,
                             "name": "msg",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2486,
+                            "referencedDeclaration": 2497,
                             "src": "2441:3:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_message",
                               "typeString": "msg"
                             }
                           },
-                          "id": 826,
+                          "id": 837,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -3257,11 +3257,11 @@
                         "operator": "==",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 827,
+                          "id": 838,
                           "name": "factory",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 665,
+                          "referencedDeclaration": 676,
                           "src": "2455:7:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
@@ -3277,7 +3277,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170506169723a20464f5242494444454e",
-                        "id": 829,
+                        "id": 840,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -3304,21 +3304,21 @@
                           "typeString": "literal_string \"DXswapPair: FORBIDDEN\""
                         }
                       ],
-                      "id": 824,
+                      "id": 835,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "2433:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 830,
+                    "id": 841,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3332,25 +3332,25 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 831,
+                  "id": 842,
                   "nodeType": "ExpressionStatement",
                   "src": "2433:55:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 834,
+                    "id": 845,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 832,
+                      "id": 843,
                       "name": "token0",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 667,
+                      "referencedDeclaration": 678,
                       "src": "2518:6:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
@@ -3361,11 +3361,11 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 833,
+                      "id": 844,
                       "name": "_token0",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 819,
+                      "referencedDeclaration": 830,
                       "src": "2527:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
@@ -3378,25 +3378,25 @@
                       "typeString": "address"
                     }
                   },
-                  "id": 835,
+                  "id": 846,
                   "nodeType": "ExpressionStatement",
                   "src": "2518:16:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 838,
+                    "id": 849,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 836,
+                      "id": 847,
                       "name": "token1",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 669,
+                      "referencedDeclaration": 680,
                       "src": "2544:6:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
@@ -3407,11 +3407,11 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 837,
+                      "id": 848,
                       "name": "_token1",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 821,
+                      "referencedDeclaration": 832,
                       "src": "2553:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_address",
@@ -3424,29 +3424,29 @@
                       "typeString": "address"
                     }
                   },
-                  "id": 839,
+                  "id": 850,
                   "nodeType": "ExpressionStatement",
                   "src": "2544:16:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 841,
+            "id": 852,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "initialize",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 822,
+              "id": 833,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 819,
+                  "id": 830,
                   "name": "_token0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 841,
+                  "scope": 852,
                   "src": "2380:15:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3455,7 +3455,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 818,
+                    "id": 829,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "2380:7:2",
@@ -3470,10 +3470,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 821,
+                  "id": 832,
                   "name": "_token1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 841,
+                  "scope": 852,
                   "src": "2397:15:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3482,7 +3482,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 820,
+                    "id": 831,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "2397:7:2",
@@ -3499,20 +3499,20 @@
               "src": "2379:34:2"
             },
             "returnParameters": {
-              "id": 823,
+              "id": 834,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2423:0:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "2360:207:2",
             "stateMutability": "nonpayable",
-            "superFunction": 2170,
+            "superFunction": 2181,
             "visibility": "external"
           },
           {
             "body": {
-              "id": 865,
+              "id": 876,
               "nodeType": "Block",
               "src": "2670:204:2",
               "statements": [
@@ -3526,7 +3526,7 @@
                           "typeIdentifier": "t_address",
                           "typeString": "address"
                         },
-                        "id": 850,
+                        "id": 861,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -3535,18 +3535,18 @@
                           "argumentTypes": null,
                           "expression": {
                             "argumentTypes": null,
-                            "id": 847,
+                            "id": 858,
                             "name": "msg",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2486,
+                            "referencedDeclaration": 2497,
                             "src": "2688:3:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_message",
                               "typeString": "msg"
                             }
                           },
-                          "id": 848,
+                          "id": 859,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -3564,11 +3564,11 @@
                         "operator": "==",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 849,
+                          "id": 860,
                           "name": "factory",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 665,
+                          "referencedDeclaration": 676,
                           "src": "2702:7:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_address",
@@ -3584,7 +3584,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "556e697377617056323a20464f5242494444454e",
-                        "id": 851,
+                        "id": 862,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -3611,21 +3611,21 @@
                           "typeString": "literal_string \"UniswapV2: FORBIDDEN\""
                         }
                       ],
-                      "id": 846,
+                      "id": 857,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "2680:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 852,
+                    "id": 863,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3639,7 +3639,7 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 853,
+                  "id": 864,
                   "nodeType": "ExpressionStatement",
                   "src": "2680:54:2"
                 },
@@ -3653,18 +3653,18 @@
                           "typeIdentifier": "t_uint8",
                           "typeString": "uint8"
                         },
-                        "id": 857,
+                        "id": 868,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 855,
+                          "id": 866,
                           "name": "_swapFee",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 843,
+                          "referencedDeclaration": 854,
                           "src": "2772:8:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint8",
@@ -3676,7 +3676,7 @@
                         "rightExpression": {
                           "argumentTypes": null,
                           "hexValue": "3330",
-                          "id": 856,
+                          "id": 867,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -3700,7 +3700,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "556e697377617056323a20464f5242494444454e5f464545",
-                        "id": 858,
+                        "id": 869,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -3727,21 +3727,21 @@
                           "typeString": "literal_string \"UniswapV2: FORBIDDEN_FEE\""
                         }
                       ],
-                      "id": 854,
+                      "id": 865,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "2764:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 859,
+                    "id": 870,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -3755,25 +3755,25 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 860,
+                  "id": 871,
                   "nodeType": "ExpressionStatement",
                   "src": "2764:51:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 863,
+                    "id": 874,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 861,
+                      "id": 872,
                       "name": "swapFee",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 684,
+                      "referencedDeclaration": 695,
                       "src": "2849:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint8",
@@ -3784,11 +3784,11 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 862,
+                      "id": 873,
                       "name": "_swapFee",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 843,
+                      "referencedDeclaration": 854,
                       "src": "2859:8:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint8",
@@ -3801,29 +3801,29 @@
                       "typeString": "uint8"
                     }
                   },
-                  "id": 864,
+                  "id": 875,
                   "nodeType": "ExpressionStatement",
                   "src": "2849:18:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 866,
+            "id": 877,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "setSwapFee",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 844,
+              "id": 855,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 843,
+                  "id": 854,
                   "name": "_swapFee",
                   "nodeType": "VariableDeclaration",
-                  "scope": 866,
+                  "scope": 877,
                   "src": "2645:14:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3832,7 +3832,7 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 842,
+                    "id": 853,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
                     "src": "2645:5:2",
@@ -3848,20 +3848,20 @@
               "src": "2644:16:2"
             },
             "returnParameters": {
-              "id": 845,
+              "id": 856,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2670:0:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "2625:249:2",
             "stateMutability": "nonpayable",
-            "superFunction": 2175,
+            "superFunction": 2186,
             "visibility": "external"
           },
           {
             "body": {
-              "id": 973,
+              "id": 984,
               "nodeType": "Block",
               "src": "3049:755:2",
               "statements": [
@@ -3875,7 +3875,7 @@
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
                         },
-                        "id": 890,
+                        "id": 901,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -3886,18 +3886,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 883,
+                          "id": 894,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 878,
+                            "id": 889,
                             "name": "balance0",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 868,
+                            "referencedDeclaration": 879,
                             "src": "3067:8:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -3911,7 +3911,7 @@
                             "arguments": [
                               {
                                 "argumentTypes": null,
-                                "id": 881,
+                                "id": 892,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": true,
@@ -3923,7 +3923,7 @@
                                 "subExpression": {
                                   "argumentTypes": null,
                                   "hexValue": "31",
-                                  "id": 880,
+                                  "id": 891,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": true,
@@ -3951,7 +3951,7 @@
                                   "typeString": "int_const -1"
                                 }
                               ],
-                              "id": 879,
+                              "id": 890,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
@@ -3964,7 +3964,7 @@
                               },
                               "typeName": "uint112"
                             },
-                            "id": 882,
+                            "id": 893,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -3992,18 +3992,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 889,
+                          "id": 900,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 884,
+                            "id": 895,
                             "name": "balance1",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 870,
+                            "referencedDeclaration": 881,
                             "src": "3094:8:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -4017,7 +4017,7 @@
                             "arguments": [
                               {
                                 "argumentTypes": null,
-                                "id": 887,
+                                "id": 898,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": true,
@@ -4029,7 +4029,7 @@
                                 "subExpression": {
                                   "argumentTypes": null,
                                   "hexValue": "31",
-                                  "id": 886,
+                                  "id": 897,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": true,
@@ -4057,7 +4057,7 @@
                                   "typeString": "int_const -1"
                                 }
                               ],
-                              "id": 885,
+                              "id": 896,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
@@ -4070,7 +4070,7 @@
                               },
                               "typeName": "uint112"
                             },
-                            "id": 888,
+                            "id": 899,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -4099,7 +4099,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170506169723a204f564552464c4f57",
-                        "id": 891,
+                        "id": 902,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -4126,21 +4126,21 @@
                           "typeString": "literal_string \"DXswapPair: OVERFLOW\""
                         }
                       ],
-                      "id": 877,
+                      "id": 888,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "3059:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 892,
+                    "id": 903,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -4154,21 +4154,21 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 893,
+                  "id": 904,
                   "nodeType": "ExpressionStatement",
                   "src": "3059:83:2"
                 },
                 {
                   "assignments": [
-                    895
+                    906
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 895,
+                      "id": 906,
                       "name": "blockTimestamp",
                       "nodeType": "VariableDeclaration",
-                      "scope": 973,
+                      "scope": 984,
                       "src": "3152:21:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -4177,7 +4177,7 @@
                         "typeString": "uint32"
                       },
                       "typeName": {
-                        "id": 894,
+                        "id": 905,
                         "name": "uint32",
                         "nodeType": "ElementaryTypeName",
                         "src": "3152:6:2",
@@ -4190,7 +4190,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 904,
+                  "id": 915,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -4200,7 +4200,7 @@
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         },
-                        "id": 902,
+                        "id": 913,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -4209,18 +4209,18 @@
                           "argumentTypes": null,
                           "expression": {
                             "argumentTypes": null,
-                            "id": 897,
+                            "id": 908,
                             "name": "block",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2476,
+                            "referencedDeclaration": 2487,
                             "src": "3183:5:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_magic_block",
                               "typeString": "block"
                             }
                           },
-                          "id": 898,
+                          "id": 909,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -4242,7 +4242,7 @@
                             "typeIdentifier": "t_rational_4294967296_by_1",
                             "typeString": "int_const 4294967296"
                           },
-                          "id": 901,
+                          "id": 912,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -4250,7 +4250,7 @@
                           "leftExpression": {
                             "argumentTypes": null,
                             "hexValue": "32",
-                            "id": 899,
+                            "id": 910,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -4270,7 +4270,7 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "3332",
-                            "id": 900,
+                            "id": 911,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -4305,7 +4305,7 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 896,
+                      "id": 907,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
@@ -4318,7 +4318,7 @@
                       },
                       "typeName": "uint32"
                     },
-                    "id": 903,
+                    "id": 914,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -4337,15 +4337,15 @@
                 },
                 {
                   "assignments": [
-                    906
+                    917
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 906,
+                      "id": 917,
                       "name": "timeElapsed",
                       "nodeType": "VariableDeclaration",
-                      "scope": 973,
+                      "scope": 984,
                       "src": "3217:18:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -4354,7 +4354,7 @@
                         "typeString": "uint32"
                       },
                       "typeName": {
-                        "id": 905,
+                        "id": 916,
                         "name": "uint32",
                         "nodeType": "ElementaryTypeName",
                         "src": "3217:6:2",
@@ -4367,25 +4367,25 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 910,
+                  "id": 921,
                   "initialValue": {
                     "argumentTypes": null,
                     "commonType": {
                       "typeIdentifier": "t_uint32",
                       "typeString": "uint32"
                     },
-                    "id": 909,
+                    "id": 920,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftExpression": {
                       "argumentTypes": null,
-                      "id": 907,
+                      "id": 918,
                       "name": "blockTimestamp",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 895,
+                      "referencedDeclaration": 906,
                       "src": "3238:14:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint32",
@@ -4396,11 +4396,11 @@
                     "operator": "-",
                     "rightExpression": {
                       "argumentTypes": null,
-                      "id": 908,
+                      "id": 919,
                       "name": "blockTimestampLast",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 675,
+                      "referencedDeclaration": 686,
                       "src": "3255:18:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint32",
@@ -4423,7 +4423,7 @@
                       "typeIdentifier": "t_bool",
                       "typeString": "bool"
                     },
-                    "id": 921,
+                    "id": 932,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -4434,7 +4434,7 @@
                         "typeIdentifier": "t_bool",
                         "typeString": "bool"
                       },
-                      "id": 917,
+                      "id": 928,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -4445,18 +4445,18 @@
                           "typeIdentifier": "t_uint32",
                           "typeString": "uint32"
                         },
-                        "id": 913,
+                        "id": 924,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 911,
+                          "id": 922,
                           "name": "timeElapsed",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 906,
+                          "referencedDeclaration": 917,
                           "src": "3310:11:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint32",
@@ -4468,7 +4468,7 @@
                         "rightExpression": {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 912,
+                          "id": 923,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -4497,18 +4497,18 @@
                           "typeIdentifier": "t_uint112",
                           "typeString": "uint112"
                         },
-                        "id": 916,
+                        "id": 927,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 914,
+                          "id": 925,
                           "name": "_reserve0",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 872,
+                          "referencedDeclaration": 883,
                           "src": "3329:9:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint112",
@@ -4520,7 +4520,7 @@
                         "rightExpression": {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 915,
+                          "id": 926,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -4555,18 +4555,18 @@
                         "typeIdentifier": "t_uint112",
                         "typeString": "uint112"
                       },
-                      "id": 920,
+                      "id": 931,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftExpression": {
                         "argumentTypes": null,
-                        "id": 918,
+                        "id": 929,
                         "name": "_reserve1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 874,
+                        "referencedDeclaration": 885,
                         "src": "3347:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -4578,7 +4578,7 @@
                       "rightExpression": {
                         "argumentTypes": null,
                         "hexValue": "30",
-                        "id": 919,
+                        "id": 930,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -4606,29 +4606,29 @@
                     }
                   },
                   "falseBody": null,
-                  "id": 951,
+                  "id": 962,
                   "nodeType": "IfStatement",
                   "src": "3306:332:2",
                   "trueBody": {
-                    "id": 950,
+                    "id": 961,
                     "nodeType": "Block",
                     "src": "3363:275:2",
                     "statements": [
                       {
                         "expression": {
                           "argumentTypes": null,
-                          "id": 934,
+                          "id": 945,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftHandSide": {
                             "argumentTypes": null,
-                            "id": 922,
+                            "id": 933,
                             "name": "price0CumulativeLast",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 677,
+                            "referencedDeclaration": 688,
                             "src": "3437:20:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -4643,7 +4643,7 @@
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             },
-                            "id": 933,
+                            "id": 944,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -4656,11 +4656,11 @@
                                   "arguments": [
                                     {
                                       "argumentTypes": null,
-                                      "id": 929,
+                                      "id": 940,
                                       "name": "_reserve0",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 872,
+                                      "referencedDeclaration": 883,
                                       "src": "3500:9:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint112",
@@ -4680,11 +4680,11 @@
                                       "arguments": [
                                         {
                                           "argumentTypes": null,
-                                          "id": 926,
+                                          "id": 937,
                                           "name": "_reserve1",
                                           "nodeType": "Identifier",
                                           "overloadedDeclarations": [],
-                                          "referencedDeclaration": 874,
+                                          "referencedDeclaration": 885,
                                           "src": "3483:9:2",
                                           "typeDescriptions": {
                                             "typeIdentifier": "t_uint112",
@@ -4701,32 +4701,32 @@
                                         ],
                                         "expression": {
                                           "argumentTypes": null,
-                                          "id": 924,
+                                          "id": 935,
                                           "name": "UQ112x112",
                                           "nodeType": "Identifier",
                                           "overloadedDeclarations": [],
-                                          "referencedDeclaration": 2453,
+                                          "referencedDeclaration": 2464,
                                           "src": "3466:9:2",
                                           "typeDescriptions": {
-                                            "typeIdentifier": "t_type$_t_contract$_UQ112x112_$2453_$",
+                                            "typeIdentifier": "t_type$_t_contract$_UQ112x112_$2464_$",
                                             "typeString": "type(library UQ112x112)"
                                           }
                                         },
-                                        "id": 925,
+                                        "id": 936,
                                         "isConstant": false,
                                         "isLValue": false,
                                         "isPure": false,
                                         "lValueRequested": false,
                                         "memberName": "encode",
                                         "nodeType": "MemberAccess",
-                                        "referencedDeclaration": 2434,
+                                        "referencedDeclaration": 2445,
                                         "src": "3466:16:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_function_internal_pure$_t_uint112_$returns$_t_uint224_$",
                                           "typeString": "function (uint112) pure returns (uint224)"
                                         }
                                       },
-                                      "id": 927,
+                                      "id": 938,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": false,
@@ -4740,21 +4740,21 @@
                                         "typeString": "uint224"
                                       }
                                     },
-                                    "id": 928,
+                                    "id": 939,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
                                     "lValueRequested": false,
                                     "memberName": "uqdiv",
                                     "nodeType": "MemberAccess",
-                                    "referencedDeclaration": 2452,
+                                    "referencedDeclaration": 2463,
                                     "src": "3466:33:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_function_internal_pure$_t_uint224_$_t_uint112_$returns$_t_uint224_$bound_to$_t_uint224_$",
                                       "typeString": "function (uint224,uint112) pure returns (uint224)"
                                     }
                                   },
-                                  "id": 930,
+                                  "id": 941,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
@@ -4776,7 +4776,7 @@
                                     "typeString": "uint224"
                                   }
                                 ],
-                                "id": 923,
+                                "id": 934,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": true,
@@ -4789,7 +4789,7 @@
                                 },
                                 "typeName": "uint"
                               },
-                              "id": 931,
+                              "id": 942,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -4807,11 +4807,11 @@
                             "operator": "*",
                             "rightExpression": {
                               "argumentTypes": null,
-                              "id": 932,
+                              "id": 943,
                               "name": "timeElapsed",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 906,
+                              "referencedDeclaration": 917,
                               "src": "3514:11:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint32",
@@ -4830,25 +4830,25 @@
                             "typeString": "uint256"
                           }
                         },
-                        "id": 935,
+                        "id": 946,
                         "nodeType": "ExpressionStatement",
                         "src": "3437:88:2"
                       },
                       {
                         "expression": {
                           "argumentTypes": null,
-                          "id": 948,
+                          "id": 959,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftHandSide": {
                             "argumentTypes": null,
-                            "id": 936,
+                            "id": 947,
                             "name": "price1CumulativeLast",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 679,
+                            "referencedDeclaration": 690,
                             "src": "3539:20:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -4863,7 +4863,7 @@
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             },
-                            "id": 947,
+                            "id": 958,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -4876,11 +4876,11 @@
                                   "arguments": [
                                     {
                                       "argumentTypes": null,
-                                      "id": 943,
+                                      "id": 954,
                                       "name": "_reserve1",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 874,
+                                      "referencedDeclaration": 885,
                                       "src": "3602:9:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint112",
@@ -4900,11 +4900,11 @@
                                       "arguments": [
                                         {
                                           "argumentTypes": null,
-                                          "id": 940,
+                                          "id": 951,
                                           "name": "_reserve0",
                                           "nodeType": "Identifier",
                                           "overloadedDeclarations": [],
-                                          "referencedDeclaration": 872,
+                                          "referencedDeclaration": 883,
                                           "src": "3585:9:2",
                                           "typeDescriptions": {
                                             "typeIdentifier": "t_uint112",
@@ -4921,32 +4921,32 @@
                                         ],
                                         "expression": {
                                           "argumentTypes": null,
-                                          "id": 938,
+                                          "id": 949,
                                           "name": "UQ112x112",
                                           "nodeType": "Identifier",
                                           "overloadedDeclarations": [],
-                                          "referencedDeclaration": 2453,
+                                          "referencedDeclaration": 2464,
                                           "src": "3568:9:2",
                                           "typeDescriptions": {
-                                            "typeIdentifier": "t_type$_t_contract$_UQ112x112_$2453_$",
+                                            "typeIdentifier": "t_type$_t_contract$_UQ112x112_$2464_$",
                                             "typeString": "type(library UQ112x112)"
                                           }
                                         },
-                                        "id": 939,
+                                        "id": 950,
                                         "isConstant": false,
                                         "isLValue": false,
                                         "isPure": false,
                                         "lValueRequested": false,
                                         "memberName": "encode",
                                         "nodeType": "MemberAccess",
-                                        "referencedDeclaration": 2434,
+                                        "referencedDeclaration": 2445,
                                         "src": "3568:16:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_function_internal_pure$_t_uint112_$returns$_t_uint224_$",
                                           "typeString": "function (uint112) pure returns (uint224)"
                                         }
                                       },
-                                      "id": 941,
+                                      "id": 952,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": false,
@@ -4960,21 +4960,21 @@
                                         "typeString": "uint224"
                                       }
                                     },
-                                    "id": 942,
+                                    "id": 953,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
                                     "lValueRequested": false,
                                     "memberName": "uqdiv",
                                     "nodeType": "MemberAccess",
-                                    "referencedDeclaration": 2452,
+                                    "referencedDeclaration": 2463,
                                     "src": "3568:33:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_function_internal_pure$_t_uint224_$_t_uint112_$returns$_t_uint224_$bound_to$_t_uint224_$",
                                       "typeString": "function (uint224,uint112) pure returns (uint224)"
                                     }
                                   },
-                                  "id": 944,
+                                  "id": 955,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
@@ -4996,7 +4996,7 @@
                                     "typeString": "uint224"
                                   }
                                 ],
-                                "id": 937,
+                                "id": 948,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": true,
@@ -5009,7 +5009,7 @@
                                 },
                                 "typeName": "uint"
                               },
-                              "id": 945,
+                              "id": 956,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -5027,11 +5027,11 @@
                             "operator": "*",
                             "rightExpression": {
                               "argumentTypes": null,
-                              "id": 946,
+                              "id": 957,
                               "name": "timeElapsed",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 906,
+                              "referencedDeclaration": 917,
                               "src": "3616:11:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint32",
@@ -5050,7 +5050,7 @@
                             "typeString": "uint256"
                           }
                         },
-                        "id": 949,
+                        "id": 960,
                         "nodeType": "ExpressionStatement",
                         "src": "3539:88:2"
                       }
@@ -5060,18 +5060,18 @@
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 956,
+                    "id": 967,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 952,
+                      "id": 963,
                       "name": "reserve0",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 671,
+                      "referencedDeclaration": 682,
                       "src": "3647:8:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint112",
@@ -5085,11 +5085,11 @@
                       "arguments": [
                         {
                           "argumentTypes": null,
-                          "id": 954,
+                          "id": 965,
                           "name": "balance0",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 868,
+                          "referencedDeclaration": 879,
                           "src": "3666:8:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -5104,7 +5104,7 @@
                             "typeString": "uint256"
                           }
                         ],
-                        "id": 953,
+                        "id": 964,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -5117,7 +5117,7 @@
                         },
                         "typeName": "uint112"
                       },
-                      "id": 955,
+                      "id": 966,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -5137,25 +5137,25 @@
                       "typeString": "uint112"
                     }
                   },
-                  "id": 957,
+                  "id": 968,
                   "nodeType": "ExpressionStatement",
                   "src": "3647:28:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 962,
+                    "id": 973,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 958,
+                      "id": 969,
                       "name": "reserve1",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 673,
+                      "referencedDeclaration": 684,
                       "src": "3685:8:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint112",
@@ -5169,11 +5169,11 @@
                       "arguments": [
                         {
                           "argumentTypes": null,
-                          "id": 960,
+                          "id": 971,
                           "name": "balance1",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 870,
+                          "referencedDeclaration": 881,
                           "src": "3704:8:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -5188,7 +5188,7 @@
                             "typeString": "uint256"
                           }
                         ],
-                        "id": 959,
+                        "id": 970,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -5201,7 +5201,7 @@
                         },
                         "typeName": "uint112"
                       },
-                      "id": 961,
+                      "id": 972,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -5221,25 +5221,25 @@
                       "typeString": "uint112"
                     }
                   },
-                  "id": 963,
+                  "id": 974,
                   "nodeType": "ExpressionStatement",
                   "src": "3685:28:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 966,
+                    "id": 977,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 964,
+                      "id": 975,
                       "name": "blockTimestampLast",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 675,
+                      "referencedDeclaration": 686,
                       "src": "3723:18:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint32",
@@ -5250,11 +5250,11 @@
                     "operator": "=",
                     "rightHandSide": {
                       "argumentTypes": null,
-                      "id": 965,
+                      "id": 976,
                       "name": "blockTimestamp",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 895,
+                      "referencedDeclaration": 906,
                       "src": "3744:14:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint32",
@@ -5267,7 +5267,7 @@
                       "typeString": "uint32"
                     }
                   },
-                  "id": 967,
+                  "id": 978,
                   "nodeType": "ExpressionStatement",
                   "src": "3723:35:2"
                 },
@@ -5277,11 +5277,11 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 969,
+                        "id": 980,
                         "name": "reserve0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 671,
+                        "referencedDeclaration": 682,
                         "src": "3778:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -5290,11 +5290,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 970,
+                        "id": 981,
                         "name": "reserve1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 673,
+                        "referencedDeclaration": 684,
                         "src": "3788:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -5313,20 +5313,20 @@
                           "typeString": "uint112"
                         }
                       ],
-                      "id": 968,
+                      "id": 979,
                       "name": "Sync",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        808
+                        819
                       ],
-                      "referencedDeclaration": 808,
+                      "referencedDeclaration": 819,
                       "src": "3773:4:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_uint112_$_t_uint112_$returns$__$",
                         "typeString": "function (uint112,uint112)"
                       }
                     },
-                    "id": 971,
+                    "id": 982,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -5340,29 +5340,29 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 972,
+                  "id": 983,
                   "nodeType": "EmitStatement",
                   "src": "3768:29:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 974,
+            "id": 985,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "_update",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 875,
+              "id": 886,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 868,
+                  "id": 879,
                   "name": "balance0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 974,
+                  "scope": 985,
                   "src": "2973:13:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -5371,7 +5371,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 867,
+                    "id": 878,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2973:4:2",
@@ -5385,10 +5385,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 870,
+                  "id": 881,
                   "name": "balance1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 974,
+                  "scope": 985,
                   "src": "2988:13:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -5397,7 +5397,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 869,
+                    "id": 880,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2988:4:2",
@@ -5411,10 +5411,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 872,
+                  "id": 883,
                   "name": "_reserve0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 974,
+                  "scope": 985,
                   "src": "3003:17:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -5423,7 +5423,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 871,
+                    "id": 882,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "3003:7:2",
@@ -5437,10 +5437,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 874,
+                  "id": 885,
                   "name": "_reserve1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 974,
+                  "scope": 985,
                   "src": "3022:17:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -5449,7 +5449,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 873,
+                    "id": 884,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "3022:7:2",
@@ -5465,12 +5465,12 @@
               "src": "2972:68:2"
             },
             "returnParameters": {
-              "id": 876,
+              "id": 887,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "3049:0:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "2956:848:2",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -5478,21 +5478,21 @@
           },
           {
             "body": {
-              "id": 1087,
+              "id": 1098,
               "nodeType": "Block",
               "src": "4009:841:2",
               "statements": [
                 {
                   "assignments": [
-                    984
+                    995
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 984,
+                      "id": 995,
                       "name": "feeTo",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1087,
+                      "scope": 1098,
                       "src": "4019:13:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -5501,7 +5501,7 @@
                         "typeString": "address"
                       },
                       "typeName": {
-                        "id": 983,
+                        "id": 994,
                         "name": "address",
                         "nodeType": "ElementaryTypeName",
                         "src": "4019:7:2",
@@ -5515,7 +5515,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 990,
+                  "id": 1001,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [],
@@ -5526,11 +5526,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 986,
+                            "id": 997,
                             "name": "factory",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 665,
+                            "referencedDeclaration": 676,
                             "src": "4050:7:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
@@ -5545,18 +5545,18 @@
                               "typeString": "address"
                             }
                           ],
-                          "id": 985,
+                          "id": 996,
                           "name": "IDXswapFactory",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1924,
+                          "referencedDeclaration": 1935,
                           "src": "4035:14:2",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_type$_t_contract$_IDXswapFactory_$1924_$",
+                            "typeIdentifier": "t_type$_t_contract$_IDXswapFactory_$1935_$",
                             "typeString": "type(contract IDXswapFactory)"
                           }
                         },
-                        "id": 987,
+                        "id": 998,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -5566,25 +5566,25 @@
                         "nodeType": "FunctionCall",
                         "src": "4035:23:2",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_contract$_IDXswapFactory_$1924",
+                          "typeIdentifier": "t_contract$_IDXswapFactory_$1935",
                           "typeString": "contract IDXswapFactory"
                         }
                       },
-                      "id": 988,
+                      "id": 999,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "memberName": "feeTo",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 1861,
+                      "referencedDeclaration": 1872,
                       "src": "4035:29:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_external_view$__$returns$_t_address_$",
                         "typeString": "function () view external returns (address)"
                       }
                     },
-                    "id": 989,
+                    "id": 1000,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -5603,15 +5603,15 @@
                 },
                 {
                   "assignments": [
-                    992
+                    1003
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 992,
+                      "id": 1003,
                       "name": "protocolFeeDenominator",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1087,
+                      "scope": 1098,
                       "src": "4076:28:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -5620,7 +5620,7 @@
                         "typeString": "uint8"
                       },
                       "typeName": {
-                        "id": 991,
+                        "id": 1002,
                         "name": "uint8",
                         "nodeType": "ElementaryTypeName",
                         "src": "4076:5:2",
@@ -5633,7 +5633,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 998,
+                  "id": 1009,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [],
@@ -5644,11 +5644,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 994,
+                            "id": 1005,
                             "name": "factory",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 665,
+                            "referencedDeclaration": 676,
                             "src": "4122:7:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
@@ -5663,18 +5663,18 @@
                               "typeString": "address"
                             }
                           ],
-                          "id": 993,
+                          "id": 1004,
                           "name": "IDXswapFactory",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1924,
+                          "referencedDeclaration": 1935,
                           "src": "4107:14:2",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_type$_t_contract$_IDXswapFactory_$1924_$",
+                            "typeIdentifier": "t_type$_t_contract$_IDXswapFactory_$1935_$",
                             "typeString": "type(contract IDXswapFactory)"
                           }
                         },
-                        "id": 995,
+                        "id": 1006,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -5684,25 +5684,25 @@
                         "nodeType": "FunctionCall",
                         "src": "4107:23:2",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_contract$_IDXswapFactory_$1924",
+                          "typeIdentifier": "t_contract$_IDXswapFactory_$1935",
                           "typeString": "contract IDXswapFactory"
                         }
                       },
-                      "id": 996,
+                      "id": 1007,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "memberName": "protocolFeeDenominator",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 1866,
+                      "referencedDeclaration": 1877,
                       "src": "4107:46:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_external_view$__$returns$_t_uint8_$",
                         "typeString": "function () view external returns (uint8)"
                       }
                     },
-                    "id": 997,
+                    "id": 1008,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -5722,18 +5722,18 @@
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 1005,
+                    "id": 1016,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 999,
+                      "id": 1010,
                       "name": "feeOn",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 981,
+                      "referencedDeclaration": 992,
                       "src": "4165:5:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_bool",
@@ -5748,18 +5748,18 @@
                         "typeIdentifier": "t_address",
                         "typeString": "address"
                       },
-                      "id": 1004,
+                      "id": 1015,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftExpression": {
                         "argumentTypes": null,
-                        "id": 1000,
+                        "id": 1011,
                         "name": "feeTo",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 984,
+                        "referencedDeclaration": 995,
                         "src": "4173:5:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -5774,7 +5774,7 @@
                           {
                             "argumentTypes": null,
                             "hexValue": "30",
-                            "id": 1002,
+                            "id": 1013,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -5797,7 +5797,7 @@
                               "typeString": "int_const 0"
                             }
                           ],
-                          "id": 1001,
+                          "id": 1012,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -5810,7 +5810,7 @@
                           },
                           "typeName": "address"
                         },
-                        "id": 1003,
+                        "id": 1014,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -5836,21 +5836,21 @@
                       "typeString": "bool"
                     }
                   },
-                  "id": 1006,
+                  "id": 1017,
                   "nodeType": "ExpressionStatement",
                   "src": "4165:27:2"
                 },
                 {
                   "assignments": [
-                    1008
+                    1019
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1008,
+                      "id": 1019,
                       "name": "_kLast",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1087,
+                      "scope": 1098,
                       "src": "4202:11:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -5859,7 +5859,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1007,
+                        "id": 1018,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "4202:4:2",
@@ -5872,14 +5872,14 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1010,
+                  "id": 1021,
                   "initialValue": {
                     "argumentTypes": null,
-                    "id": 1009,
+                    "id": 1020,
                     "name": "kLast",
                     "nodeType": "Identifier",
                     "overloadedDeclarations": [],
-                    "referencedDeclaration": 681,
+                    "referencedDeclaration": 692,
                     "src": "4216:5:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint256",
@@ -5892,11 +5892,11 @@
                 {
                   "condition": {
                     "argumentTypes": null,
-                    "id": 1011,
+                    "id": 1022,
                     "name": "feeOn",
                     "nodeType": "Identifier",
                     "overloadedDeclarations": [],
-                    "referencedDeclaration": 981,
+                    "referencedDeclaration": 992,
                     "src": "4250:5:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
@@ -5910,18 +5910,18 @@
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       },
-                      "id": 1079,
+                      "id": 1090,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftExpression": {
                         "argumentTypes": null,
-                        "id": 1077,
+                        "id": 1088,
                         "name": "_kLast",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1008,
+                        "referencedDeclaration": 1019,
                         "src": "4797:6:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -5933,7 +5933,7 @@
                       "rightExpression": {
                         "argumentTypes": null,
                         "hexValue": "30",
-                        "id": 1078,
+                        "id": 1089,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -5955,29 +5955,29 @@
                       }
                     },
                     "falseBody": null,
-                    "id": 1085,
+                    "id": 1096,
                     "nodeType": "IfStatement",
                     "src": "4793:51:2",
                     "trueBody": {
-                      "id": 1084,
+                      "id": 1095,
                       "nodeType": "Block",
                       "src": "4810:34:2",
                       "statements": [
                         {
                           "expression": {
                             "argumentTypes": null,
-                            "id": 1082,
+                            "id": 1093,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
                             "lValueRequested": false,
                             "leftHandSide": {
                               "argumentTypes": null,
-                              "id": 1080,
+                              "id": 1091,
                               "name": "kLast",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 681,
+                              "referencedDeclaration": 692,
                               "src": "4824:5:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint256",
@@ -5989,7 +5989,7 @@
                             "rightHandSide": {
                               "argumentTypes": null,
                               "hexValue": "30",
-                              "id": 1081,
+                              "id": 1092,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
@@ -6010,18 +6010,18 @@
                               "typeString": "uint256"
                             }
                           },
-                          "id": 1083,
+                          "id": 1094,
                           "nodeType": "ExpressionStatement",
                           "src": "4824:9:2"
                         }
                       ]
                     }
                   },
-                  "id": 1086,
+                  "id": 1097,
                   "nodeType": "IfStatement",
                   "src": "4246:598:2",
                   "trueBody": {
-                    "id": 1076,
+                    "id": 1087,
                     "nodeType": "Block",
                     "src": "4257:530:2",
                     "statements": [
@@ -6032,18 +6032,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 1014,
+                          "id": 1025,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 1012,
+                            "id": 1023,
                             "name": "_kLast",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1008,
+                            "referencedDeclaration": 1019,
                             "src": "4275:6:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -6055,7 +6055,7 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "30",
-                            "id": 1013,
+                            "id": 1024,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -6077,25 +6077,25 @@
                           }
                         },
                         "falseBody": null,
-                        "id": 1075,
+                        "id": 1086,
                         "nodeType": "IfStatement",
                         "src": "4271:506:2",
                         "trueBody": {
-                          "id": 1074,
+                          "id": 1085,
                           "nodeType": "Block",
                           "src": "4288:489:2",
                           "statements": [
                             {
                               "assignments": [
-                                1016
+                                1027
                               ],
                               "declarations": [
                                 {
                                   "constant": false,
-                                  "id": 1016,
+                                  "id": 1027,
                                   "name": "rootK",
                                   "nodeType": "VariableDeclaration",
-                                  "scope": 1074,
+                                  "scope": 1085,
                                   "src": "4306:10:2",
                                   "stateVariable": false,
                                   "storageLocation": "default",
@@ -6104,7 +6104,7 @@
                                     "typeString": "uint256"
                                   },
                                   "typeName": {
-                                    "id": 1015,
+                                    "id": 1026,
                                     "name": "uint",
                                     "nodeType": "ElementaryTypeName",
                                     "src": "4306:4:2",
@@ -6117,7 +6117,7 @@
                                   "visibility": "internal"
                                 }
                               ],
-                              "id": 1026,
+                              "id": 1037,
                               "initialValue": {
                                 "argumentTypes": null,
                                 "arguments": [
@@ -6126,11 +6126,11 @@
                                     "arguments": [
                                       {
                                         "argumentTypes": null,
-                                        "id": 1023,
+                                        "id": 1034,
                                         "name": "_reserve1",
                                         "nodeType": "Identifier",
                                         "overloadedDeclarations": [],
-                                        "referencedDeclaration": 978,
+                                        "referencedDeclaration": 989,
                                         "src": "4349:9:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_uint112",
@@ -6150,11 +6150,11 @@
                                         "arguments": [
                                           {
                                             "argumentTypes": null,
-                                            "id": 1020,
+                                            "id": 1031,
                                             "name": "_reserve0",
                                             "nodeType": "Identifier",
                                             "overloadedDeclarations": [],
-                                            "referencedDeclaration": 976,
+                                            "referencedDeclaration": 987,
                                             "src": "4334:9:2",
                                             "typeDescriptions": {
                                               "typeIdentifier": "t_uint112",
@@ -6169,7 +6169,7 @@
                                               "typeString": "uint112"
                                             }
                                           ],
-                                          "id": 1019,
+                                          "id": 1030,
                                           "isConstant": false,
                                           "isLValue": false,
                                           "isPure": true,
@@ -6182,7 +6182,7 @@
                                           },
                                           "typeName": "uint"
                                         },
-                                        "id": 1021,
+                                        "id": 1032,
                                         "isConstant": false,
                                         "isLValue": false,
                                         "isPure": false,
@@ -6196,21 +6196,21 @@
                                           "typeString": "uint256"
                                         }
                                       },
-                                      "id": 1022,
+                                      "id": 1033,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": false,
                                       "lValueRequested": false,
                                       "memberName": "mul",
                                       "nodeType": "MemberAccess",
-                                      "referencedDeclaration": 2410,
+                                      "referencedDeclaration": 2421,
                                       "src": "4329:19:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                         "typeString": "function (uint256,uint256) pure returns (uint256)"
                                       }
                                     },
-                                    "id": 1024,
+                                    "id": 1035,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
@@ -6234,32 +6234,32 @@
                                   ],
                                   "expression": {
                                     "argumentTypes": null,
-                                    "id": 1017,
+                                    "id": 1028,
                                     "name": "Math",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 2336,
+                                    "referencedDeclaration": 2347,
                                     "src": "4319:4:2",
                                     "typeDescriptions": {
-                                      "typeIdentifier": "t_type$_t_contract$_Math_$2336_$",
+                                      "typeIdentifier": "t_type$_t_contract$_Math_$2347_$",
                                       "typeString": "type(library Math)"
                                     }
                                   },
-                                  "id": 1018,
+                                  "id": 1029,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
                                   "lValueRequested": false,
                                   "memberName": "sqrt",
                                   "nodeType": "MemberAccess",
-                                  "referencedDeclaration": 2335,
+                                  "referencedDeclaration": 2346,
                                   "src": "4319:9:2",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_function_internal_pure$_t_uint256_$returns$_t_uint256_$",
                                     "typeString": "function (uint256) pure returns (uint256)"
                                   }
                                 },
-                                "id": 1025,
+                                "id": 1036,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
@@ -6278,15 +6278,15 @@
                             },
                             {
                               "assignments": [
-                                1028
+                                1039
                               ],
                               "declarations": [
                                 {
                                   "constant": false,
-                                  "id": 1028,
+                                  "id": 1039,
                                   "name": "rootKLast",
                                   "nodeType": "VariableDeclaration",
-                                  "scope": 1074,
+                                  "scope": 1085,
                                   "src": "4378:14:2",
                                   "stateVariable": false,
                                   "storageLocation": "default",
@@ -6295,7 +6295,7 @@
                                     "typeString": "uint256"
                                   },
                                   "typeName": {
-                                    "id": 1027,
+                                    "id": 1038,
                                     "name": "uint",
                                     "nodeType": "ElementaryTypeName",
                                     "src": "4378:4:2",
@@ -6308,17 +6308,17 @@
                                   "visibility": "internal"
                                 }
                               ],
-                              "id": 1033,
+                              "id": 1044,
                               "initialValue": {
                                 "argumentTypes": null,
                                 "arguments": [
                                   {
                                     "argumentTypes": null,
-                                    "id": 1031,
+                                    "id": 1042,
                                     "name": "_kLast",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 1008,
+                                    "referencedDeclaration": 1019,
                                     "src": "4405:6:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_uint256",
@@ -6335,32 +6335,32 @@
                                   ],
                                   "expression": {
                                     "argumentTypes": null,
-                                    "id": 1029,
+                                    "id": 1040,
                                     "name": "Math",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 2336,
+                                    "referencedDeclaration": 2347,
                                     "src": "4395:4:2",
                                     "typeDescriptions": {
-                                      "typeIdentifier": "t_type$_t_contract$_Math_$2336_$",
+                                      "typeIdentifier": "t_type$_t_contract$_Math_$2347_$",
                                       "typeString": "type(library Math)"
                                     }
                                   },
-                                  "id": 1030,
+                                  "id": 1041,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
                                   "lValueRequested": false,
                                   "memberName": "sqrt",
                                   "nodeType": "MemberAccess",
-                                  "referencedDeclaration": 2335,
+                                  "referencedDeclaration": 2346,
                                   "src": "4395:9:2",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_function_internal_pure$_t_uint256_$returns$_t_uint256_$",
                                     "typeString": "function (uint256) pure returns (uint256)"
                                   }
                                 },
-                                "id": 1032,
+                                "id": 1043,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
@@ -6384,18 +6384,18 @@
                                   "typeIdentifier": "t_uint256",
                                   "typeString": "uint256"
                                 },
-                                "id": 1036,
+                                "id": 1047,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
                                 "lValueRequested": false,
                                 "leftExpression": {
                                   "argumentTypes": null,
-                                  "id": 1034,
+                                  "id": 1045,
                                   "name": "rootK",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 1016,
+                                  "referencedDeclaration": 1027,
                                   "src": "4434:5:2",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_uint256",
@@ -6406,11 +6406,11 @@
                                 "operator": ">",
                                 "rightExpression": {
                                   "argumentTypes": null,
-                                  "id": 1035,
+                                  "id": 1046,
                                   "name": "rootKLast",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 1028,
+                                  "referencedDeclaration": 1039,
                                   "src": "4442:9:2",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_uint256",
@@ -6424,25 +6424,25 @@
                                 }
                               },
                               "falseBody": null,
-                              "id": 1073,
+                              "id": 1084,
                               "nodeType": "IfStatement",
                               "src": "4430:333:2",
                               "trueBody": {
-                                "id": 1072,
+                                "id": 1083,
                                 "nodeType": "Block",
                                 "src": "4453:310:2",
                                 "statements": [
                                   {
                                     "assignments": [
-                                      1038
+                                      1049
                                     ],
                                     "declarations": [
                                       {
                                         "constant": false,
-                                        "id": 1038,
+                                        "id": 1049,
                                         "name": "numerator",
                                         "nodeType": "VariableDeclaration",
-                                        "scope": 1072,
+                                        "scope": 1083,
                                         "src": "4475:14:2",
                                         "stateVariable": false,
                                         "storageLocation": "default",
@@ -6451,7 +6451,7 @@
                                           "typeString": "uint256"
                                         },
                                         "typeName": {
-                                          "id": 1037,
+                                          "id": 1048,
                                           "name": "uint",
                                           "nodeType": "ElementaryTypeName",
                                           "src": "4475:4:2",
@@ -6464,7 +6464,7 @@
                                         "visibility": "internal"
                                       }
                                     ],
-                                    "id": 1046,
+                                    "id": 1057,
                                     "initialValue": {
                                       "argumentTypes": null,
                                       "arguments": [
@@ -6473,11 +6473,11 @@
                                           "arguments": [
                                             {
                                               "argumentTypes": null,
-                                              "id": 1043,
+                                              "id": 1054,
                                               "name": "rootKLast",
                                               "nodeType": "Identifier",
                                               "overloadedDeclarations": [],
-                                              "referencedDeclaration": 1028,
+                                              "referencedDeclaration": 1039,
                                               "src": "4518:9:2",
                                               "typeDescriptions": {
                                                 "typeIdentifier": "t_uint256",
@@ -6494,32 +6494,32 @@
                                             ],
                                             "expression": {
                                               "argumentTypes": null,
-                                              "id": 1041,
+                                              "id": 1052,
                                               "name": "rootK",
                                               "nodeType": "Identifier",
                                               "overloadedDeclarations": [],
-                                              "referencedDeclaration": 1016,
+                                              "referencedDeclaration": 1027,
                                               "src": "4508:5:2",
                                               "typeDescriptions": {
                                                 "typeIdentifier": "t_uint256",
                                                 "typeString": "uint256"
                                               }
                                             },
-                                            "id": 1042,
+                                            "id": 1053,
                                             "isConstant": false,
                                             "isLValue": false,
                                             "isPure": false,
                                             "lValueRequested": false,
                                             "memberName": "sub",
                                             "nodeType": "MemberAccess",
-                                            "referencedDeclaration": 2382,
+                                            "referencedDeclaration": 2393,
                                             "src": "4508:9:2",
                                             "typeDescriptions": {
                                               "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                               "typeString": "function (uint256,uint256) pure returns (uint256)"
                                             }
                                           },
-                                          "id": 1044,
+                                          "id": 1055,
                                           "isConstant": false,
                                           "isLValue": false,
                                           "isPure": false,
@@ -6543,7 +6543,7 @@
                                         ],
                                         "expression": {
                                           "argumentTypes": null,
-                                          "id": 1039,
+                                          "id": 1050,
                                           "name": "totalSupply",
                                           "nodeType": "Identifier",
                                           "overloadedDeclarations": [],
@@ -6554,21 +6554,21 @@
                                             "typeString": "uint256"
                                           }
                                         },
-                                        "id": 1040,
+                                        "id": 1051,
                                         "isConstant": false,
                                         "isLValue": false,
                                         "isPure": false,
                                         "lValueRequested": false,
                                         "memberName": "mul",
                                         "nodeType": "MemberAccess",
-                                        "referencedDeclaration": 2410,
+                                        "referencedDeclaration": 2421,
                                         "src": "4492:15:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                           "typeString": "function (uint256,uint256) pure returns (uint256)"
                                         }
                                       },
-                                      "id": 1045,
+                                      "id": 1056,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": false,
@@ -6587,15 +6587,15 @@
                                   },
                                   {
                                     "assignments": [
-                                      1048
+                                      1059
                                     ],
                                     "declarations": [
                                       {
                                         "constant": false,
-                                        "id": 1048,
+                                        "id": 1059,
                                         "name": "denominator",
                                         "nodeType": "VariableDeclaration",
-                                        "scope": 1072,
+                                        "scope": 1083,
                                         "src": "4551:16:2",
                                         "stateVariable": false,
                                         "storageLocation": "default",
@@ -6604,7 +6604,7 @@
                                           "typeString": "uint256"
                                         },
                                         "typeName": {
-                                          "id": 1047,
+                                          "id": 1058,
                                           "name": "uint",
                                           "nodeType": "ElementaryTypeName",
                                           "src": "4551:4:2",
@@ -6617,17 +6617,17 @@
                                         "visibility": "internal"
                                       }
                                     ],
-                                    "id": 1056,
+                                    "id": 1067,
                                     "initialValue": {
                                       "argumentTypes": null,
                                       "arguments": [
                                         {
                                           "argumentTypes": null,
-                                          "id": 1054,
+                                          "id": 1065,
                                           "name": "rootKLast",
                                           "nodeType": "Identifier",
                                           "overloadedDeclarations": [],
-                                          "referencedDeclaration": 1028,
+                                          "referencedDeclaration": 1039,
                                           "src": "4608:9:2",
                                           "typeDescriptions": {
                                             "typeIdentifier": "t_uint256",
@@ -6647,11 +6647,11 @@
                                           "arguments": [
                                             {
                                               "argumentTypes": null,
-                                              "id": 1051,
+                                              "id": 1062,
                                               "name": "protocolFeeDenominator",
                                               "nodeType": "Identifier",
                                               "overloadedDeclarations": [],
-                                              "referencedDeclaration": 992,
+                                              "referencedDeclaration": 1003,
                                               "src": "4580:22:2",
                                               "typeDescriptions": {
                                                 "typeIdentifier": "t_uint8",
@@ -6668,32 +6668,32 @@
                                             ],
                                             "expression": {
                                               "argumentTypes": null,
-                                              "id": 1049,
+                                              "id": 1060,
                                               "name": "rootK",
                                               "nodeType": "Identifier",
                                               "overloadedDeclarations": [],
-                                              "referencedDeclaration": 1016,
+                                              "referencedDeclaration": 1027,
                                               "src": "4570:5:2",
                                               "typeDescriptions": {
                                                 "typeIdentifier": "t_uint256",
                                                 "typeString": "uint256"
                                               }
                                             },
-                                            "id": 1050,
+                                            "id": 1061,
                                             "isConstant": false,
                                             "isLValue": false,
                                             "isPure": false,
                                             "lValueRequested": false,
                                             "memberName": "mul",
                                             "nodeType": "MemberAccess",
-                                            "referencedDeclaration": 2410,
+                                            "referencedDeclaration": 2421,
                                             "src": "4570:9:2",
                                             "typeDescriptions": {
                                               "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                               "typeString": "function (uint256,uint256) pure returns (uint256)"
                                             }
                                           },
-                                          "id": 1052,
+                                          "id": 1063,
                                           "isConstant": false,
                                           "isLValue": false,
                                           "isPure": false,
@@ -6707,21 +6707,21 @@
                                             "typeString": "uint256"
                                           }
                                         },
-                                        "id": 1053,
+                                        "id": 1064,
                                         "isConstant": false,
                                         "isLValue": false,
                                         "isPure": false,
                                         "lValueRequested": false,
                                         "memberName": "add",
                                         "nodeType": "MemberAccess",
-                                        "referencedDeclaration": 2360,
+                                        "referencedDeclaration": 2371,
                                         "src": "4570:37:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                           "typeString": "function (uint256,uint256) pure returns (uint256)"
                                         }
                                       },
-                                      "id": 1055,
+                                      "id": 1066,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": false,
@@ -6740,15 +6740,15 @@
                                   },
                                   {
                                     "assignments": [
-                                      1058
+                                      1069
                                     ],
                                     "declarations": [
                                       {
                                         "constant": false,
-                                        "id": 1058,
+                                        "id": 1069,
                                         "name": "liquidity",
                                         "nodeType": "VariableDeclaration",
-                                        "scope": 1072,
+                                        "scope": 1083,
                                         "src": "4640:14:2",
                                         "stateVariable": false,
                                         "storageLocation": "default",
@@ -6757,7 +6757,7 @@
                                           "typeString": "uint256"
                                         },
                                         "typeName": {
-                                          "id": 1057,
+                                          "id": 1068,
                                           "name": "uint",
                                           "nodeType": "ElementaryTypeName",
                                           "src": "4640:4:2",
@@ -6770,25 +6770,25 @@
                                         "visibility": "internal"
                                       }
                                     ],
-                                    "id": 1062,
+                                    "id": 1073,
                                     "initialValue": {
                                       "argumentTypes": null,
                                       "commonType": {
                                         "typeIdentifier": "t_uint256",
                                         "typeString": "uint256"
                                       },
-                                      "id": 1061,
+                                      "id": 1072,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": false,
                                       "lValueRequested": false,
                                       "leftExpression": {
                                         "argumentTypes": null,
-                                        "id": 1059,
+                                        "id": 1070,
                                         "name": "numerator",
                                         "nodeType": "Identifier",
                                         "overloadedDeclarations": [],
-                                        "referencedDeclaration": 1038,
+                                        "referencedDeclaration": 1049,
                                         "src": "4657:9:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_uint256",
@@ -6799,11 +6799,11 @@
                                       "operator": "/",
                                       "rightExpression": {
                                         "argumentTypes": null,
-                                        "id": 1060,
+                                        "id": 1071,
                                         "name": "denominator",
                                         "nodeType": "Identifier",
                                         "overloadedDeclarations": [],
-                                        "referencedDeclaration": 1048,
+                                        "referencedDeclaration": 1059,
                                         "src": "4669:11:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_uint256",
@@ -6826,18 +6826,18 @@
                                         "typeIdentifier": "t_uint256",
                                         "typeString": "uint256"
                                       },
-                                      "id": 1065,
+                                      "id": 1076,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": false,
                                       "lValueRequested": false,
                                       "leftExpression": {
                                         "argumentTypes": null,
-                                        "id": 1063,
+                                        "id": 1074,
                                         "name": "liquidity",
                                         "nodeType": "Identifier",
                                         "overloadedDeclarations": [],
-                                        "referencedDeclaration": 1058,
+                                        "referencedDeclaration": 1069,
                                         "src": "4706:9:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_uint256",
@@ -6849,7 +6849,7 @@
                                       "rightExpression": {
                                         "argumentTypes": null,
                                         "hexValue": "30",
-                                        "id": 1064,
+                                        "id": 1075,
                                         "isConstant": false,
                                         "isLValue": false,
                                         "isPure": true,
@@ -6871,7 +6871,7 @@
                                       }
                                     },
                                     "falseBody": null,
-                                    "id": 1071,
+                                    "id": 1082,
                                     "nodeType": "IfStatement",
                                     "src": "4702:42:2",
                                     "trueBody": {
@@ -6880,11 +6880,11 @@
                                         "arguments": [
                                           {
                                             "argumentTypes": null,
-                                            "id": 1067,
+                                            "id": 1078,
                                             "name": "feeTo",
                                             "nodeType": "Identifier",
                                             "overloadedDeclarations": [],
-                                            "referencedDeclaration": 984,
+                                            "referencedDeclaration": 995,
                                             "src": "4727:5:2",
                                             "typeDescriptions": {
                                               "typeIdentifier": "t_address",
@@ -6893,11 +6893,11 @@
                                           },
                                           {
                                             "argumentTypes": null,
-                                            "id": 1068,
+                                            "id": 1079,
                                             "name": "liquidity",
                                             "nodeType": "Identifier",
                                             "overloadedDeclarations": [],
-                                            "referencedDeclaration": 1058,
+                                            "referencedDeclaration": 1069,
                                             "src": "4734:9:2",
                                             "typeDescriptions": {
                                               "typeIdentifier": "t_uint256",
@@ -6916,7 +6916,7 @@
                                               "typeString": "uint256"
                                             }
                                           ],
-                                          "id": 1066,
+                                          "id": 1077,
                                           "name": "_mint",
                                           "nodeType": "Identifier",
                                           "overloadedDeclarations": [],
@@ -6927,7 +6927,7 @@
                                             "typeString": "function (address,uint256)"
                                           }
                                         },
-                                        "id": 1069,
+                                        "id": 1080,
                                         "isConstant": false,
                                         "isLValue": false,
                                         "isPure": false,
@@ -6941,7 +6941,7 @@
                                           "typeString": "tuple()"
                                         }
                                       },
-                                      "id": 1070,
+                                      "id": 1081,
                                       "nodeType": "ExpressionStatement",
                                       "src": "4721:23:2"
                                     }
@@ -6958,22 +6958,22 @@
               ]
             },
             "documentation": null,
-            "id": 1088,
+            "id": 1099,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "_mintFee",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 979,
+              "id": 990,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 976,
+                  "id": 987,
                   "name": "_reserve0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1088,
+                  "scope": 1099,
                   "src": "3942:17:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -6982,7 +6982,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 975,
+                    "id": 986,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "3942:7:2",
@@ -6996,10 +6996,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 978,
+                  "id": 989,
                   "name": "_reserve1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1088,
+                  "scope": 1099,
                   "src": "3961:17:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -7008,7 +7008,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 977,
+                    "id": 988,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "3961:7:2",
@@ -7024,15 +7024,15 @@
               "src": "3941:38:2"
             },
             "returnParameters": {
-              "id": 982,
+              "id": 993,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 981,
+                  "id": 992,
                   "name": "feeOn",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1088,
+                  "scope": 1099,
                   "src": "3997:10:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -7041,7 +7041,7 @@
                     "typeString": "bool"
                   },
                   "typeName": {
-                    "id": 980,
+                    "id": 991,
                     "name": "bool",
                     "nodeType": "ElementaryTypeName",
                     "src": "3997:4:2",
@@ -7056,7 +7056,7 @@
               ],
               "src": "3996:12:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "3924:926:2",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -7064,23 +7064,23 @@
           },
           {
             "body": {
-              "id": 1232,
+              "id": 1243,
               "nodeType": "Block",
               "src": "5024:1155:2",
               "statements": [
                 {
                   "assignments": [
-                    1098,
-                    1100,
+                    1109,
+                    1111,
                     null
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1098,
+                      "id": 1109,
                       "name": "_reserve0",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1232,
+                      "scope": 1243,
                       "src": "5035:17:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -7089,7 +7089,7 @@
                         "typeString": "uint112"
                       },
                       "typeName": {
-                        "id": 1097,
+                        "id": 1108,
                         "name": "uint112",
                         "nodeType": "ElementaryTypeName",
                         "src": "5035:7:2",
@@ -7103,10 +7103,10 @@
                     },
                     {
                       "constant": false,
-                      "id": 1100,
+                      "id": 1111,
                       "name": "_reserve1",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1232,
+                      "scope": 1243,
                       "src": "5054:17:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -7115,7 +7115,7 @@
                         "typeString": "uint112"
                       },
                       "typeName": {
-                        "id": 1099,
+                        "id": 1110,
                         "name": "uint112",
                         "nodeType": "ElementaryTypeName",
                         "src": "5054:7:2",
@@ -7129,24 +7129,24 @@
                     },
                     null
                   ],
-                  "id": 1103,
+                  "id": 1114,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [],
                     "expression": {
                       "argumentTypes": [],
-                      "id": 1101,
+                      "id": 1112,
                       "name": "getReserves",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 728,
+                      "referencedDeclaration": 739,
                       "src": "5076:11:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_view$__$returns$_t_uint112_$_t_uint112_$_t_uint32_$",
                         "typeString": "function () view returns (uint112,uint112,uint32)"
                       }
                     },
-                    "id": 1102,
+                    "id": 1113,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -7165,15 +7165,15 @@
                 },
                 {
                   "assignments": [
-                    1105
+                    1116
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1105,
+                      "id": 1116,
                       "name": "balance0",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1232,
+                      "scope": 1243,
                       "src": "5114:13:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -7182,7 +7182,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1104,
+                        "id": 1115,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "5114:4:2",
@@ -7195,7 +7195,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1114,
+                  "id": 1125,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -7204,14 +7204,14 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1111,
+                            "id": 1122,
                             "name": "this",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2518,
+                            "referencedDeclaration": 2529,
                             "src": "5163:4:2",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                              "typeIdentifier": "t_contract$_DXswapPair_$1723",
                               "typeString": "contract DXswapPair"
                             }
                           }
@@ -7219,11 +7219,11 @@
                         "expression": {
                           "argumentTypes": [
                             {
-                              "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                              "typeIdentifier": "t_contract$_DXswapPair_$1723",
                               "typeString": "contract DXswapPair"
                             }
                           ],
-                          "id": 1110,
+                          "id": 1121,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -7236,7 +7236,7 @@
                           },
                           "typeName": "address"
                         },
-                        "id": 1112,
+                        "id": 1123,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -7263,11 +7263,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1107,
+                            "id": 1118,
                             "name": "token0",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 667,
+                            "referencedDeclaration": 678,
                             "src": "5137:6:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
@@ -7282,18 +7282,18 @@
                               "typeString": "address"
                             }
                           ],
-                          "id": 1106,
+                          "id": 1117,
                           "name": "IERC20",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2260,
+                          "referencedDeclaration": 2271,
                           "src": "5130:6:2",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                            "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                             "typeString": "type(contract IERC20)"
                           }
                         },
-                        "id": 1108,
+                        "id": 1119,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -7303,25 +7303,25 @@
                         "nodeType": "FunctionCall",
                         "src": "5130:14:2",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_contract$_IERC20_$2260",
+                          "typeIdentifier": "t_contract$_IERC20_$2271",
                           "typeString": "contract IERC20"
                         }
                       },
-                      "id": 1109,
+                      "id": 1120,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "memberName": "balanceOf",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 2221,
+                      "referencedDeclaration": 2232,
                       "src": "5130:24:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                         "typeString": "function (address) view external returns (uint256)"
                       }
                     },
-                    "id": 1113,
+                    "id": 1124,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -7340,15 +7340,15 @@
                 },
                 {
                   "assignments": [
-                    1116
+                    1127
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1116,
+                      "id": 1127,
                       "name": "balance1",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1232,
+                      "scope": 1243,
                       "src": "5179:13:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -7357,7 +7357,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1115,
+                        "id": 1126,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "5179:4:2",
@@ -7370,7 +7370,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1125,
+                  "id": 1136,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -7379,14 +7379,14 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1122,
+                            "id": 1133,
                             "name": "this",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2518,
+                            "referencedDeclaration": 2529,
                             "src": "5228:4:2",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                              "typeIdentifier": "t_contract$_DXswapPair_$1723",
                               "typeString": "contract DXswapPair"
                             }
                           }
@@ -7394,11 +7394,11 @@
                         "expression": {
                           "argumentTypes": [
                             {
-                              "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                              "typeIdentifier": "t_contract$_DXswapPair_$1723",
                               "typeString": "contract DXswapPair"
                             }
                           ],
-                          "id": 1121,
+                          "id": 1132,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -7411,7 +7411,7 @@
                           },
                           "typeName": "address"
                         },
-                        "id": 1123,
+                        "id": 1134,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -7438,11 +7438,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1118,
+                            "id": 1129,
                             "name": "token1",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 669,
+                            "referencedDeclaration": 680,
                             "src": "5202:6:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
@@ -7457,18 +7457,18 @@
                               "typeString": "address"
                             }
                           ],
-                          "id": 1117,
+                          "id": 1128,
                           "name": "IERC20",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2260,
+                          "referencedDeclaration": 2271,
                           "src": "5195:6:2",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                            "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                             "typeString": "type(contract IERC20)"
                           }
                         },
-                        "id": 1119,
+                        "id": 1130,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -7478,25 +7478,25 @@
                         "nodeType": "FunctionCall",
                         "src": "5195:14:2",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_contract$_IERC20_$2260",
+                          "typeIdentifier": "t_contract$_IERC20_$2271",
                           "typeString": "contract IERC20"
                         }
                       },
-                      "id": 1120,
+                      "id": 1131,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "memberName": "balanceOf",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 2221,
+                      "referencedDeclaration": 2232,
                       "src": "5195:24:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                         "typeString": "function (address) view external returns (uint256)"
                       }
                     },
-                    "id": 1124,
+                    "id": 1135,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -7515,15 +7515,15 @@
                 },
                 {
                   "assignments": [
-                    1127
+                    1138
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1127,
+                      "id": 1138,
                       "name": "amount0",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1232,
+                      "scope": 1243,
                       "src": "5244:12:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -7532,7 +7532,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1126,
+                        "id": 1137,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "5244:4:2",
@@ -7545,17 +7545,17 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1132,
+                  "id": 1143,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1130,
+                        "id": 1141,
                         "name": "_reserve0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1098,
+                        "referencedDeclaration": 1109,
                         "src": "5272:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -7572,32 +7572,32 @@
                       ],
                       "expression": {
                         "argumentTypes": null,
-                        "id": 1128,
+                        "id": 1139,
                         "name": "balance0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1105,
+                        "referencedDeclaration": 1116,
                         "src": "5259:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         }
                       },
-                      "id": 1129,
+                      "id": 1140,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "memberName": "sub",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 2382,
+                      "referencedDeclaration": 2393,
                       "src": "5259:12:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                         "typeString": "function (uint256,uint256) pure returns (uint256)"
                       }
                     },
-                    "id": 1131,
+                    "id": 1142,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -7616,15 +7616,15 @@
                 },
                 {
                   "assignments": [
-                    1134
+                    1145
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1134,
+                      "id": 1145,
                       "name": "amount1",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1232,
+                      "scope": 1243,
                       "src": "5292:12:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -7633,7 +7633,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1133,
+                        "id": 1144,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "5292:4:2",
@@ -7646,17 +7646,17 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1139,
+                  "id": 1150,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1137,
+                        "id": 1148,
                         "name": "_reserve1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1100,
+                        "referencedDeclaration": 1111,
                         "src": "5320:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -7673,32 +7673,32 @@
                       ],
                       "expression": {
                         "argumentTypes": null,
-                        "id": 1135,
+                        "id": 1146,
                         "name": "balance1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1116,
+                        "referencedDeclaration": 1127,
                         "src": "5307:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         }
                       },
-                      "id": 1136,
+                      "id": 1147,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "memberName": "sub",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 2382,
+                      "referencedDeclaration": 2393,
                       "src": "5307:12:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                         "typeString": "function (uint256,uint256) pure returns (uint256)"
                       }
                     },
-                    "id": 1138,
+                    "id": 1149,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -7717,15 +7717,15 @@
                 },
                 {
                   "assignments": [
-                    1141
+                    1152
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1141,
+                      "id": 1152,
                       "name": "feeOn",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1232,
+                      "scope": 1243,
                       "src": "5341:10:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -7734,7 +7734,7 @@
                         "typeString": "bool"
                       },
                       "typeName": {
-                        "id": 1140,
+                        "id": 1151,
                         "name": "bool",
                         "nodeType": "ElementaryTypeName",
                         "src": "5341:4:2",
@@ -7747,17 +7747,17 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1146,
+                  "id": 1157,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1143,
+                        "id": 1154,
                         "name": "_reserve0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1098,
+                        "referencedDeclaration": 1109,
                         "src": "5363:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -7766,11 +7766,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1144,
+                        "id": 1155,
                         "name": "_reserve1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1100,
+                        "referencedDeclaration": 1111,
                         "src": "5374:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -7789,18 +7789,18 @@
                           "typeString": "uint112"
                         }
                       ],
-                      "id": 1142,
+                      "id": 1153,
                       "name": "_mintFee",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1088,
+                      "referencedDeclaration": 1099,
                       "src": "5354:8:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_uint112_$_t_uint112_$returns$_t_bool_$",
                         "typeString": "function (uint112,uint112) returns (bool)"
                       }
                     },
-                    "id": 1145,
+                    "id": 1156,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -7819,15 +7819,15 @@
                 },
                 {
                   "assignments": [
-                    1148
+                    1159
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1148,
+                      "id": 1159,
                       "name": "_totalSupply",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1232,
+                      "scope": 1243,
                       "src": "5394:17:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -7836,7 +7836,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1147,
+                        "id": 1158,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "5394:4:2",
@@ -7849,10 +7849,10 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1150,
+                  "id": 1161,
                   "initialValue": {
                     "argumentTypes": null,
-                    "id": 1149,
+                    "id": 1160,
                     "name": "totalSupply",
                     "nodeType": "Identifier",
                     "overloadedDeclarations": [],
@@ -7873,18 +7873,18 @@
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
                     },
-                    "id": 1153,
+                    "id": 1164,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftExpression": {
                       "argumentTypes": null,
-                      "id": 1151,
+                      "id": 1162,
                       "name": "_totalSupply",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1148,
+                      "referencedDeclaration": 1159,
                       "src": "5517:12:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
@@ -7896,7 +7896,7 @@
                     "rightExpression": {
                       "argumentTypes": null,
                       "hexValue": "30",
-                      "id": 1152,
+                      "id": 1163,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
@@ -7918,25 +7918,25 @@
                     }
                   },
                   "falseBody": {
-                    "id": 1193,
+                    "id": 1204,
                     "nodeType": "Block",
                     "src": "5737:123:2",
                     "statements": [
                       {
                         "expression": {
                           "argumentTypes": null,
-                          "id": 1191,
+                          "id": 1202,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftHandSide": {
                             "argumentTypes": null,
-                            "id": 1175,
+                            "id": 1186,
                             "name": "liquidity",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1095,
+                            "referencedDeclaration": 1106,
                             "src": "5751:9:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -7954,7 +7954,7 @@
                                   "typeIdentifier": "t_uint256",
                                   "typeString": "uint256"
                                 },
-                                "id": 1183,
+                                "id": 1194,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
@@ -7964,11 +7964,11 @@
                                   "arguments": [
                                     {
                                       "argumentTypes": null,
-                                      "id": 1180,
+                                      "id": 1191,
                                       "name": "_totalSupply",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 1148,
+                                      "referencedDeclaration": 1159,
                                       "src": "5784:12:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint256",
@@ -7985,32 +7985,32 @@
                                     ],
                                     "expression": {
                                       "argumentTypes": null,
-                                      "id": 1178,
+                                      "id": 1189,
                                       "name": "amount0",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 1127,
+                                      "referencedDeclaration": 1138,
                                       "src": "5772:7:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint256",
                                         "typeString": "uint256"
                                       }
                                     },
-                                    "id": 1179,
+                                    "id": 1190,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
                                     "lValueRequested": false,
                                     "memberName": "mul",
                                     "nodeType": "MemberAccess",
-                                    "referencedDeclaration": 2410,
+                                    "referencedDeclaration": 2421,
                                     "src": "5772:11:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                       "typeString": "function (uint256,uint256) pure returns (uint256)"
                                     }
                                   },
-                                  "id": 1181,
+                                  "id": 1192,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
@@ -8028,11 +8028,11 @@
                                 "operator": "/",
                                 "rightExpression": {
                                   "argumentTypes": null,
-                                  "id": 1182,
+                                  "id": 1193,
                                   "name": "_reserve0",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 1098,
+                                  "referencedDeclaration": 1109,
                                   "src": "5800:9:2",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_uint112",
@@ -8051,7 +8051,7 @@
                                   "typeIdentifier": "t_uint256",
                                   "typeString": "uint256"
                                 },
-                                "id": 1189,
+                                "id": 1200,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
@@ -8061,11 +8061,11 @@
                                   "arguments": [
                                     {
                                       "argumentTypes": null,
-                                      "id": 1186,
+                                      "id": 1197,
                                       "name": "_totalSupply",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 1148,
+                                      "referencedDeclaration": 1159,
                                       "src": "5823:12:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint256",
@@ -8082,32 +8082,32 @@
                                     ],
                                     "expression": {
                                       "argumentTypes": null,
-                                      "id": 1184,
+                                      "id": 1195,
                                       "name": "amount1",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 1134,
+                                      "referencedDeclaration": 1145,
                                       "src": "5811:7:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint256",
                                         "typeString": "uint256"
                                       }
                                     },
-                                    "id": 1185,
+                                    "id": 1196,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
                                     "lValueRequested": false,
                                     "memberName": "mul",
                                     "nodeType": "MemberAccess",
-                                    "referencedDeclaration": 2410,
+                                    "referencedDeclaration": 2421,
                                     "src": "5811:11:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                       "typeString": "function (uint256,uint256) pure returns (uint256)"
                                     }
                                   },
-                                  "id": 1187,
+                                  "id": 1198,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
@@ -8125,11 +8125,11 @@
                                 "operator": "/",
                                 "rightExpression": {
                                   "argumentTypes": null,
-                                  "id": 1188,
+                                  "id": 1199,
                                   "name": "_reserve1",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 1100,
+                                  "referencedDeclaration": 1111,
                                   "src": "5839:9:2",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_uint112",
@@ -8156,32 +8156,32 @@
                               ],
                               "expression": {
                                 "argumentTypes": null,
-                                "id": 1176,
+                                "id": 1187,
                                 "name": "Math",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2336,
+                                "referencedDeclaration": 2347,
                                 "src": "5763:4:2",
                                 "typeDescriptions": {
-                                  "typeIdentifier": "t_type$_t_contract$_Math_$2336_$",
+                                  "typeIdentifier": "t_type$_t_contract$_Math_$2347_$",
                                   "typeString": "type(library Math)"
                                 }
                               },
-                              "id": 1177,
+                              "id": 1188,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
                               "lValueRequested": false,
                               "memberName": "min",
                               "nodeType": "MemberAccess",
-                              "referencedDeclaration": 2281,
+                              "referencedDeclaration": 2292,
                               "src": "5763:8:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$",
                                 "typeString": "function (uint256,uint256) pure returns (uint256)"
                               }
                             },
-                            "id": 1190,
+                            "id": 1201,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -8201,35 +8201,35 @@
                             "typeString": "uint256"
                           }
                         },
-                        "id": 1192,
+                        "id": 1203,
                         "nodeType": "ExpressionStatement",
                         "src": "5751:98:2"
                       }
                     ]
                   },
-                  "id": 1194,
+                  "id": 1205,
                   "nodeType": "IfStatement",
                   "src": "5513:347:2",
                   "trueBody": {
-                    "id": 1174,
+                    "id": 1185,
                     "nodeType": "Block",
                     "src": "5536:195:2",
                     "statements": [
                       {
                         "expression": {
                           "argumentTypes": null,
-                          "id": 1165,
+                          "id": 1176,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftHandSide": {
                             "argumentTypes": null,
-                            "id": 1154,
+                            "id": 1165,
                             "name": "liquidity",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1095,
+                            "referencedDeclaration": 1106,
                             "src": "5550:9:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -8243,11 +8243,11 @@
                             "arguments": [
                               {
                                 "argumentTypes": null,
-                                "id": 1163,
+                                "id": 1174,
                                 "name": "MINIMUM_LIQUIDITY",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 654,
+                                "referencedDeclaration": 665,
                                 "src": "5598:17:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_uint256",
@@ -8270,11 +8270,11 @@
                                     "arguments": [
                                       {
                                         "argumentTypes": null,
-                                        "id": 1159,
+                                        "id": 1170,
                                         "name": "amount1",
                                         "nodeType": "Identifier",
                                         "overloadedDeclarations": [],
-                                        "referencedDeclaration": 1134,
+                                        "referencedDeclaration": 1145,
                                         "src": "5584:7:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_uint256",
@@ -8291,32 +8291,32 @@
                                       ],
                                       "expression": {
                                         "argumentTypes": null,
-                                        "id": 1157,
+                                        "id": 1168,
                                         "name": "amount0",
                                         "nodeType": "Identifier",
                                         "overloadedDeclarations": [],
-                                        "referencedDeclaration": 1127,
+                                        "referencedDeclaration": 1138,
                                         "src": "5572:7:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_uint256",
                                           "typeString": "uint256"
                                         }
                                       },
-                                      "id": 1158,
+                                      "id": 1169,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": false,
                                       "lValueRequested": false,
                                       "memberName": "mul",
                                       "nodeType": "MemberAccess",
-                                      "referencedDeclaration": 2410,
+                                      "referencedDeclaration": 2421,
                                       "src": "5572:11:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                         "typeString": "function (uint256,uint256) pure returns (uint256)"
                                       }
                                     },
-                                    "id": 1160,
+                                    "id": 1171,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
@@ -8340,32 +8340,32 @@
                                   ],
                                   "expression": {
                                     "argumentTypes": null,
-                                    "id": 1155,
+                                    "id": 1166,
                                     "name": "Math",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 2336,
+                                    "referencedDeclaration": 2347,
                                     "src": "5562:4:2",
                                     "typeDescriptions": {
-                                      "typeIdentifier": "t_type$_t_contract$_Math_$2336_$",
+                                      "typeIdentifier": "t_type$_t_contract$_Math_$2347_$",
                                       "typeString": "type(library Math)"
                                     }
                                   },
-                                  "id": 1156,
+                                  "id": 1167,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
                                   "lValueRequested": false,
                                   "memberName": "sqrt",
                                   "nodeType": "MemberAccess",
-                                  "referencedDeclaration": 2335,
+                                  "referencedDeclaration": 2346,
                                   "src": "5562:9:2",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_function_internal_pure$_t_uint256_$returns$_t_uint256_$",
                                     "typeString": "function (uint256) pure returns (uint256)"
                                   }
                                 },
-                                "id": 1161,
+                                "id": 1172,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
@@ -8379,21 +8379,21 @@
                                   "typeString": "uint256"
                                 }
                               },
-                              "id": 1162,
+                              "id": 1173,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
                               "lValueRequested": false,
                               "memberName": "sub",
                               "nodeType": "MemberAccess",
-                              "referencedDeclaration": 2382,
+                              "referencedDeclaration": 2393,
                               "src": "5562:35:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                 "typeString": "function (uint256,uint256) pure returns (uint256)"
                               }
                             },
-                            "id": 1164,
+                            "id": 1175,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -8413,7 +8413,7 @@
                             "typeString": "uint256"
                           }
                         },
-                        "id": 1166,
+                        "id": 1177,
                         "nodeType": "ExpressionStatement",
                         "src": "5550:66:2"
                       },
@@ -8427,7 +8427,7 @@
                                 {
                                   "argumentTypes": null,
                                   "hexValue": "30",
-                                  "id": 1169,
+                                  "id": 1180,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": true,
@@ -8450,7 +8450,7 @@
                                     "typeString": "int_const 0"
                                   }
                                 ],
-                                "id": 1168,
+                                "id": 1179,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": true,
@@ -8463,7 +8463,7 @@
                                 },
                                 "typeName": "address"
                               },
-                              "id": 1170,
+                              "id": 1181,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
@@ -8479,11 +8479,11 @@
                             },
                             {
                               "argumentTypes": null,
-                              "id": 1171,
+                              "id": 1182,
                               "name": "MINIMUM_LIQUIDITY",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 654,
+                              "referencedDeclaration": 665,
                               "src": "5647:17:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint256",
@@ -8502,7 +8502,7 @@
                                 "typeString": "uint256"
                               }
                             ],
-                            "id": 1167,
+                            "id": 1178,
                             "name": "_mint",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
@@ -8513,7 +8513,7 @@
                               "typeString": "function (address,uint256)"
                             }
                           },
-                          "id": 1172,
+                          "id": 1183,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -8527,7 +8527,7 @@
                             "typeString": "tuple()"
                           }
                         },
-                        "id": 1173,
+                        "id": 1184,
                         "nodeType": "ExpressionStatement",
                         "src": "5629:36:2"
                       }
@@ -8544,18 +8544,18 @@
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         },
-                        "id": 1198,
+                        "id": 1209,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 1196,
+                          "id": 1207,
                           "name": "liquidity",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1095,
+                          "referencedDeclaration": 1106,
                           "src": "5877:9:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -8567,7 +8567,7 @@
                         "rightExpression": {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 1197,
+                          "id": 1208,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -8591,7 +8591,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170506169723a20494e53554646494349454e545f4c49515549444954595f4d494e544544",
-                        "id": 1199,
+                        "id": 1210,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -8618,21 +8618,21 @@
                           "typeString": "literal_string \"DXswapPair: INSUFFICIENT_LIQUIDITY_MINTED\""
                         }
                       ],
-                      "id": 1195,
+                      "id": 1206,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "5869:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 1200,
+                    "id": 1211,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -8646,7 +8646,7 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1201,
+                  "id": 1212,
                   "nodeType": "ExpressionStatement",
                   "src": "5869:67:2"
                 },
@@ -8656,11 +8656,11 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1203,
+                        "id": 1214,
                         "name": "to",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1090,
+                        "referencedDeclaration": 1101,
                         "src": "5952:2:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -8669,11 +8669,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1204,
+                        "id": 1215,
                         "name": "liquidity",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1095,
+                        "referencedDeclaration": 1106,
                         "src": "5956:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -8692,7 +8692,7 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 1202,
+                      "id": 1213,
                       "name": "_mint",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
@@ -8703,7 +8703,7 @@
                         "typeString": "function (address,uint256)"
                       }
                     },
-                    "id": 1205,
+                    "id": 1216,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -8717,7 +8717,7 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1206,
+                  "id": 1217,
                   "nodeType": "ExpressionStatement",
                   "src": "5946:20:2"
                 },
@@ -8727,11 +8727,11 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1208,
+                        "id": 1219,
                         "name": "balance0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1105,
+                        "referencedDeclaration": 1116,
                         "src": "5985:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -8740,11 +8740,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1209,
+                        "id": 1220,
                         "name": "balance1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1116,
+                        "referencedDeclaration": 1127,
                         "src": "5995:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -8753,11 +8753,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1210,
+                        "id": 1221,
                         "name": "_reserve0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1098,
+                        "referencedDeclaration": 1109,
                         "src": "6005:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -8766,11 +8766,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1211,
+                        "id": 1222,
                         "name": "_reserve1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1100,
+                        "referencedDeclaration": 1111,
                         "src": "6016:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -8797,18 +8797,18 @@
                           "typeString": "uint112"
                         }
                       ],
-                      "id": 1207,
+                      "id": 1218,
                       "name": "_update",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 974,
+                      "referencedDeclaration": 985,
                       "src": "5977:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$_t_uint256_$_t_uint112_$_t_uint112_$returns$__$",
                         "typeString": "function (uint256,uint256,uint112,uint112)"
                       }
                     },
-                    "id": 1212,
+                    "id": 1223,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -8822,18 +8822,18 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1213,
+                  "id": 1224,
                   "nodeType": "ExpressionStatement",
                   "src": "5977:49:2"
                 },
                 {
                   "condition": {
                     "argumentTypes": null,
-                    "id": 1214,
+                    "id": 1225,
                     "name": "feeOn",
                     "nodeType": "Identifier",
                     "overloadedDeclarations": [],
-                    "referencedDeclaration": 1141,
+                    "referencedDeclaration": 1152,
                     "src": "6040:5:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
@@ -8841,24 +8841,24 @@
                     }
                   },
                   "falseBody": null,
-                  "id": 1224,
+                  "id": 1235,
                   "nodeType": "IfStatement",
                   "src": "6036:47:2",
                   "trueBody": {
                     "expression": {
                       "argumentTypes": null,
-                      "id": 1222,
+                      "id": 1233,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftHandSide": {
                         "argumentTypes": null,
-                        "id": 1215,
+                        "id": 1226,
                         "name": "kLast",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 681,
+                        "referencedDeclaration": 692,
                         "src": "6047:5:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -8872,11 +8872,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1220,
+                            "id": 1231,
                             "name": "reserve1",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 673,
+                            "referencedDeclaration": 684,
                             "src": "6074:8:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint112",
@@ -8896,11 +8896,11 @@
                             "arguments": [
                               {
                                 "argumentTypes": null,
-                                "id": 1217,
+                                "id": 1228,
                                 "name": "reserve0",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 671,
+                                "referencedDeclaration": 682,
                                 "src": "6060:8:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_uint112",
@@ -8915,7 +8915,7 @@
                                   "typeString": "uint112"
                                 }
                               ],
-                              "id": 1216,
+                              "id": 1227,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
@@ -8928,7 +8928,7 @@
                               },
                               "typeName": "uint"
                             },
-                            "id": 1218,
+                            "id": 1229,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -8942,21 +8942,21 @@
                               "typeString": "uint256"
                             }
                           },
-                          "id": 1219,
+                          "id": 1230,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "memberName": "mul",
                           "nodeType": "MemberAccess",
-                          "referencedDeclaration": 2410,
+                          "referencedDeclaration": 2421,
                           "src": "6055:18:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                             "typeString": "function (uint256,uint256) pure returns (uint256)"
                           }
                         },
-                        "id": 1221,
+                        "id": 1232,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -8976,7 +8976,7 @@
                         "typeString": "uint256"
                       }
                     },
-                    "id": 1223,
+                    "id": 1234,
                     "nodeType": "ExpressionStatement",
                     "src": "6047:36:2"
                   }
@@ -8989,18 +8989,18 @@
                         "argumentTypes": null,
                         "expression": {
                           "argumentTypes": null,
-                          "id": 1226,
+                          "id": 1237,
                           "name": "msg",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2486,
+                          "referencedDeclaration": 2497,
                           "src": "6143:3:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_magic_message",
                             "typeString": "msg"
                           }
                         },
-                        "id": 1227,
+                        "id": 1238,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -9016,11 +9016,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1228,
+                        "id": 1239,
                         "name": "amount0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1127,
+                        "referencedDeclaration": 1138,
                         "src": "6155:7:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -9029,11 +9029,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1229,
+                        "id": 1240,
                         "name": "amount1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1134,
+                        "referencedDeclaration": 1145,
                         "src": "6164:7:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -9056,20 +9056,20 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 1225,
+                      "id": 1236,
                       "name": "Mint",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        778
+                        789
                       ],
-                      "referencedDeclaration": 778,
+                      "referencedDeclaration": 789,
                       "src": "6138:4:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_uint256_$returns$__$",
                         "typeString": "function (address,uint256,uint256)"
                       }
                     },
-                    "id": 1230,
+                    "id": 1241,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -9083,27 +9083,27 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1231,
+                  "id": 1242,
                   "nodeType": "EmitStatement",
                   "src": "6133:39:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 1233,
+            "id": 1244,
             "implemented": true,
             "kind": "function",
             "modifiers": [
               {
                 "arguments": null,
-                "id": 1093,
+                "id": 1104,
                 "modifierName": {
                   "argumentTypes": null,
-                  "id": 1092,
+                  "id": 1103,
                   "name": "lock",
                   "nodeType": "Identifier",
                   "overloadedDeclarations": [],
-                  "referencedDeclaration": 706,
+                  "referencedDeclaration": 717,
                   "src": "4994:4:2",
                   "typeDescriptions": {
                     "typeIdentifier": "t_modifier$__$",
@@ -9117,15 +9117,15 @@
             "name": "mint",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1091,
+              "id": 1102,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1090,
+                  "id": 1101,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1233,
+                  "scope": 1244,
                   "src": "4973:10:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -9134,7 +9134,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1089,
+                    "id": 1100,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "4973:7:2",
@@ -9151,15 +9151,15 @@
               "src": "4972:12:2"
             },
             "returnParameters": {
-              "id": 1096,
+              "id": 1107,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1095,
+                  "id": 1106,
                   "name": "liquidity",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1233,
+                  "scope": 1244,
                   "src": "5008:14:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -9168,7 +9168,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1094,
+                    "id": 1105,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "5008:4:2",
@@ -9183,31 +9183,31 @@
               ],
               "src": "5007:16:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "4959:1220:2",
             "stateMutability": "nonpayable",
-            "superFunction": 2135,
+            "superFunction": 2146,
             "visibility": "external"
           },
           {
             "body": {
-              "id": 1396,
+              "id": 1407,
               "nodeType": "Block",
               "src": "6365:1368:2",
               "statements": [
                 {
                   "assignments": [
-                    1245,
-                    1247,
+                    1256,
+                    1258,
                     null
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1245,
+                      "id": 1256,
                       "name": "_reserve0",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1396,
+                      "scope": 1407,
                       "src": "6376:17:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -9216,7 +9216,7 @@
                         "typeString": "uint112"
                       },
                       "typeName": {
-                        "id": 1244,
+                        "id": 1255,
                         "name": "uint112",
                         "nodeType": "ElementaryTypeName",
                         "src": "6376:7:2",
@@ -9230,10 +9230,10 @@
                     },
                     {
                       "constant": false,
-                      "id": 1247,
+                      "id": 1258,
                       "name": "_reserve1",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1396,
+                      "scope": 1407,
                       "src": "6395:17:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -9242,7 +9242,7 @@
                         "typeString": "uint112"
                       },
                       "typeName": {
-                        "id": 1246,
+                        "id": 1257,
                         "name": "uint112",
                         "nodeType": "ElementaryTypeName",
                         "src": "6395:7:2",
@@ -9256,24 +9256,24 @@
                     },
                     null
                   ],
-                  "id": 1250,
+                  "id": 1261,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [],
                     "expression": {
                       "argumentTypes": [],
-                      "id": 1248,
+                      "id": 1259,
                       "name": "getReserves",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 728,
+                      "referencedDeclaration": 739,
                       "src": "6417:11:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_view$__$returns$_t_uint112_$_t_uint112_$_t_uint32_$",
                         "typeString": "function () view returns (uint112,uint112,uint32)"
                       }
                     },
-                    "id": 1249,
+                    "id": 1260,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -9292,15 +9292,15 @@
                 },
                 {
                   "assignments": [
-                    1252
+                    1263
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1252,
+                      "id": 1263,
                       "name": "_token0",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1396,
+                      "scope": 1407,
                       "src": "6455:15:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -9309,7 +9309,7 @@
                         "typeString": "address"
                       },
                       "typeName": {
-                        "id": 1251,
+                        "id": 1262,
                         "name": "address",
                         "nodeType": "ElementaryTypeName",
                         "src": "6455:7:2",
@@ -9323,14 +9323,14 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1254,
+                  "id": 1265,
                   "initialValue": {
                     "argumentTypes": null,
-                    "id": 1253,
+                    "id": 1264,
                     "name": "token0",
                     "nodeType": "Identifier",
                     "overloadedDeclarations": [],
-                    "referencedDeclaration": 667,
+                    "referencedDeclaration": 678,
                     "src": "6473:6:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -9342,15 +9342,15 @@
                 },
                 {
                   "assignments": [
-                    1256
+                    1267
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1256,
+                      "id": 1267,
                       "name": "_token1",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1396,
+                      "scope": 1407,
                       "src": "6535:15:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -9359,7 +9359,7 @@
                         "typeString": "address"
                       },
                       "typeName": {
-                        "id": 1255,
+                        "id": 1266,
                         "name": "address",
                         "nodeType": "ElementaryTypeName",
                         "src": "6535:7:2",
@@ -9373,14 +9373,14 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1258,
+                  "id": 1269,
                   "initialValue": {
                     "argumentTypes": null,
-                    "id": 1257,
+                    "id": 1268,
                     "name": "token1",
                     "nodeType": "Identifier",
                     "overloadedDeclarations": [],
-                    "referencedDeclaration": 669,
+                    "referencedDeclaration": 680,
                     "src": "6553:6:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -9392,15 +9392,15 @@
                 },
                 {
                   "assignments": [
-                    1260
+                    1271
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1260,
+                      "id": 1271,
                       "name": "balance0",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1396,
+                      "scope": 1407,
                       "src": "6615:13:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -9409,7 +9409,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1259,
+                        "id": 1270,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "6615:4:2",
@@ -9422,7 +9422,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1269,
+                  "id": 1280,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -9431,14 +9431,14 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1266,
+                            "id": 1277,
                             "name": "this",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2518,
+                            "referencedDeclaration": 2529,
                             "src": "6665:4:2",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                              "typeIdentifier": "t_contract$_DXswapPair_$1723",
                               "typeString": "contract DXswapPair"
                             }
                           }
@@ -9446,11 +9446,11 @@
                         "expression": {
                           "argumentTypes": [
                             {
-                              "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                              "typeIdentifier": "t_contract$_DXswapPair_$1723",
                               "typeString": "contract DXswapPair"
                             }
                           ],
-                          "id": 1265,
+                          "id": 1276,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -9463,7 +9463,7 @@
                           },
                           "typeName": "address"
                         },
-                        "id": 1267,
+                        "id": 1278,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -9490,11 +9490,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1262,
+                            "id": 1273,
                             "name": "_token0",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1252,
+                            "referencedDeclaration": 1263,
                             "src": "6638:7:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
@@ -9509,18 +9509,18 @@
                               "typeString": "address"
                             }
                           ],
-                          "id": 1261,
+                          "id": 1272,
                           "name": "IERC20",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2260,
+                          "referencedDeclaration": 2271,
                           "src": "6631:6:2",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                            "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                             "typeString": "type(contract IERC20)"
                           }
                         },
-                        "id": 1263,
+                        "id": 1274,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -9530,25 +9530,25 @@
                         "nodeType": "FunctionCall",
                         "src": "6631:15:2",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_contract$_IERC20_$2260",
+                          "typeIdentifier": "t_contract$_IERC20_$2271",
                           "typeString": "contract IERC20"
                         }
                       },
-                      "id": 1264,
+                      "id": 1275,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "memberName": "balanceOf",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 2221,
+                      "referencedDeclaration": 2232,
                       "src": "6631:25:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                         "typeString": "function (address) view external returns (uint256)"
                       }
                     },
-                    "id": 1268,
+                    "id": 1279,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -9567,15 +9567,15 @@
                 },
                 {
                   "assignments": [
-                    1271
+                    1282
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1271,
+                      "id": 1282,
                       "name": "balance1",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1396,
+                      "scope": 1407,
                       "src": "6681:13:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -9584,7 +9584,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1270,
+                        "id": 1281,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "6681:4:2",
@@ -9597,7 +9597,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1280,
+                  "id": 1291,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
@@ -9606,14 +9606,14 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1277,
+                            "id": 1288,
                             "name": "this",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2518,
+                            "referencedDeclaration": 2529,
                             "src": "6731:4:2",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                              "typeIdentifier": "t_contract$_DXswapPair_$1723",
                               "typeString": "contract DXswapPair"
                             }
                           }
@@ -9621,11 +9621,11 @@
                         "expression": {
                           "argumentTypes": [
                             {
-                              "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                              "typeIdentifier": "t_contract$_DXswapPair_$1723",
                               "typeString": "contract DXswapPair"
                             }
                           ],
-                          "id": 1276,
+                          "id": 1287,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -9638,7 +9638,7 @@
                           },
                           "typeName": "address"
                         },
-                        "id": 1278,
+                        "id": 1289,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -9665,11 +9665,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1273,
+                            "id": 1284,
                             "name": "_token1",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1256,
+                            "referencedDeclaration": 1267,
                             "src": "6704:7:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_address",
@@ -9684,18 +9684,18 @@
                               "typeString": "address"
                             }
                           ],
-                          "id": 1272,
+                          "id": 1283,
                           "name": "IERC20",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2260,
+                          "referencedDeclaration": 2271,
                           "src": "6697:6:2",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                            "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                             "typeString": "type(contract IERC20)"
                           }
                         },
-                        "id": 1274,
+                        "id": 1285,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -9705,25 +9705,25 @@
                         "nodeType": "FunctionCall",
                         "src": "6697:15:2",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_contract$_IERC20_$2260",
+                          "typeIdentifier": "t_contract$_IERC20_$2271",
                           "typeString": "contract IERC20"
                         }
                       },
-                      "id": 1275,
+                      "id": 1286,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "memberName": "balanceOf",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 2221,
+                      "referencedDeclaration": 2232,
                       "src": "6697:25:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                         "typeString": "function (address) view external returns (uint256)"
                       }
                     },
-                    "id": 1279,
+                    "id": 1290,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -9742,15 +9742,15 @@
                 },
                 {
                   "assignments": [
-                    1282
+                    1293
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1282,
+                      "id": 1293,
                       "name": "liquidity",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1396,
+                      "scope": 1407,
                       "src": "6747:14:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -9759,7 +9759,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1281,
+                        "id": 1292,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "6747:4:2",
@@ -9772,12 +9772,12 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1288,
+                  "id": 1299,
                   "initialValue": {
                     "argumentTypes": null,
                     "baseExpression": {
                       "argumentTypes": null,
-                      "id": 1283,
+                      "id": 1294,
                       "name": "balanceOf",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
@@ -9788,20 +9788,20 @@
                         "typeString": "mapping(address => uint256)"
                       }
                     },
-                    "id": 1287,
+                    "id": 1298,
                     "indexExpression": {
                       "argumentTypes": null,
                       "arguments": [
                         {
                           "argumentTypes": null,
-                          "id": 1285,
+                          "id": 1296,
                           "name": "this",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2518,
+                          "referencedDeclaration": 2529,
                           "src": "6782:4:2",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                            "typeIdentifier": "t_contract$_DXswapPair_$1723",
                             "typeString": "contract DXswapPair"
                           }
                         }
@@ -9809,11 +9809,11 @@
                       "expression": {
                         "argumentTypes": [
                           {
-                            "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                            "typeIdentifier": "t_contract$_DXswapPair_$1723",
                             "typeString": "contract DXswapPair"
                           }
                         ],
-                        "id": 1284,
+                        "id": 1295,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -9826,7 +9826,7 @@
                         },
                         "typeName": "address"
                       },
-                      "id": 1286,
+                      "id": 1297,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -9856,15 +9856,15 @@
                 },
                 {
                   "assignments": [
-                    1290
+                    1301
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1290,
+                      "id": 1301,
                       "name": "feeOn",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1396,
+                      "scope": 1407,
                       "src": "6799:10:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -9873,7 +9873,7 @@
                         "typeString": "bool"
                       },
                       "typeName": {
-                        "id": 1289,
+                        "id": 1300,
                         "name": "bool",
                         "nodeType": "ElementaryTypeName",
                         "src": "6799:4:2",
@@ -9886,17 +9886,17 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1295,
+                  "id": 1306,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1292,
+                        "id": 1303,
                         "name": "_reserve0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1245,
+                        "referencedDeclaration": 1256,
                         "src": "6821:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -9905,11 +9905,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1293,
+                        "id": 1304,
                         "name": "_reserve1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1247,
+                        "referencedDeclaration": 1258,
                         "src": "6832:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -9928,18 +9928,18 @@
                           "typeString": "uint112"
                         }
                       ],
-                      "id": 1291,
+                      "id": 1302,
                       "name": "_mintFee",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1088,
+                      "referencedDeclaration": 1099,
                       "src": "6812:8:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_uint112_$_t_uint112_$returns$_t_bool_$",
                         "typeString": "function (uint112,uint112) returns (bool)"
                       }
                     },
-                    "id": 1294,
+                    "id": 1305,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -9958,15 +9958,15 @@
                 },
                 {
                   "assignments": [
-                    1297
+                    1308
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1297,
+                      "id": 1308,
                       "name": "_totalSupply",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1396,
+                      "scope": 1407,
                       "src": "6852:17:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -9975,7 +9975,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1296,
+                        "id": 1307,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "6852:4:2",
@@ -9988,10 +9988,10 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1299,
+                  "id": 1310,
                   "initialValue": {
                     "argumentTypes": null,
-                    "id": 1298,
+                    "id": 1309,
                     "name": "totalSupply",
                     "nodeType": "Identifier",
                     "overloadedDeclarations": [],
@@ -10008,18 +10008,18 @@
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 1307,
+                    "id": 1318,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 1300,
+                      "id": 1311,
                       "name": "amount0",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1240,
+                      "referencedDeclaration": 1251,
                       "src": "6971:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
@@ -10034,7 +10034,7 @@
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       },
-                      "id": 1306,
+                      "id": 1317,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -10044,11 +10044,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1303,
+                            "id": 1314,
                             "name": "balance0",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1260,
+                            "referencedDeclaration": 1271,
                             "src": "6995:8:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -10065,32 +10065,32 @@
                           ],
                           "expression": {
                             "argumentTypes": null,
-                            "id": 1301,
+                            "id": 1312,
                             "name": "liquidity",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1282,
+                            "referencedDeclaration": 1293,
                             "src": "6981:9:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
-                          "id": 1302,
+                          "id": 1313,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "memberName": "mul",
                           "nodeType": "MemberAccess",
-                          "referencedDeclaration": 2410,
+                          "referencedDeclaration": 2421,
                           "src": "6981:13:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                             "typeString": "function (uint256,uint256) pure returns (uint256)"
                           }
                         },
-                        "id": 1304,
+                        "id": 1315,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -10108,11 +10108,11 @@
                       "operator": "/",
                       "rightExpression": {
                         "argumentTypes": null,
-                        "id": 1305,
+                        "id": 1316,
                         "name": "_totalSupply",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1297,
+                        "referencedDeclaration": 1308,
                         "src": "7007:12:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -10131,25 +10131,25 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 1308,
+                  "id": 1319,
                   "nodeType": "ExpressionStatement",
                   "src": "6971:48:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 1316,
+                    "id": 1327,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 1309,
+                      "id": 1320,
                       "name": "amount1",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1242,
+                      "referencedDeclaration": 1253,
                       "src": "7077:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
@@ -10164,7 +10164,7 @@
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       },
-                      "id": 1315,
+                      "id": 1326,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -10174,11 +10174,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1312,
+                            "id": 1323,
                             "name": "balance1",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1271,
+                            "referencedDeclaration": 1282,
                             "src": "7101:8:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -10195,32 +10195,32 @@
                           ],
                           "expression": {
                             "argumentTypes": null,
-                            "id": 1310,
+                            "id": 1321,
                             "name": "liquidity",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1282,
+                            "referencedDeclaration": 1293,
                             "src": "7087:9:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             }
                           },
-                          "id": 1311,
+                          "id": 1322,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "memberName": "mul",
                           "nodeType": "MemberAccess",
-                          "referencedDeclaration": 2410,
+                          "referencedDeclaration": 2421,
                           "src": "7087:13:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                             "typeString": "function (uint256,uint256) pure returns (uint256)"
                           }
                         },
-                        "id": 1313,
+                        "id": 1324,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -10238,11 +10238,11 @@
                       "operator": "/",
                       "rightExpression": {
                         "argumentTypes": null,
-                        "id": 1314,
+                        "id": 1325,
                         "name": "_totalSupply",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1297,
+                        "referencedDeclaration": 1308,
                         "src": "7113:12:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -10261,7 +10261,7 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 1317,
+                  "id": 1328,
                   "nodeType": "ExpressionStatement",
                   "src": "7077:48:2"
                 },
@@ -10275,7 +10275,7 @@
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
                         },
-                        "id": 1325,
+                        "id": 1336,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -10286,18 +10286,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 1321,
+                          "id": 1332,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 1319,
+                            "id": 1330,
                             "name": "amount0",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1240,
+                            "referencedDeclaration": 1251,
                             "src": "7191:7:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -10309,7 +10309,7 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "30",
-                            "id": 1320,
+                            "id": 1331,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -10338,18 +10338,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 1324,
+                          "id": 1335,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 1322,
+                            "id": 1333,
                             "name": "amount1",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1242,
+                            "referencedDeclaration": 1253,
                             "src": "7206:7:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -10361,7 +10361,7 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "30",
-                            "id": 1323,
+                            "id": 1334,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -10391,7 +10391,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170506169723a20494e53554646494349454e545f4c49515549444954595f4255524e4544",
-                        "id": 1326,
+                        "id": 1337,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -10418,21 +10418,21 @@
                           "typeString": "literal_string \"DXswapPair: INSUFFICIENT_LIQUIDITY_BURNED\""
                         }
                       ],
-                      "id": 1318,
+                      "id": 1329,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "7183:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 1327,
+                    "id": 1338,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -10446,7 +10446,7 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1328,
+                  "id": 1339,
                   "nodeType": "ExpressionStatement",
                   "src": "7183:80:2"
                 },
@@ -10459,14 +10459,14 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1331,
+                            "id": 1342,
                             "name": "this",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2518,
+                            "referencedDeclaration": 2529,
                             "src": "7287:4:2",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                              "typeIdentifier": "t_contract$_DXswapPair_$1723",
                               "typeString": "contract DXswapPair"
                             }
                           }
@@ -10474,11 +10474,11 @@
                         "expression": {
                           "argumentTypes": [
                             {
-                              "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                              "typeIdentifier": "t_contract$_DXswapPair_$1723",
                               "typeString": "contract DXswapPair"
                             }
                           ],
-                          "id": 1330,
+                          "id": 1341,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -10491,7 +10491,7 @@
                           },
                           "typeName": "address"
                         },
-                        "id": 1332,
+                        "id": 1343,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -10507,11 +10507,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1333,
+                        "id": 1344,
                         "name": "liquidity",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1282,
+                        "referencedDeclaration": 1293,
                         "src": "7294:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -10530,7 +10530,7 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 1329,
+                      "id": 1340,
                       "name": "_burn",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
@@ -10541,7 +10541,7 @@
                         "typeString": "function (address,uint256)"
                       }
                     },
-                    "id": 1334,
+                    "id": 1345,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -10555,7 +10555,7 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1335,
+                  "id": 1346,
                   "nodeType": "ExpressionStatement",
                   "src": "7273:31:2"
                 },
@@ -10565,11 +10565,11 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1337,
+                        "id": 1348,
                         "name": "_token0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1252,
+                        "referencedDeclaration": 1263,
                         "src": "7328:7:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -10578,11 +10578,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1338,
+                        "id": 1349,
                         "name": "to",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1235,
+                        "referencedDeclaration": 1246,
                         "src": "7337:2:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -10591,11 +10591,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1339,
+                        "id": 1350,
                         "name": "amount0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1240,
+                        "referencedDeclaration": 1251,
                         "src": "7341:7:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -10618,18 +10618,18 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 1336,
+                      "id": 1347,
                       "name": "_safeTransfer",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 770,
+                      "referencedDeclaration": 781,
                       "src": "7314:13:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_address_$_t_address_$_t_uint256_$returns$__$",
                         "typeString": "function (address,address,uint256)"
                       }
                     },
-                    "id": 1340,
+                    "id": 1351,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -10643,7 +10643,7 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1341,
+                  "id": 1352,
                   "nodeType": "ExpressionStatement",
                   "src": "7314:35:2"
                 },
@@ -10653,11 +10653,11 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1343,
+                        "id": 1354,
                         "name": "_token1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1256,
+                        "referencedDeclaration": 1267,
                         "src": "7373:7:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -10666,11 +10666,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1344,
+                        "id": 1355,
                         "name": "to",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1235,
+                        "referencedDeclaration": 1246,
                         "src": "7382:2:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -10679,11 +10679,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1345,
+                        "id": 1356,
                         "name": "amount1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1242,
+                        "referencedDeclaration": 1253,
                         "src": "7386:7:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -10706,18 +10706,18 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 1342,
+                      "id": 1353,
                       "name": "_safeTransfer",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 770,
+                      "referencedDeclaration": 781,
                       "src": "7359:13:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_address_$_t_address_$_t_uint256_$returns$__$",
                         "typeString": "function (address,address,uint256)"
                       }
                     },
-                    "id": 1346,
+                    "id": 1357,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -10731,25 +10731,25 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1347,
+                  "id": 1358,
                   "nodeType": "ExpressionStatement",
                   "src": "7359:35:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 1357,
+                    "id": 1368,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 1348,
+                      "id": 1359,
                       "name": "balance0",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1260,
+                      "referencedDeclaration": 1271,
                       "src": "7404:8:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
@@ -10766,14 +10766,14 @@
                           "arguments": [
                             {
                               "argumentTypes": null,
-                              "id": 1354,
+                              "id": 1365,
                               "name": "this",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 2518,
+                              "referencedDeclaration": 2529,
                               "src": "7449:4:2",
                               "typeDescriptions": {
-                                "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                 "typeString": "contract DXswapPair"
                               }
                             }
@@ -10781,11 +10781,11 @@
                           "expression": {
                             "argumentTypes": [
                               {
-                                "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                 "typeString": "contract DXswapPair"
                               }
                             ],
-                            "id": 1353,
+                            "id": 1364,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -10798,7 +10798,7 @@
                             },
                             "typeName": "address"
                           },
-                          "id": 1355,
+                          "id": 1366,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -10825,11 +10825,11 @@
                           "arguments": [
                             {
                               "argumentTypes": null,
-                              "id": 1350,
+                              "id": 1361,
                               "name": "_token0",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1252,
+                              "referencedDeclaration": 1263,
                               "src": "7422:7:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
@@ -10844,18 +10844,18 @@
                                 "typeString": "address"
                               }
                             ],
-                            "id": 1349,
+                            "id": 1360,
                             "name": "IERC20",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2260,
+                            "referencedDeclaration": 2271,
                             "src": "7415:6:2",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                              "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                               "typeString": "type(contract IERC20)"
                             }
                           },
-                          "id": 1351,
+                          "id": 1362,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -10865,25 +10865,25 @@
                           "nodeType": "FunctionCall",
                           "src": "7415:15:2",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_contract$_IERC20_$2260",
+                            "typeIdentifier": "t_contract$_IERC20_$2271",
                             "typeString": "contract IERC20"
                           }
                         },
-                        "id": 1352,
+                        "id": 1363,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "memberName": "balanceOf",
                         "nodeType": "MemberAccess",
-                        "referencedDeclaration": 2221,
+                        "referencedDeclaration": 2232,
                         "src": "7415:25:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                           "typeString": "function (address) view external returns (uint256)"
                         }
                       },
-                      "id": 1356,
+                      "id": 1367,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -10903,25 +10903,25 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 1358,
+                  "id": 1369,
                   "nodeType": "ExpressionStatement",
                   "src": "7404:51:2"
                 },
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 1368,
+                    "id": 1379,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 1359,
+                      "id": 1370,
                       "name": "balance1",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 1271,
+                      "referencedDeclaration": 1282,
                       "src": "7465:8:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
@@ -10938,14 +10938,14 @@
                           "arguments": [
                             {
                               "argumentTypes": null,
-                              "id": 1365,
+                              "id": 1376,
                               "name": "this",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 2518,
+                              "referencedDeclaration": 2529,
                               "src": "7510:4:2",
                               "typeDescriptions": {
-                                "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                 "typeString": "contract DXswapPair"
                               }
                             }
@@ -10953,11 +10953,11 @@
                           "expression": {
                             "argumentTypes": [
                               {
-                                "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                 "typeString": "contract DXswapPair"
                               }
                             ],
-                            "id": 1364,
+                            "id": 1375,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -10970,7 +10970,7 @@
                             },
                             "typeName": "address"
                           },
-                          "id": 1366,
+                          "id": 1377,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -10997,11 +10997,11 @@
                           "arguments": [
                             {
                               "argumentTypes": null,
-                              "id": 1361,
+                              "id": 1372,
                               "name": "_token1",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1256,
+                              "referencedDeclaration": 1267,
                               "src": "7483:7:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
@@ -11016,18 +11016,18 @@
                                 "typeString": "address"
                               }
                             ],
-                            "id": 1360,
+                            "id": 1371,
                             "name": "IERC20",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2260,
+                            "referencedDeclaration": 2271,
                             "src": "7476:6:2",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                              "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                               "typeString": "type(contract IERC20)"
                             }
                           },
-                          "id": 1362,
+                          "id": 1373,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -11037,25 +11037,25 @@
                           "nodeType": "FunctionCall",
                           "src": "7476:15:2",
                           "typeDescriptions": {
-                            "typeIdentifier": "t_contract$_IERC20_$2260",
+                            "typeIdentifier": "t_contract$_IERC20_$2271",
                             "typeString": "contract IERC20"
                           }
                         },
-                        "id": 1363,
+                        "id": 1374,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "memberName": "balanceOf",
                         "nodeType": "MemberAccess",
-                        "referencedDeclaration": 2221,
+                        "referencedDeclaration": 2232,
                         "src": "7476:25:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                           "typeString": "function (address) view external returns (uint256)"
                         }
                       },
-                      "id": 1367,
+                      "id": 1378,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -11075,7 +11075,7 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 1369,
+                  "id": 1380,
                   "nodeType": "ExpressionStatement",
                   "src": "7465:51:2"
                 },
@@ -11085,11 +11085,11 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1371,
+                        "id": 1382,
                         "name": "balance0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1260,
+                        "referencedDeclaration": 1271,
                         "src": "7535:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -11098,11 +11098,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1372,
+                        "id": 1383,
                         "name": "balance1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1271,
+                        "referencedDeclaration": 1282,
                         "src": "7545:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -11111,11 +11111,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1373,
+                        "id": 1384,
                         "name": "_reserve0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1245,
+                        "referencedDeclaration": 1256,
                         "src": "7555:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -11124,11 +11124,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1374,
+                        "id": 1385,
                         "name": "_reserve1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1247,
+                        "referencedDeclaration": 1258,
                         "src": "7566:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -11155,18 +11155,18 @@
                           "typeString": "uint112"
                         }
                       ],
-                      "id": 1370,
+                      "id": 1381,
                       "name": "_update",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 974,
+                      "referencedDeclaration": 985,
                       "src": "7527:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$_t_uint256_$_t_uint112_$_t_uint112_$returns$__$",
                         "typeString": "function (uint256,uint256,uint112,uint112)"
                       }
                     },
-                    "id": 1375,
+                    "id": 1386,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -11180,18 +11180,18 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1376,
+                  "id": 1387,
                   "nodeType": "ExpressionStatement",
                   "src": "7527:49:2"
                 },
                 {
                   "condition": {
                     "argumentTypes": null,
-                    "id": 1377,
+                    "id": 1388,
                     "name": "feeOn",
                     "nodeType": "Identifier",
                     "overloadedDeclarations": [],
-                    "referencedDeclaration": 1290,
+                    "referencedDeclaration": 1301,
                     "src": "7590:5:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_bool",
@@ -11199,24 +11199,24 @@
                     }
                   },
                   "falseBody": null,
-                  "id": 1387,
+                  "id": 1398,
                   "nodeType": "IfStatement",
                   "src": "7586:47:2",
                   "trueBody": {
                     "expression": {
                       "argumentTypes": null,
-                      "id": 1385,
+                      "id": 1396,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftHandSide": {
                         "argumentTypes": null,
-                        "id": 1378,
+                        "id": 1389,
                         "name": "kLast",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 681,
+                        "referencedDeclaration": 692,
                         "src": "7597:5:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -11230,11 +11230,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1383,
+                            "id": 1394,
                             "name": "reserve1",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 673,
+                            "referencedDeclaration": 684,
                             "src": "7624:8:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint112",
@@ -11254,11 +11254,11 @@
                             "arguments": [
                               {
                                 "argumentTypes": null,
-                                "id": 1380,
+                                "id": 1391,
                                 "name": "reserve0",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 671,
+                                "referencedDeclaration": 682,
                                 "src": "7610:8:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_uint112",
@@ -11273,7 +11273,7 @@
                                   "typeString": "uint112"
                                 }
                               ],
-                              "id": 1379,
+                              "id": 1390,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
@@ -11286,7 +11286,7 @@
                               },
                               "typeName": "uint"
                             },
-                            "id": 1381,
+                            "id": 1392,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -11300,21 +11300,21 @@
                               "typeString": "uint256"
                             }
                           },
-                          "id": 1382,
+                          "id": 1393,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "memberName": "mul",
                           "nodeType": "MemberAccess",
-                          "referencedDeclaration": 2410,
+                          "referencedDeclaration": 2421,
                           "src": "7605:18:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                             "typeString": "function (uint256,uint256) pure returns (uint256)"
                           }
                         },
-                        "id": 1384,
+                        "id": 1395,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -11334,7 +11334,7 @@
                         "typeString": "uint256"
                       }
                     },
-                    "id": 1386,
+                    "id": 1397,
                     "nodeType": "ExpressionStatement",
                     "src": "7597:36:2"
                   }
@@ -11347,18 +11347,18 @@
                         "argumentTypes": null,
                         "expression": {
                           "argumentTypes": null,
-                          "id": 1389,
+                          "id": 1400,
                           "name": "msg",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2486,
+                          "referencedDeclaration": 2497,
                           "src": "7693:3:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_magic_message",
                             "typeString": "msg"
                           }
                         },
-                        "id": 1390,
+                        "id": 1401,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -11374,11 +11374,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1391,
+                        "id": 1402,
                         "name": "amount0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1240,
+                        "referencedDeclaration": 1251,
                         "src": "7705:7:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -11387,11 +11387,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1392,
+                        "id": 1403,
                         "name": "amount1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1242,
+                        "referencedDeclaration": 1253,
                         "src": "7714:7:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -11400,11 +11400,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1393,
+                        "id": 1404,
                         "name": "to",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1235,
+                        "referencedDeclaration": 1246,
                         "src": "7723:2:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -11431,20 +11431,20 @@
                           "typeString": "address"
                         }
                       ],
-                      "id": 1388,
+                      "id": 1399,
                       "name": "Burn",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        788
+                        799
                       ],
-                      "referencedDeclaration": 788,
+                      "referencedDeclaration": 799,
                       "src": "7688:4:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_uint256_$_t_address_$returns$__$",
                         "typeString": "function (address,uint256,uint256,address)"
                       }
                     },
-                    "id": 1394,
+                    "id": 1405,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -11458,27 +11458,27 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1395,
+                  "id": 1406,
                   "nodeType": "EmitStatement",
                   "src": "7683:43:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 1397,
+            "id": 1408,
             "implemented": true,
             "kind": "function",
             "modifiers": [
               {
                 "arguments": null,
-                "id": 1238,
+                "id": 1249,
                 "modifierName": {
                   "argumentTypes": null,
-                  "id": 1237,
+                  "id": 1248,
                   "name": "lock",
                   "nodeType": "Identifier",
                   "overloadedDeclarations": [],
-                  "referencedDeclaration": 706,
+                  "referencedDeclaration": 717,
                   "src": "6323:4:2",
                   "typeDescriptions": {
                     "typeIdentifier": "t_modifier$__$",
@@ -11492,15 +11492,15 @@
             "name": "burn",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1236,
+              "id": 1247,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1235,
+                  "id": 1246,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1397,
+                  "scope": 1408,
                   "src": "6302:10:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -11509,7 +11509,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1234,
+                    "id": 1245,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "6302:7:2",
@@ -11526,15 +11526,15 @@
               "src": "6301:12:2"
             },
             "returnParameters": {
-              "id": 1243,
+              "id": 1254,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1240,
+                  "id": 1251,
                   "name": "amount0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1397,
+                  "scope": 1408,
                   "src": "6337:12:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -11543,7 +11543,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1239,
+                    "id": 1250,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "6337:4:2",
@@ -11557,10 +11557,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1242,
+                  "id": 1253,
                   "name": "amount1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1397,
+                  "scope": 1408,
                   "src": "6351:12:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -11569,7 +11569,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1241,
+                    "id": 1252,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "6351:4:2",
@@ -11584,15 +11584,15 @@
               ],
               "src": "6336:28:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "6288:1445:2",
             "stateMutability": "nonpayable",
-            "superFunction": 2144,
+            "superFunction": 2155,
             "visibility": "external"
           },
           {
             "body": {
-              "id": 1635,
+              "id": 1646,
               "nodeType": "Block",
               "src": "7937:1823:2",
               "statements": [
@@ -11606,7 +11606,7 @@
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
                         },
-                        "id": 1417,
+                        "id": 1428,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -11617,18 +11617,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 1413,
+                          "id": 1424,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 1411,
+                            "id": 1422,
                             "name": "amount0Out",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1399,
+                            "referencedDeclaration": 1410,
                             "src": "7955:10:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -11640,7 +11640,7 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "30",
-                            "id": 1412,
+                            "id": 1423,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -11669,18 +11669,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 1416,
+                          "id": 1427,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 1414,
+                            "id": 1425,
                             "name": "amount1Out",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1401,
+                            "referencedDeclaration": 1412,
                             "src": "7973:10:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -11692,7 +11692,7 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "30",
-                            "id": 1415,
+                            "id": 1426,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -11722,7 +11722,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170506169723a20494e53554646494349454e545f4f55545055545f414d4f554e54",
-                        "id": 1418,
+                        "id": 1429,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -11749,21 +11749,21 @@
                           "typeString": "literal_string \"DXswapPair: INSUFFICIENT_OUTPUT_AMOUNT\""
                         }
                       ],
-                      "id": 1410,
+                      "id": 1421,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "7947:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 1419,
+                    "id": 1430,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -11777,23 +11777,23 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1420,
+                  "id": 1431,
                   "nodeType": "ExpressionStatement",
                   "src": "7947:83:2"
                 },
                 {
                   "assignments": [
-                    1422,
-                    1424,
+                    1433,
+                    1435,
                     null
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1422,
+                      "id": 1433,
                       "name": "_reserve0",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1635,
+                      "scope": 1646,
                       "src": "8041:17:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -11802,7 +11802,7 @@
                         "typeString": "uint112"
                       },
                       "typeName": {
-                        "id": 1421,
+                        "id": 1432,
                         "name": "uint112",
                         "nodeType": "ElementaryTypeName",
                         "src": "8041:7:2",
@@ -11816,10 +11816,10 @@
                     },
                     {
                       "constant": false,
-                      "id": 1424,
+                      "id": 1435,
                       "name": "_reserve1",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1635,
+                      "scope": 1646,
                       "src": "8060:17:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -11828,7 +11828,7 @@
                         "typeString": "uint112"
                       },
                       "typeName": {
-                        "id": 1423,
+                        "id": 1434,
                         "name": "uint112",
                         "nodeType": "ElementaryTypeName",
                         "src": "8060:7:2",
@@ -11842,24 +11842,24 @@
                     },
                     null
                   ],
-                  "id": 1427,
+                  "id": 1438,
                   "initialValue": {
                     "argumentTypes": null,
                     "arguments": [],
                     "expression": {
                       "argumentTypes": [],
-                      "id": 1425,
+                      "id": 1436,
                       "name": "getReserves",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 728,
+                      "referencedDeclaration": 739,
                       "src": "8082:11:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_view$__$returns$_t_uint112_$_t_uint112_$_t_uint32_$",
                         "typeString": "function () view returns (uint112,uint112,uint32)"
                       }
                     },
-                    "id": 1426,
+                    "id": 1437,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -11886,7 +11886,7 @@
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
                         },
-                        "id": 1435,
+                        "id": 1446,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -11897,18 +11897,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 1431,
+                          "id": 1442,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 1429,
+                            "id": 1440,
                             "name": "amount0Out",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1399,
+                            "referencedDeclaration": 1410,
                             "src": "8128:10:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -11919,11 +11919,11 @@
                           "operator": "<",
                           "rightExpression": {
                             "argumentTypes": null,
-                            "id": 1430,
+                            "id": 1441,
                             "name": "_reserve0",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1422,
+                            "referencedDeclaration": 1433,
                             "src": "8141:9:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint112",
@@ -11944,18 +11944,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 1434,
+                          "id": 1445,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 1432,
+                            "id": 1443,
                             "name": "amount1Out",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1401,
+                            "referencedDeclaration": 1412,
                             "src": "8154:10:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -11966,11 +11966,11 @@
                           "operator": "<",
                           "rightExpression": {
                             "argumentTypes": null,
-                            "id": 1433,
+                            "id": 1444,
                             "name": "_reserve1",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1424,
+                            "referencedDeclaration": 1435,
                             "src": "8167:9:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint112",
@@ -11992,7 +11992,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170506169723a20494e53554646494349454e545f4c4951554944495459",
-                        "id": 1436,
+                        "id": 1447,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -12019,21 +12019,21 @@
                           "typeString": "literal_string \"DXswapPair: INSUFFICIENT_LIQUIDITY\""
                         }
                       ],
-                      "id": 1428,
+                      "id": 1439,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "8120:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 1437,
+                    "id": 1448,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -12047,21 +12047,21 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1438,
+                  "id": 1449,
                   "nodeType": "ExpressionStatement",
                   "src": "8120:95:2"
                 },
                 {
                   "assignments": [
-                    1440
+                    1451
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1440,
+                      "id": 1451,
                       "name": "balance0",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1635,
+                      "scope": 1646,
                       "src": "8226:13:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -12070,7 +12070,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1439,
+                        "id": 1450,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "8226:4:2",
@@ -12083,22 +12083,22 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1441,
+                  "id": 1452,
                   "initialValue": null,
                   "nodeType": "VariableDeclarationStatement",
                   "src": "8226:13:2"
                 },
                 {
                   "assignments": [
-                    1443
+                    1454
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1443,
+                      "id": 1454,
                       "name": "balance1",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1635,
+                      "scope": 1646,
                       "src": "8249:13:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -12107,7 +12107,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1442,
+                        "id": 1453,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "8249:4:2",
@@ -12120,27 +12120,27 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1444,
+                  "id": 1455,
                   "initialValue": null,
                   "nodeType": "VariableDeclarationStatement",
                   "src": "8249:13:2"
                 },
                 {
-                  "id": 1522,
+                  "id": 1533,
                   "nodeType": "Block",
                   "src": "8272:636:2",
                   "statements": [
                     {
                       "assignments": [
-                        1446
+                        1457
                       ],
                       "declarations": [
                         {
                           "constant": false,
-                          "id": 1446,
+                          "id": 1457,
                           "name": "_token0",
                           "nodeType": "VariableDeclaration",
-                          "scope": 1522,
+                          "scope": 1533,
                           "src": "8337:15:2",
                           "stateVariable": false,
                           "storageLocation": "default",
@@ -12149,7 +12149,7 @@
                             "typeString": "address"
                           },
                           "typeName": {
-                            "id": 1445,
+                            "id": 1456,
                             "name": "address",
                             "nodeType": "ElementaryTypeName",
                             "src": "8337:7:2",
@@ -12163,14 +12163,14 @@
                           "visibility": "internal"
                         }
                       ],
-                      "id": 1448,
+                      "id": 1459,
                       "initialValue": {
                         "argumentTypes": null,
-                        "id": 1447,
+                        "id": 1458,
                         "name": "token0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 667,
+                        "referencedDeclaration": 678,
                         "src": "8355:6:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -12182,15 +12182,15 @@
                     },
                     {
                       "assignments": [
-                        1450
+                        1461
                       ],
                       "declarations": [
                         {
                           "constant": false,
-                          "id": 1450,
+                          "id": 1461,
                           "name": "_token1",
                           "nodeType": "VariableDeclaration",
-                          "scope": 1522,
+                          "scope": 1533,
                           "src": "8371:15:2",
                           "stateVariable": false,
                           "storageLocation": "default",
@@ -12199,7 +12199,7 @@
                             "typeString": "address"
                           },
                           "typeName": {
-                            "id": 1449,
+                            "id": 1460,
                             "name": "address",
                             "nodeType": "ElementaryTypeName",
                             "src": "8371:7:2",
@@ -12213,14 +12213,14 @@
                           "visibility": "internal"
                         }
                       ],
-                      "id": 1452,
+                      "id": 1463,
                       "initialValue": {
                         "argumentTypes": null,
-                        "id": 1451,
+                        "id": 1462,
                         "name": "token1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 669,
+                        "referencedDeclaration": 680,
                         "src": "8389:6:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -12240,7 +12240,7 @@
                               "typeIdentifier": "t_bool",
                               "typeString": "bool"
                             },
-                            "id": 1460,
+                            "id": 1471,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -12251,18 +12251,18 @@
                                 "typeIdentifier": "t_address",
                                 "typeString": "address"
                               },
-                              "id": 1456,
+                              "id": 1467,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
                               "lValueRequested": false,
                               "leftExpression": {
                                 "argumentTypes": null,
-                                "id": 1454,
+                                "id": 1465,
                                 "name": "to",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 1403,
+                                "referencedDeclaration": 1414,
                                 "src": "8413:2:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
@@ -12273,11 +12273,11 @@
                               "operator": "!=",
                               "rightExpression": {
                                 "argumentTypes": null,
-                                "id": 1455,
+                                "id": 1466,
                                 "name": "_token0",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 1446,
+                                "referencedDeclaration": 1457,
                                 "src": "8419:7:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
@@ -12298,18 +12298,18 @@
                                 "typeIdentifier": "t_address",
                                 "typeString": "address"
                               },
-                              "id": 1459,
+                              "id": 1470,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
                               "lValueRequested": false,
                               "leftExpression": {
                                 "argumentTypes": null,
-                                "id": 1457,
+                                "id": 1468,
                                 "name": "to",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 1403,
+                                "referencedDeclaration": 1414,
                                 "src": "8430:2:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
@@ -12320,11 +12320,11 @@
                               "operator": "!=",
                               "rightExpression": {
                                 "argumentTypes": null,
-                                "id": 1458,
+                                "id": 1469,
                                 "name": "_token1",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 1450,
+                                "referencedDeclaration": 1461,
                                 "src": "8436:7:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
@@ -12346,7 +12346,7 @@
                           {
                             "argumentTypes": null,
                             "hexValue": "445873776170506169723a20494e56414c49445f544f",
-                            "id": 1461,
+                            "id": 1472,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -12373,21 +12373,21 @@
                               "typeString": "literal_string \"DXswapPair: INVALID_TO\""
                             }
                           ],
-                          "id": 1453,
+                          "id": 1464,
                           "name": "require",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [
-                            2489,
-                            2490
+                            2500,
+                            2501
                           ],
-                          "referencedDeclaration": 2490,
+                          "referencedDeclaration": 2501,
                           "src": "8405:7:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                             "typeString": "function (bool,string memory) pure"
                           }
                         },
-                        "id": 1462,
+                        "id": 1473,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -12401,7 +12401,7 @@
                           "typeString": "tuple()"
                         }
                       },
-                      "id": 1463,
+                      "id": 1474,
                       "nodeType": "ExpressionStatement",
                       "src": "8405:65:2"
                     },
@@ -12412,18 +12412,18 @@
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         },
-                        "id": 1466,
+                        "id": 1477,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 1464,
+                          "id": 1475,
                           "name": "amount0Out",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1399,
+                          "referencedDeclaration": 1410,
                           "src": "8484:10:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -12435,7 +12435,7 @@
                         "rightExpression": {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 1465,
+                          "id": 1476,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -12457,7 +12457,7 @@
                         }
                       },
                       "falseBody": null,
-                      "id": 1473,
+                      "id": 1484,
                       "nodeType": "IfStatement",
                       "src": "8480:58:2",
                       "trueBody": {
@@ -12466,11 +12466,11 @@
                           "arguments": [
                             {
                               "argumentTypes": null,
-                              "id": 1468,
+                              "id": 1479,
                               "name": "_token0",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1446,
+                              "referencedDeclaration": 1457,
                               "src": "8514:7:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
@@ -12479,11 +12479,11 @@
                             },
                             {
                               "argumentTypes": null,
-                              "id": 1469,
+                              "id": 1480,
                               "name": "to",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1403,
+                              "referencedDeclaration": 1414,
                               "src": "8523:2:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
@@ -12492,11 +12492,11 @@
                             },
                             {
                               "argumentTypes": null,
-                              "id": 1470,
+                              "id": 1481,
                               "name": "amount0Out",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1399,
+                              "referencedDeclaration": 1410,
                               "src": "8527:10:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint256",
@@ -12519,18 +12519,18 @@
                                 "typeString": "uint256"
                               }
                             ],
-                            "id": 1467,
+                            "id": 1478,
                             "name": "_safeTransfer",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 770,
+                            "referencedDeclaration": 781,
                             "src": "8500:13:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_function_internal_nonpayable$_t_address_$_t_address_$_t_uint256_$returns$__$",
                               "typeString": "function (address,address,uint256)"
                             }
                           },
-                          "id": 1471,
+                          "id": 1482,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -12544,7 +12544,7 @@
                             "typeString": "tuple()"
                           }
                         },
-                        "id": 1472,
+                        "id": 1483,
                         "nodeType": "ExpressionStatement",
                         "src": "8500:38:2"
                       }
@@ -12556,18 +12556,18 @@
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         },
-                        "id": 1476,
+                        "id": 1487,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 1474,
+                          "id": 1485,
                           "name": "amount1Out",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1401,
+                          "referencedDeclaration": 1412,
                           "src": "8586:10:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -12579,7 +12579,7 @@
                         "rightExpression": {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 1475,
+                          "id": 1486,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -12601,7 +12601,7 @@
                         }
                       },
                       "falseBody": null,
-                      "id": 1483,
+                      "id": 1494,
                       "nodeType": "IfStatement",
                       "src": "8582:58:2",
                       "trueBody": {
@@ -12610,11 +12610,11 @@
                           "arguments": [
                             {
                               "argumentTypes": null,
-                              "id": 1478,
+                              "id": 1489,
                               "name": "_token1",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1450,
+                              "referencedDeclaration": 1461,
                               "src": "8616:7:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
@@ -12623,11 +12623,11 @@
                             },
                             {
                               "argumentTypes": null,
-                              "id": 1479,
+                              "id": 1490,
                               "name": "to",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1403,
+                              "referencedDeclaration": 1414,
                               "src": "8625:2:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_address",
@@ -12636,11 +12636,11 @@
                             },
                             {
                               "argumentTypes": null,
-                              "id": 1480,
+                              "id": 1491,
                               "name": "amount1Out",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1401,
+                              "referencedDeclaration": 1412,
                               "src": "8629:10:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint256",
@@ -12663,18 +12663,18 @@
                                 "typeString": "uint256"
                               }
                             ],
-                            "id": 1477,
+                            "id": 1488,
                             "name": "_safeTransfer",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 770,
+                            "referencedDeclaration": 781,
                             "src": "8602:13:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_function_internal_nonpayable$_t_address_$_t_address_$_t_uint256_$returns$__$",
                               "typeString": "function (address,address,uint256)"
                             }
                           },
-                          "id": 1481,
+                          "id": 1492,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -12688,7 +12688,7 @@
                             "typeString": "tuple()"
                           }
                         },
-                        "id": 1482,
+                        "id": 1493,
                         "nodeType": "ExpressionStatement",
                         "src": "8602:38:2"
                       }
@@ -12700,7 +12700,7 @@
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         },
-                        "id": 1487,
+                        "id": 1498,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -12709,18 +12709,18 @@
                           "argumentTypes": null,
                           "expression": {
                             "argumentTypes": null,
-                            "id": 1484,
+                            "id": 1495,
                             "name": "data",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1405,
+                            "referencedDeclaration": 1416,
                             "src": "8688:4:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_bytes_calldata_ptr",
                               "typeString": "bytes calldata"
                             }
                           },
-                          "id": 1485,
+                          "id": 1496,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -12739,7 +12739,7 @@
                         "rightExpression": {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 1486,
+                          "id": 1497,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -12761,7 +12761,7 @@
                         }
                       },
                       "falseBody": null,
-                      "id": 1499,
+                      "id": 1510,
                       "nodeType": "IfStatement",
                       "src": "8684:91:2",
                       "trueBody": {
@@ -12772,18 +12772,18 @@
                               "argumentTypes": null,
                               "expression": {
                                 "argumentTypes": null,
-                                "id": 1492,
+                                "id": 1503,
                                 "name": "msg",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2486,
+                                "referencedDeclaration": 2497,
                                 "src": "8734:3:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_magic_message",
                                   "typeString": "msg"
                                 }
                               },
-                              "id": 1493,
+                              "id": 1504,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -12799,11 +12799,11 @@
                             },
                             {
                               "argumentTypes": null,
-                              "id": 1494,
+                              "id": 1505,
                               "name": "amount0Out",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1399,
+                              "referencedDeclaration": 1410,
                               "src": "8746:10:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint256",
@@ -12812,11 +12812,11 @@
                             },
                             {
                               "argumentTypes": null,
-                              "id": 1495,
+                              "id": 1506,
                               "name": "amount1Out",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1401,
+                              "referencedDeclaration": 1412,
                               "src": "8758:10:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint256",
@@ -12825,11 +12825,11 @@
                             },
                             {
                               "argumentTypes": null,
-                              "id": 1496,
+                              "id": 1507,
                               "name": "data",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1405,
+                              "referencedDeclaration": 1416,
                               "src": "8770:4:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_bytes_calldata_ptr",
@@ -12861,11 +12861,11 @@
                               "arguments": [
                                 {
                                   "argumentTypes": null,
-                                  "id": 1489,
+                                  "id": 1500,
                                   "name": "to",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 1403,
+                                  "referencedDeclaration": 1414,
                                   "src": "8719:2:2",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_address",
@@ -12880,18 +12880,18 @@
                                     "typeString": "address"
                                   }
                                 ],
-                                "id": 1488,
+                                "id": 1499,
                                 "name": "IDXswapCallee",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 1726,
+                                "referencedDeclaration": 1737,
                                 "src": "8705:13:2",
                                 "typeDescriptions": {
-                                  "typeIdentifier": "t_type$_t_contract$_IDXswapCallee_$1726_$",
+                                  "typeIdentifier": "t_type$_t_contract$_IDXswapCallee_$1737_$",
                                   "typeString": "type(contract IDXswapCallee)"
                                 }
                               },
-                              "id": 1490,
+                              "id": 1501,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -12901,25 +12901,25 @@
                               "nodeType": "FunctionCall",
                               "src": "8705:17:2",
                               "typeDescriptions": {
-                                "typeIdentifier": "t_contract$_IDXswapCallee_$1726",
+                                "typeIdentifier": "t_contract$_IDXswapCallee_$1737",
                                 "typeString": "contract IDXswapCallee"
                               }
                             },
-                            "id": 1491,
+                            "id": 1502,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
                             "lValueRequested": false,
                             "memberName": "DXswapCall",
                             "nodeType": "MemberAccess",
-                            "referencedDeclaration": 1725,
+                            "referencedDeclaration": 1736,
                             "src": "8705:28:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_function_external_nonpayable$_t_address_$_t_uint256_$_t_uint256_$_t_bytes_memory_ptr_$returns$__$",
                               "typeString": "function (address,uint256,uint256,bytes memory) external"
                             }
                           },
-                          "id": 1497,
+                          "id": 1508,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -12933,7 +12933,7 @@
                             "typeString": "tuple()"
                           }
                         },
-                        "id": 1498,
+                        "id": 1509,
                         "nodeType": "ExpressionStatement",
                         "src": "8705:70:2"
                       }
@@ -12941,18 +12941,18 @@
                     {
                       "expression": {
                         "argumentTypes": null,
-                        "id": 1509,
+                        "id": 1520,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftHandSide": {
                           "argumentTypes": null,
-                          "id": 1500,
+                          "id": 1511,
                           "name": "balance0",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1440,
+                          "referencedDeclaration": 1451,
                           "src": "8785:8:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -12969,14 +12969,14 @@
                               "arguments": [
                                 {
                                   "argumentTypes": null,
-                                  "id": 1506,
+                                  "id": 1517,
                                   "name": "this",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2518,
+                                  "referencedDeclaration": 2529,
                                   "src": "8830:4:2",
                                   "typeDescriptions": {
-                                    "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                    "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                     "typeString": "contract DXswapPair"
                                   }
                                 }
@@ -12984,11 +12984,11 @@
                               "expression": {
                                 "argumentTypes": [
                                   {
-                                    "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                    "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                     "typeString": "contract DXswapPair"
                                   }
                                 ],
-                                "id": 1505,
+                                "id": 1516,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": true,
@@ -13001,7 +13001,7 @@
                                 },
                                 "typeName": "address"
                               },
-                              "id": 1507,
+                              "id": 1518,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -13028,11 +13028,11 @@
                               "arguments": [
                                 {
                                   "argumentTypes": null,
-                                  "id": 1502,
+                                  "id": 1513,
                                   "name": "_token0",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 1446,
+                                  "referencedDeclaration": 1457,
                                   "src": "8803:7:2",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_address",
@@ -13047,18 +13047,18 @@
                                     "typeString": "address"
                                   }
                                 ],
-                                "id": 1501,
+                                "id": 1512,
                                 "name": "IERC20",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2260,
+                                "referencedDeclaration": 2271,
                                 "src": "8796:6:2",
                                 "typeDescriptions": {
-                                  "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                                  "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                                   "typeString": "type(contract IERC20)"
                                 }
                               },
-                              "id": 1503,
+                              "id": 1514,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -13068,25 +13068,25 @@
                               "nodeType": "FunctionCall",
                               "src": "8796:15:2",
                               "typeDescriptions": {
-                                "typeIdentifier": "t_contract$_IERC20_$2260",
+                                "typeIdentifier": "t_contract$_IERC20_$2271",
                                 "typeString": "contract IERC20"
                               }
                             },
-                            "id": 1504,
+                            "id": 1515,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
                             "lValueRequested": false,
                             "memberName": "balanceOf",
                             "nodeType": "MemberAccess",
-                            "referencedDeclaration": 2221,
+                            "referencedDeclaration": 2232,
                             "src": "8796:25:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                               "typeString": "function (address) view external returns (uint256)"
                             }
                           },
-                          "id": 1508,
+                          "id": 1519,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -13106,25 +13106,25 @@
                           "typeString": "uint256"
                         }
                       },
-                      "id": 1510,
+                      "id": 1521,
                       "nodeType": "ExpressionStatement",
                       "src": "8785:51:2"
                     },
                     {
                       "expression": {
                         "argumentTypes": null,
-                        "id": 1520,
+                        "id": 1531,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftHandSide": {
                           "argumentTypes": null,
-                          "id": 1511,
+                          "id": 1522,
                           "name": "balance1",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1443,
+                          "referencedDeclaration": 1454,
                           "src": "8846:8:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -13141,14 +13141,14 @@
                               "arguments": [
                                 {
                                   "argumentTypes": null,
-                                  "id": 1517,
+                                  "id": 1528,
                                   "name": "this",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2518,
+                                  "referencedDeclaration": 2529,
                                   "src": "8891:4:2",
                                   "typeDescriptions": {
-                                    "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                    "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                     "typeString": "contract DXswapPair"
                                   }
                                 }
@@ -13156,11 +13156,11 @@
                               "expression": {
                                 "argumentTypes": [
                                   {
-                                    "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                    "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                     "typeString": "contract DXswapPair"
                                   }
                                 ],
-                                "id": 1516,
+                                "id": 1527,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": true,
@@ -13173,7 +13173,7 @@
                                 },
                                 "typeName": "address"
                               },
-                              "id": 1518,
+                              "id": 1529,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -13200,11 +13200,11 @@
                               "arguments": [
                                 {
                                   "argumentTypes": null,
-                                  "id": 1513,
+                                  "id": 1524,
                                   "name": "_token1",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 1450,
+                                  "referencedDeclaration": 1461,
                                   "src": "8864:7:2",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_address",
@@ -13219,18 +13219,18 @@
                                     "typeString": "address"
                                   }
                                 ],
-                                "id": 1512,
+                                "id": 1523,
                                 "name": "IERC20",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2260,
+                                "referencedDeclaration": 2271,
                                 "src": "8857:6:2",
                                 "typeDescriptions": {
-                                  "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                                  "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                                   "typeString": "type(contract IERC20)"
                                 }
                               },
-                              "id": 1514,
+                              "id": 1525,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -13240,25 +13240,25 @@
                               "nodeType": "FunctionCall",
                               "src": "8857:15:2",
                               "typeDescriptions": {
-                                "typeIdentifier": "t_contract$_IERC20_$2260",
+                                "typeIdentifier": "t_contract$_IERC20_$2271",
                                 "typeString": "contract IERC20"
                               }
                             },
-                            "id": 1515,
+                            "id": 1526,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
                             "lValueRequested": false,
                             "memberName": "balanceOf",
                             "nodeType": "MemberAccess",
-                            "referencedDeclaration": 2221,
+                            "referencedDeclaration": 2232,
                             "src": "8857:25:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                               "typeString": "function (address) view external returns (uint256)"
                             }
                           },
-                          "id": 1519,
+                          "id": 1530,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -13278,7 +13278,7 @@
                           "typeString": "uint256"
                         }
                       },
-                      "id": 1521,
+                      "id": 1532,
                       "nodeType": "ExpressionStatement",
                       "src": "8846:51:2"
                     }
@@ -13286,15 +13286,15 @@
                 },
                 {
                   "assignments": [
-                    1524
+                    1535
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1524,
+                      "id": 1535,
                       "name": "amount0In",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1635,
+                      "scope": 1646,
                       "src": "8917:14:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -13303,7 +13303,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1523,
+                        "id": 1534,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "8917:4:2",
@@ -13316,7 +13316,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1538,
+                  "id": 1549,
                   "initialValue": {
                     "argumentTypes": null,
                     "condition": {
@@ -13325,18 +13325,18 @@
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       },
-                      "id": 1529,
+                      "id": 1540,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftExpression": {
                         "argumentTypes": null,
-                        "id": 1525,
+                        "id": 1536,
                         "name": "balance0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1440,
+                        "referencedDeclaration": 1451,
                         "src": "8934:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -13351,18 +13351,18 @@
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         },
-                        "id": 1528,
+                        "id": 1539,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 1526,
+                          "id": 1537,
                           "name": "_reserve0",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1422,
+                          "referencedDeclaration": 1433,
                           "src": "8945:9:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint112",
@@ -13373,11 +13373,11 @@
                         "operator": "-",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 1527,
+                          "id": 1538,
                           "name": "amount0Out",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1399,
+                          "referencedDeclaration": 1410,
                           "src": "8957:10:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -13399,7 +13399,7 @@
                     "falseExpression": {
                       "argumentTypes": null,
                       "hexValue": "30",
-                      "id": 1536,
+                      "id": 1547,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
@@ -13414,7 +13414,7 @@
                       },
                       "value": "0"
                     },
-                    "id": 1537,
+                    "id": 1548,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -13427,18 +13427,18 @@
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       },
-                      "id": 1535,
+                      "id": 1546,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftExpression": {
                         "argumentTypes": null,
-                        "id": 1530,
+                        "id": 1541,
                         "name": "balance0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1440,
+                        "referencedDeclaration": 1451,
                         "src": "8970:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -13456,18 +13456,18 @@
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             },
-                            "id": 1533,
+                            "id": 1544,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
                             "lValueRequested": false,
                             "leftExpression": {
                               "argumentTypes": null,
-                              "id": 1531,
+                              "id": 1542,
                               "name": "_reserve0",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1422,
+                              "referencedDeclaration": 1433,
                               "src": "8982:9:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint112",
@@ -13478,11 +13478,11 @@
                             "operator": "-",
                             "rightExpression": {
                               "argumentTypes": null,
-                              "id": 1532,
+                              "id": 1543,
                               "name": "amount0Out",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1399,
+                              "referencedDeclaration": 1410,
                               "src": "8994:10:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint256",
@@ -13496,7 +13496,7 @@
                             }
                           }
                         ],
-                        "id": 1534,
+                        "id": 1545,
                         "isConstant": false,
                         "isInlineArray": false,
                         "isLValue": false,
@@ -13525,15 +13525,15 @@
                 },
                 {
                   "assignments": [
-                    1540
+                    1551
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1540,
+                      "id": 1551,
                       "name": "amount1In",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1635,
+                      "scope": 1646,
                       "src": "9019:14:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -13542,7 +13542,7 @@
                         "typeString": "uint256"
                       },
                       "typeName": {
-                        "id": 1539,
+                        "id": 1550,
                         "name": "uint",
                         "nodeType": "ElementaryTypeName",
                         "src": "9019:4:2",
@@ -13555,7 +13555,7 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1554,
+                  "id": 1565,
                   "initialValue": {
                     "argumentTypes": null,
                     "condition": {
@@ -13564,18 +13564,18 @@
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       },
-                      "id": 1545,
+                      "id": 1556,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftExpression": {
                         "argumentTypes": null,
-                        "id": 1541,
+                        "id": 1552,
                         "name": "balance1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1443,
+                        "referencedDeclaration": 1454,
                         "src": "9036:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -13590,18 +13590,18 @@
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         },
-                        "id": 1544,
+                        "id": 1555,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 1542,
+                          "id": 1553,
                           "name": "_reserve1",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1424,
+                          "referencedDeclaration": 1435,
                           "src": "9047:9:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint112",
@@ -13612,11 +13612,11 @@
                         "operator": "-",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 1543,
+                          "id": 1554,
                           "name": "amount1Out",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 1401,
+                          "referencedDeclaration": 1412,
                           "src": "9059:10:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -13638,7 +13638,7 @@
                     "falseExpression": {
                       "argumentTypes": null,
                       "hexValue": "30",
-                      "id": 1552,
+                      "id": 1563,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
@@ -13653,7 +13653,7 @@
                       },
                       "value": "0"
                     },
-                    "id": 1553,
+                    "id": 1564,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -13666,18 +13666,18 @@
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       },
-                      "id": 1551,
+                      "id": 1562,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftExpression": {
                         "argumentTypes": null,
-                        "id": 1546,
+                        "id": 1557,
                         "name": "balance1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1443,
+                        "referencedDeclaration": 1454,
                         "src": "9072:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -13695,18 +13695,18 @@
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             },
-                            "id": 1549,
+                            "id": 1560,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
                             "lValueRequested": false,
                             "leftExpression": {
                               "argumentTypes": null,
-                              "id": 1547,
+                              "id": 1558,
                               "name": "_reserve1",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1424,
+                              "referencedDeclaration": 1435,
                               "src": "9084:9:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint112",
@@ -13717,11 +13717,11 @@
                             "operator": "-",
                             "rightExpression": {
                               "argumentTypes": null,
-                              "id": 1548,
+                              "id": 1559,
                               "name": "amount1Out",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 1401,
+                              "referencedDeclaration": 1412,
                               "src": "9096:10:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint256",
@@ -13735,7 +13735,7 @@
                             }
                           }
                         ],
-                        "id": 1550,
+                        "id": 1561,
                         "isConstant": false,
                         "isInlineArray": false,
                         "isLValue": false,
@@ -13772,7 +13772,7 @@
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
                         },
-                        "id": 1562,
+                        "id": 1573,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -13783,18 +13783,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 1558,
+                          "id": 1569,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 1556,
+                            "id": 1567,
                             "name": "amount0In",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1524,
+                            "referencedDeclaration": 1535,
                             "src": "9129:9:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -13806,7 +13806,7 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "30",
-                            "id": 1557,
+                            "id": 1568,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -13835,18 +13835,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 1561,
+                          "id": 1572,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 1559,
+                            "id": 1570,
                             "name": "amount1In",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 1540,
+                            "referencedDeclaration": 1551,
                             "src": "9146:9:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -13858,7 +13858,7 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "30",
-                            "id": 1560,
+                            "id": 1571,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -13888,7 +13888,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "445873776170506169723a20494e53554646494349454e545f494e5055545f414d4f554e54",
-                        "id": 1563,
+                        "id": 1574,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -13915,21 +13915,21 @@
                           "typeString": "literal_string \"DXswapPair: INSUFFICIENT_INPUT_AMOUNT\""
                         }
                       ],
-                      "id": 1555,
+                      "id": 1566,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "9121:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 1564,
+                    "id": 1575,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -13943,12 +13943,12 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1565,
+                  "id": 1576,
                   "nodeType": "ExpressionStatement",
                   "src": "9121:80:2"
                 },
                 {
-                  "id": 1617,
+                  "id": 1628,
                   "nodeType": "Block",
                   "src": "9211:402:2",
                   "statements": [
@@ -13959,18 +13959,18 @@
                           "typeIdentifier": "t_uint8",
                           "typeString": "uint8"
                         },
-                        "id": 1568,
+                        "id": 1579,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 1566,
+                          "id": 1577,
                           "name": "swapFee",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 684,
+                          "referencedDeclaration": 695,
                           "src": "9289:7:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint8",
@@ -13982,7 +13982,7 @@
                         "rightExpression": {
                           "argumentTypes": null,
                           "hexValue": "30",
-                          "id": 1567,
+                          "id": 1578,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -14004,25 +14004,25 @@
                         }
                       },
                       "falseBody": null,
-                      "id": 1616,
+                      "id": 1627,
                       "nodeType": "IfStatement",
                       "src": "9285:318:2",
                       "trueBody": {
-                        "id": 1615,
+                        "id": 1626,
                         "nodeType": "Block",
                         "src": "9302:301:2",
                         "statements": [
                           {
                             "assignments": [
-                              1570
+                              1581
                             ],
                             "declarations": [
                               {
                                 "constant": false,
-                                "id": 1570,
+                                "id": 1581,
                                 "name": "balance0Adjusted",
                                 "nodeType": "VariableDeclaration",
-                                "scope": 1615,
+                                "scope": 1626,
                                 "src": "9314:21:2",
                                 "stateVariable": false,
                                 "storageLocation": "default",
@@ -14031,7 +14031,7 @@
                                   "typeString": "uint256"
                                 },
                                 "typeName": {
-                                  "id": 1569,
+                                  "id": 1580,
                                   "name": "uint",
                                   "nodeType": "ElementaryTypeName",
                                   "src": "9314:4:2",
@@ -14044,7 +14044,7 @@
                                 "visibility": "internal"
                               }
                             ],
-                            "id": 1581,
+                            "id": 1592,
                             "initialValue": {
                               "argumentTypes": null,
                               "arguments": [
@@ -14053,11 +14053,11 @@
                                   "arguments": [
                                     {
                                       "argumentTypes": null,
-                                      "id": 1578,
+                                      "id": 1589,
                                       "name": "swapFee",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 684,
+                                      "referencedDeclaration": 695,
                                       "src": "9376:7:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint8",
@@ -14074,32 +14074,32 @@
                                     ],
                                     "expression": {
                                       "argumentTypes": null,
-                                      "id": 1576,
+                                      "id": 1587,
                                       "name": "amount0In",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 1524,
+                                      "referencedDeclaration": 1535,
                                       "src": "9362:9:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint256",
                                         "typeString": "uint256"
                                       }
                                     },
-                                    "id": 1577,
+                                    "id": 1588,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
                                     "lValueRequested": false,
                                     "memberName": "mul",
                                     "nodeType": "MemberAccess",
-                                    "referencedDeclaration": 2410,
+                                    "referencedDeclaration": 2421,
                                     "src": "9362:13:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                       "typeString": "function (uint256,uint256) pure returns (uint256)"
                                     }
                                   },
-                                  "id": 1579,
+                                  "id": 1590,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
@@ -14127,7 +14127,7 @@
                                     {
                                       "argumentTypes": null,
                                       "hexValue": "3130303030",
-                                      "id": 1573,
+                                      "id": 1584,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": true,
@@ -14152,32 +14152,32 @@
                                     ],
                                     "expression": {
                                       "argumentTypes": null,
-                                      "id": 1571,
+                                      "id": 1582,
                                       "name": "balance0",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 1440,
+                                      "referencedDeclaration": 1451,
                                       "src": "9338:8:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint256",
                                         "typeString": "uint256"
                                       }
                                     },
-                                    "id": 1572,
+                                    "id": 1583,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
                                     "lValueRequested": false,
                                     "memberName": "mul",
                                     "nodeType": "MemberAccess",
-                                    "referencedDeclaration": 2410,
+                                    "referencedDeclaration": 2421,
                                     "src": "9338:12:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                       "typeString": "function (uint256,uint256) pure returns (uint256)"
                                     }
                                   },
-                                  "id": 1574,
+                                  "id": 1585,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
@@ -14191,21 +14191,21 @@
                                     "typeString": "uint256"
                                   }
                                 },
-                                "id": 1575,
+                                "id": 1586,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
                                 "lValueRequested": false,
                                 "memberName": "sub",
                                 "nodeType": "MemberAccess",
-                                "referencedDeclaration": 2382,
+                                "referencedDeclaration": 2393,
                                 "src": "9338:23:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                   "typeString": "function (uint256,uint256) pure returns (uint256)"
                                 }
                               },
-                              "id": 1580,
+                              "id": 1591,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -14224,15 +14224,15 @@
                           },
                           {
                             "assignments": [
-                              1583
+                              1594
                             ],
                             "declarations": [
                               {
                                 "constant": false,
-                                "id": 1583,
+                                "id": 1594,
                                 "name": "balance1Adjusted",
                                 "nodeType": "VariableDeclaration",
-                                "scope": 1615,
+                                "scope": 1626,
                                 "src": "9397:21:2",
                                 "stateVariable": false,
                                 "storageLocation": "default",
@@ -14241,7 +14241,7 @@
                                   "typeString": "uint256"
                                 },
                                 "typeName": {
-                                  "id": 1582,
+                                  "id": 1593,
                                   "name": "uint",
                                   "nodeType": "ElementaryTypeName",
                                   "src": "9397:4:2",
@@ -14254,7 +14254,7 @@
                                 "visibility": "internal"
                               }
                             ],
-                            "id": 1594,
+                            "id": 1605,
                             "initialValue": {
                               "argumentTypes": null,
                               "arguments": [
@@ -14263,11 +14263,11 @@
                                   "arguments": [
                                     {
                                       "argumentTypes": null,
-                                      "id": 1591,
+                                      "id": 1602,
                                       "name": "swapFee",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 684,
+                                      "referencedDeclaration": 695,
                                       "src": "9459:7:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint8",
@@ -14284,32 +14284,32 @@
                                     ],
                                     "expression": {
                                       "argumentTypes": null,
-                                      "id": 1589,
+                                      "id": 1600,
                                       "name": "amount1In",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 1540,
+                                      "referencedDeclaration": 1551,
                                       "src": "9445:9:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint256",
                                         "typeString": "uint256"
                                       }
                                     },
-                                    "id": 1590,
+                                    "id": 1601,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
                                     "lValueRequested": false,
                                     "memberName": "mul",
                                     "nodeType": "MemberAccess",
-                                    "referencedDeclaration": 2410,
+                                    "referencedDeclaration": 2421,
                                     "src": "9445:13:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                       "typeString": "function (uint256,uint256) pure returns (uint256)"
                                     }
                                   },
-                                  "id": 1592,
+                                  "id": 1603,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
@@ -14337,7 +14337,7 @@
                                     {
                                       "argumentTypes": null,
                                       "hexValue": "3130303030",
-                                      "id": 1586,
+                                      "id": 1597,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": true,
@@ -14362,32 +14362,32 @@
                                     ],
                                     "expression": {
                                       "argumentTypes": null,
-                                      "id": 1584,
+                                      "id": 1595,
                                       "name": "balance1",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 1443,
+                                      "referencedDeclaration": 1454,
                                       "src": "9421:8:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint256",
                                         "typeString": "uint256"
                                       }
                                     },
-                                    "id": 1585,
+                                    "id": 1596,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
                                     "lValueRequested": false,
                                     "memberName": "mul",
                                     "nodeType": "MemberAccess",
-                                    "referencedDeclaration": 2410,
+                                    "referencedDeclaration": 2421,
                                     "src": "9421:12:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                       "typeString": "function (uint256,uint256) pure returns (uint256)"
                                     }
                                   },
-                                  "id": 1587,
+                                  "id": 1598,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
@@ -14401,21 +14401,21 @@
                                     "typeString": "uint256"
                                   }
                                 },
-                                "id": 1588,
+                                "id": 1599,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
                                 "lValueRequested": false,
                                 "memberName": "sub",
                                 "nodeType": "MemberAccess",
-                                "referencedDeclaration": 2382,
+                                "referencedDeclaration": 2393,
                                 "src": "9421:23:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                   "typeString": "function (uint256,uint256) pure returns (uint256)"
                                 }
                               },
-                              "id": 1593,
+                              "id": 1604,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -14442,7 +14442,7 @@
                                     "typeIdentifier": "t_uint256",
                                     "typeString": "uint256"
                                   },
-                                  "id": 1611,
+                                  "id": 1622,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
@@ -14452,11 +14452,11 @@
                                     "arguments": [
                                       {
                                         "argumentTypes": null,
-                                        "id": 1598,
+                                        "id": 1609,
                                         "name": "balance1Adjusted",
                                         "nodeType": "Identifier",
                                         "overloadedDeclarations": [],
-                                        "referencedDeclaration": 1583,
+                                        "referencedDeclaration": 1594,
                                         "src": "9509:16:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_uint256",
@@ -14473,32 +14473,32 @@
                                       ],
                                       "expression": {
                                         "argumentTypes": null,
-                                        "id": 1596,
+                                        "id": 1607,
                                         "name": "balance0Adjusted",
                                         "nodeType": "Identifier",
                                         "overloadedDeclarations": [],
-                                        "referencedDeclaration": 1570,
+                                        "referencedDeclaration": 1581,
                                         "src": "9488:16:2",
                                         "typeDescriptions": {
                                           "typeIdentifier": "t_uint256",
                                           "typeString": "uint256"
                                         }
                                       },
-                                      "id": 1597,
+                                      "id": 1608,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": false,
                                       "lValueRequested": false,
                                       "memberName": "mul",
                                       "nodeType": "MemberAccess",
-                                      "referencedDeclaration": 2410,
+                                      "referencedDeclaration": 2421,
                                       "src": "9488:20:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                         "typeString": "function (uint256,uint256) pure returns (uint256)"
                                       }
                                     },
-                                    "id": 1599,
+                                    "id": 1610,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
@@ -14523,7 +14523,7 @@
                                           "typeIdentifier": "t_rational_100000000_by_1",
                                           "typeString": "int_const 100000000"
                                         },
-                                        "id": 1609,
+                                        "id": 1620,
                                         "isConstant": false,
                                         "isLValue": false,
                                         "isPure": true,
@@ -14531,7 +14531,7 @@
                                         "leftExpression": {
                                           "argumentTypes": null,
                                           "hexValue": "3130303030",
-                                          "id": 1607,
+                                          "id": 1618,
                                           "isConstant": false,
                                           "isLValue": false,
                                           "isPure": true,
@@ -14551,7 +14551,7 @@
                                         "rightExpression": {
                                           "argumentTypes": null,
                                           "hexValue": "32",
-                                          "id": 1608,
+                                          "id": 1619,
                                           "isConstant": false,
                                           "isLValue": false,
                                           "isPure": true,
@@ -14585,11 +14585,11 @@
                                         "arguments": [
                                           {
                                             "argumentTypes": null,
-                                            "id": 1604,
+                                            "id": 1615,
                                             "name": "_reserve1",
                                             "nodeType": "Identifier",
                                             "overloadedDeclarations": [],
-                                            "referencedDeclaration": 1424,
+                                            "referencedDeclaration": 1435,
                                             "src": "9550:9:2",
                                             "typeDescriptions": {
                                               "typeIdentifier": "t_uint112",
@@ -14609,11 +14609,11 @@
                                             "arguments": [
                                               {
                                                 "argumentTypes": null,
-                                                "id": 1601,
+                                                "id": 1612,
                                                 "name": "_reserve0",
                                                 "nodeType": "Identifier",
                                                 "overloadedDeclarations": [],
-                                                "referencedDeclaration": 1422,
+                                                "referencedDeclaration": 1433,
                                                 "src": "9535:9:2",
                                                 "typeDescriptions": {
                                                   "typeIdentifier": "t_uint112",
@@ -14628,7 +14628,7 @@
                                                   "typeString": "uint112"
                                                 }
                                               ],
-                                              "id": 1600,
+                                              "id": 1611,
                                               "isConstant": false,
                                               "isLValue": false,
                                               "isPure": true,
@@ -14641,7 +14641,7 @@
                                               },
                                               "typeName": "uint"
                                             },
-                                            "id": 1602,
+                                            "id": 1613,
                                             "isConstant": false,
                                             "isLValue": false,
                                             "isPure": false,
@@ -14655,21 +14655,21 @@
                                               "typeString": "uint256"
                                             }
                                           },
-                                          "id": 1603,
+                                          "id": 1614,
                                           "isConstant": false,
                                           "isLValue": false,
                                           "isPure": false,
                                           "lValueRequested": false,
                                           "memberName": "mul",
                                           "nodeType": "MemberAccess",
-                                          "referencedDeclaration": 2410,
+                                          "referencedDeclaration": 2421,
                                           "src": "9530:19:2",
                                           "typeDescriptions": {
                                             "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                             "typeString": "function (uint256,uint256) pure returns (uint256)"
                                           }
                                         },
-                                        "id": 1605,
+                                        "id": 1616,
                                         "isConstant": false,
                                         "isLValue": false,
                                         "isPure": false,
@@ -14683,21 +14683,21 @@
                                           "typeString": "uint256"
                                         }
                                       },
-                                      "id": 1606,
+                                      "id": 1617,
                                       "isConstant": false,
                                       "isLValue": false,
                                       "isPure": false,
                                       "lValueRequested": false,
                                       "memberName": "mul",
                                       "nodeType": "MemberAccess",
-                                      "referencedDeclaration": 2410,
+                                      "referencedDeclaration": 2421,
                                       "src": "9530:34:2",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                                         "typeString": "function (uint256,uint256) pure returns (uint256)"
                                       }
                                     },
-                                    "id": 1610,
+                                    "id": 1621,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
@@ -14720,7 +14720,7 @@
                                 {
                                   "argumentTypes": null,
                                   "hexValue": "445873776170506169723a204b",
-                                  "id": 1612,
+                                  "id": 1623,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": true,
@@ -14747,21 +14747,21 @@
                                     "typeString": "literal_string \"DXswapPair: K\""
                                   }
                                 ],
-                                "id": 1595,
+                                "id": 1606,
                                 "name": "require",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [
-                                  2489,
-                                  2490
+                                  2500,
+                                  2501
                                 ],
-                                "referencedDeclaration": 2490,
+                                "referencedDeclaration": 2501,
                                 "src": "9480:7:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                                   "typeString": "function (bool,string memory) pure"
                                 }
                               },
-                              "id": 1613,
+                              "id": 1624,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
@@ -14775,7 +14775,7 @@
                                 "typeString": "tuple()"
                               }
                             },
-                            "id": 1614,
+                            "id": 1625,
                             "nodeType": "ExpressionStatement",
                             "src": "9480:112:2"
                           }
@@ -14790,11 +14790,11 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1619,
+                        "id": 1630,
                         "name": "balance0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1440,
+                        "referencedDeclaration": 1451,
                         "src": "9631:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -14803,11 +14803,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1620,
+                        "id": 1631,
                         "name": "balance1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1443,
+                        "referencedDeclaration": 1454,
                         "src": "9641:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -14816,11 +14816,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1621,
+                        "id": 1632,
                         "name": "_reserve0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1422,
+                        "referencedDeclaration": 1433,
                         "src": "9651:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -14829,11 +14829,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1622,
+                        "id": 1633,
                         "name": "_reserve1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1424,
+                        "referencedDeclaration": 1435,
                         "src": "9662:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -14860,18 +14860,18 @@
                           "typeString": "uint112"
                         }
                       ],
-                      "id": 1618,
+                      "id": 1629,
                       "name": "_update",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 974,
+                      "referencedDeclaration": 985,
                       "src": "9623:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$_t_uint256_$_t_uint112_$_t_uint112_$returns$__$",
                         "typeString": "function (uint256,uint256,uint112,uint112)"
                       }
                     },
-                    "id": 1623,
+                    "id": 1634,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -14885,7 +14885,7 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1624,
+                  "id": 1635,
                   "nodeType": "ExpressionStatement",
                   "src": "9623:49:2"
                 },
@@ -14897,18 +14897,18 @@
                         "argumentTypes": null,
                         "expression": {
                           "argumentTypes": null,
-                          "id": 1626,
+                          "id": 1637,
                           "name": "msg",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2486,
+                          "referencedDeclaration": 2497,
                           "src": "9692:3:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_magic_message",
                             "typeString": "msg"
                           }
                         },
-                        "id": 1627,
+                        "id": 1638,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -14924,11 +14924,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1628,
+                        "id": 1639,
                         "name": "amount0In",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1524,
+                        "referencedDeclaration": 1535,
                         "src": "9704:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -14937,11 +14937,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1629,
+                        "id": 1640,
                         "name": "amount1In",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1540,
+                        "referencedDeclaration": 1551,
                         "src": "9715:9:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -14950,11 +14950,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1630,
+                        "id": 1641,
                         "name": "amount0Out",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1399,
+                        "referencedDeclaration": 1410,
                         "src": "9726:10:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -14963,11 +14963,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1631,
+                        "id": 1642,
                         "name": "amount1Out",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1401,
+                        "referencedDeclaration": 1412,
                         "src": "9738:10:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -14976,11 +14976,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1632,
+                        "id": 1643,
                         "name": "to",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1403,
+                        "referencedDeclaration": 1414,
                         "src": "9750:2:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -15015,20 +15015,20 @@
                           "typeString": "address"
                         }
                       ],
-                      "id": 1625,
+                      "id": 1636,
                       "name": "Swap",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        802
+                        813
                       ],
-                      "referencedDeclaration": 802,
+                      "referencedDeclaration": 813,
                       "src": "9687:4:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_uint256_$_t_uint256_$_t_uint256_$_t_address_$returns$__$",
                         "typeString": "function (address,uint256,uint256,uint256,uint256,address)"
                       }
                     },
-                    "id": 1633,
+                    "id": 1644,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -15042,27 +15042,27 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1634,
+                  "id": 1645,
                   "nodeType": "EmitStatement",
                   "src": "9682:71:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 1636,
+            "id": 1647,
             "implemented": true,
             "kind": "function",
             "modifiers": [
               {
                 "arguments": null,
-                "id": 1408,
+                "id": 1419,
                 "modifierName": {
                   "argumentTypes": null,
-                  "id": 1407,
+                  "id": 1418,
                   "name": "lock",
                   "nodeType": "Identifier",
                   "overloadedDeclarations": [],
-                  "referencedDeclaration": 706,
+                  "referencedDeclaration": 717,
                   "src": "7932:4:2",
                   "typeDescriptions": {
                     "typeIdentifier": "t_modifier$__$",
@@ -15076,15 +15076,15 @@
             "name": "swap",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1406,
+              "id": 1417,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1399,
+                  "id": 1410,
                   "name": "amount0Out",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1636,
+                  "scope": 1647,
                   "src": "7856:15:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -15093,7 +15093,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1398,
+                    "id": 1409,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "7856:4:2",
@@ -15107,10 +15107,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1401,
+                  "id": 1412,
                   "name": "amount1Out",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1636,
+                  "scope": 1647,
                   "src": "7873:15:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -15119,7 +15119,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1400,
+                    "id": 1411,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "7873:4:2",
@@ -15133,10 +15133,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1403,
+                  "id": 1414,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1636,
+                  "scope": 1647,
                   "src": "7890:10:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -15145,7 +15145,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1402,
+                    "id": 1413,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "7890:7:2",
@@ -15160,10 +15160,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1405,
+                  "id": 1416,
                   "name": "data",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1636,
+                  "scope": 1647,
                   "src": "7902:19:2",
                   "stateVariable": false,
                   "storageLocation": "calldata",
@@ -15172,7 +15172,7 @@
                     "typeString": "bytes"
                   },
                   "typeName": {
-                    "id": 1404,
+                    "id": 1415,
                     "name": "bytes",
                     "nodeType": "ElementaryTypeName",
                     "src": "7902:5:2",
@@ -15188,34 +15188,34 @@
               "src": "7855:67:2"
             },
             "returnParameters": {
-              "id": 1409,
+              "id": 1420,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "7937:0:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "7842:1918:2",
             "stateMutability": "nonpayable",
-            "superFunction": 2155,
+            "superFunction": 2166,
             "visibility": "external"
           },
           {
             "body": {
-              "id": 1683,
+              "id": 1694,
               "nodeType": "Block",
               "src": "9846:289:2",
               "statements": [
                 {
                   "assignments": [
-                    1644
+                    1655
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1644,
+                      "id": 1655,
                       "name": "_token0",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1683,
+                      "scope": 1694,
                       "src": "9856:15:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -15224,7 +15224,7 @@
                         "typeString": "address"
                       },
                       "typeName": {
-                        "id": 1643,
+                        "id": 1654,
                         "name": "address",
                         "nodeType": "ElementaryTypeName",
                         "src": "9856:7:2",
@@ -15238,14 +15238,14 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1646,
+                  "id": 1657,
                   "initialValue": {
                     "argumentTypes": null,
-                    "id": 1645,
+                    "id": 1656,
                     "name": "token0",
                     "nodeType": "Identifier",
                     "overloadedDeclarations": [],
-                    "referencedDeclaration": 667,
+                    "referencedDeclaration": 678,
                     "src": "9874:6:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -15257,15 +15257,15 @@
                 },
                 {
                   "assignments": [
-                    1648
+                    1659
                   ],
                   "declarations": [
                     {
                       "constant": false,
-                      "id": 1648,
+                      "id": 1659,
                       "name": "_token1",
                       "nodeType": "VariableDeclaration",
-                      "scope": 1683,
+                      "scope": 1694,
                       "src": "9905:15:2",
                       "stateVariable": false,
                       "storageLocation": "default",
@@ -15274,7 +15274,7 @@
                         "typeString": "address"
                       },
                       "typeName": {
-                        "id": 1647,
+                        "id": 1658,
                         "name": "address",
                         "nodeType": "ElementaryTypeName",
                         "src": "9905:7:2",
@@ -15288,14 +15288,14 @@
                       "visibility": "internal"
                     }
                   ],
-                  "id": 1650,
+                  "id": 1661,
                   "initialValue": {
                     "argumentTypes": null,
-                    "id": 1649,
+                    "id": 1660,
                     "name": "token1",
                     "nodeType": "Identifier",
                     "overloadedDeclarations": [],
-                    "referencedDeclaration": 669,
+                    "referencedDeclaration": 680,
                     "src": "9923:6:2",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -15311,11 +15311,11 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1652,
+                        "id": 1663,
                         "name": "_token0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1644,
+                        "referencedDeclaration": 1655,
                         "src": "9968:7:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -15324,11 +15324,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1653,
+                        "id": 1664,
                         "name": "to",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1638,
+                        "referencedDeclaration": 1649,
                         "src": "9977:2:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -15340,11 +15340,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1663,
+                            "id": 1674,
                             "name": "reserve0",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 671,
+                            "referencedDeclaration": 682,
                             "src": "10026:8:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint112",
@@ -15367,14 +15367,14 @@
                                 "arguments": [
                                   {
                                     "argumentTypes": null,
-                                    "id": 1659,
+                                    "id": 1670,
                                     "name": "this",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 2518,
+                                    "referencedDeclaration": 2529,
                                     "src": "10015:4:2",
                                     "typeDescriptions": {
-                                      "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                      "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                       "typeString": "contract DXswapPair"
                                     }
                                   }
@@ -15382,11 +15382,11 @@
                                 "expression": {
                                   "argumentTypes": [
                                     {
-                                      "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                      "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                       "typeString": "contract DXswapPair"
                                     }
                                   ],
-                                  "id": 1658,
+                                  "id": 1669,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": true,
@@ -15399,7 +15399,7 @@
                                   },
                                   "typeName": "address"
                                 },
-                                "id": 1660,
+                                "id": 1671,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
@@ -15426,11 +15426,11 @@
                                 "arguments": [
                                   {
                                     "argumentTypes": null,
-                                    "id": 1655,
+                                    "id": 1666,
                                     "name": "_token0",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 1644,
+                                    "referencedDeclaration": 1655,
                                     "src": "9988:7:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_address",
@@ -15445,18 +15445,18 @@
                                       "typeString": "address"
                                     }
                                   ],
-                                  "id": 1654,
+                                  "id": 1665,
                                   "name": "IERC20",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2260,
+                                  "referencedDeclaration": 2271,
                                   "src": "9981:6:2",
                                   "typeDescriptions": {
-                                    "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                                    "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                                     "typeString": "type(contract IERC20)"
                                   }
                                 },
-                                "id": 1656,
+                                "id": 1667,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
@@ -15466,25 +15466,25 @@
                                 "nodeType": "FunctionCall",
                                 "src": "9981:15:2",
                                 "typeDescriptions": {
-                                  "typeIdentifier": "t_contract$_IERC20_$2260",
+                                  "typeIdentifier": "t_contract$_IERC20_$2271",
                                   "typeString": "contract IERC20"
                                 }
                               },
-                              "id": 1657,
+                              "id": 1668,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
                               "lValueRequested": false,
                               "memberName": "balanceOf",
                               "nodeType": "MemberAccess",
-                              "referencedDeclaration": 2221,
+                              "referencedDeclaration": 2232,
                               "src": "9981:25:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                                 "typeString": "function (address) view external returns (uint256)"
                               }
                             },
-                            "id": 1661,
+                            "id": 1672,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -15498,21 +15498,21 @@
                               "typeString": "uint256"
                             }
                           },
-                          "id": 1662,
+                          "id": 1673,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "memberName": "sub",
                           "nodeType": "MemberAccess",
-                          "referencedDeclaration": 2382,
+                          "referencedDeclaration": 2393,
                           "src": "9981:44:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                             "typeString": "function (uint256,uint256) pure returns (uint256)"
                           }
                         },
-                        "id": 1664,
+                        "id": 1675,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -15542,18 +15542,18 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 1651,
+                      "id": 1662,
                       "name": "_safeTransfer",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 770,
+                      "referencedDeclaration": 781,
                       "src": "9954:13:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_address_$_t_address_$_t_uint256_$returns$__$",
                         "typeString": "function (address,address,uint256)"
                       }
                     },
-                    "id": 1665,
+                    "id": 1676,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -15567,7 +15567,7 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1666,
+                  "id": 1677,
                   "nodeType": "ExpressionStatement",
                   "src": "9954:82:2"
                 },
@@ -15577,11 +15577,11 @@
                     "arguments": [
                       {
                         "argumentTypes": null,
-                        "id": 1668,
+                        "id": 1679,
                         "name": "_token1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1648,
+                        "referencedDeclaration": 1659,
                         "src": "10060:7:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -15590,11 +15590,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1669,
+                        "id": 1680,
                         "name": "to",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 1638,
+                        "referencedDeclaration": 1649,
                         "src": "10069:2:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_address",
@@ -15606,11 +15606,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 1679,
+                            "id": 1690,
                             "name": "reserve1",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 673,
+                            "referencedDeclaration": 684,
                             "src": "10118:8:2",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint112",
@@ -15633,14 +15633,14 @@
                                 "arguments": [
                                   {
                                     "argumentTypes": null,
-                                    "id": 1675,
+                                    "id": 1686,
                                     "name": "this",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 2518,
+                                    "referencedDeclaration": 2529,
                                     "src": "10107:4:2",
                                     "typeDescriptions": {
-                                      "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                      "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                       "typeString": "contract DXswapPair"
                                     }
                                   }
@@ -15648,11 +15648,11 @@
                                 "expression": {
                                   "argumentTypes": [
                                     {
-                                      "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                      "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                       "typeString": "contract DXswapPair"
                                     }
                                   ],
-                                  "id": 1674,
+                                  "id": 1685,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": true,
@@ -15665,7 +15665,7 @@
                                   },
                                   "typeName": "address"
                                 },
-                                "id": 1676,
+                                "id": 1687,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
@@ -15692,11 +15692,11 @@
                                 "arguments": [
                                   {
                                     "argumentTypes": null,
-                                    "id": 1671,
+                                    "id": 1682,
                                     "name": "_token1",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 1648,
+                                    "referencedDeclaration": 1659,
                                     "src": "10080:7:2",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_address",
@@ -15711,18 +15711,18 @@
                                       "typeString": "address"
                                     }
                                   ],
-                                  "id": 1670,
+                                  "id": 1681,
                                   "name": "IERC20",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2260,
+                                  "referencedDeclaration": 2271,
                                   "src": "10073:6:2",
                                   "typeDescriptions": {
-                                    "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                                    "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                                     "typeString": "type(contract IERC20)"
                                   }
                                 },
-                                "id": 1672,
+                                "id": 1683,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
@@ -15732,25 +15732,25 @@
                                 "nodeType": "FunctionCall",
                                 "src": "10073:15:2",
                                 "typeDescriptions": {
-                                  "typeIdentifier": "t_contract$_IERC20_$2260",
+                                  "typeIdentifier": "t_contract$_IERC20_$2271",
                                   "typeString": "contract IERC20"
                                 }
                               },
-                              "id": 1673,
+                              "id": 1684,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
                               "lValueRequested": false,
                               "memberName": "balanceOf",
                               "nodeType": "MemberAccess",
-                              "referencedDeclaration": 2221,
+                              "referencedDeclaration": 2232,
                               "src": "10073:25:2",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                                 "typeString": "function (address) view external returns (uint256)"
                               }
                             },
-                            "id": 1677,
+                            "id": 1688,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -15764,21 +15764,21 @@
                               "typeString": "uint256"
                             }
                           },
-                          "id": 1678,
+                          "id": 1689,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "memberName": "sub",
                           "nodeType": "MemberAccess",
-                          "referencedDeclaration": 2382,
+                          "referencedDeclaration": 2393,
                           "src": "10073:44:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_internal_pure$_t_uint256_$_t_uint256_$returns$_t_uint256_$bound_to$_t_uint256_$",
                             "typeString": "function (uint256,uint256) pure returns (uint256)"
                           }
                         },
-                        "id": 1680,
+                        "id": 1691,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -15808,18 +15808,18 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 1667,
+                      "id": 1678,
                       "name": "_safeTransfer",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 770,
+                      "referencedDeclaration": 781,
                       "src": "10046:13:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_address_$_t_address_$_t_uint256_$returns$__$",
                         "typeString": "function (address,address,uint256)"
                       }
                     },
-                    "id": 1681,
+                    "id": 1692,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -15833,27 +15833,27 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1682,
+                  "id": 1693,
                   "nodeType": "ExpressionStatement",
                   "src": "10046:82:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 1684,
+            "id": 1695,
             "implemented": true,
             "kind": "function",
             "modifiers": [
               {
                 "arguments": null,
-                "id": 1641,
+                "id": 1652,
                 "modifierName": {
                   "argumentTypes": null,
-                  "id": 1640,
+                  "id": 1651,
                   "name": "lock",
                   "nodeType": "Identifier",
                   "overloadedDeclarations": [],
-                  "referencedDeclaration": 706,
+                  "referencedDeclaration": 717,
                   "src": "9841:4:2",
                   "typeDescriptions": {
                     "typeIdentifier": "t_modifier$__$",
@@ -15867,15 +15867,15 @@
             "name": "skim",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1639,
+              "id": 1650,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1638,
+                  "id": 1649,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1684,
+                  "scope": 1695,
                   "src": "9820:10:2",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -15884,7 +15884,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1637,
+                    "id": 1648,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "9820:7:2",
@@ -15901,20 +15901,20 @@
               "src": "9819:12:2"
             },
             "returnParameters": {
-              "id": 1642,
+              "id": 1653,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "9846:0:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "9806:329:2",
             "stateMutability": "nonpayable",
-            "superFunction": 2160,
+            "superFunction": 2171,
             "visibility": "external"
           },
           {
             "body": {
-              "id": 1710,
+              "id": 1721,
               "nodeType": "Block",
               "src": "10211:126:2",
               "statements": [
@@ -15930,14 +15930,14 @@
                             "arguments": [
                               {
                                 "argumentTypes": null,
-                                "id": 1695,
+                                "id": 1706,
                                 "name": "this",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2518,
+                                "referencedDeclaration": 2529,
                                 "src": "10262:4:2",
                                 "typeDescriptions": {
-                                  "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                  "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                   "typeString": "contract DXswapPair"
                                 }
                               }
@@ -15945,11 +15945,11 @@
                             "expression": {
                               "argumentTypes": [
                                 {
-                                  "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                  "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                   "typeString": "contract DXswapPair"
                                 }
                               ],
-                              "id": 1694,
+                              "id": 1705,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
@@ -15962,7 +15962,7 @@
                               },
                               "typeName": "address"
                             },
-                            "id": 1696,
+                            "id": 1707,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -15989,11 +15989,11 @@
                             "arguments": [
                               {
                                 "argumentTypes": null,
-                                "id": 1691,
+                                "id": 1702,
                                 "name": "token0",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 667,
+                                "referencedDeclaration": 678,
                                 "src": "10236:6:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
@@ -16008,18 +16008,18 @@
                                   "typeString": "address"
                                 }
                               ],
-                              "id": 1690,
+                              "id": 1701,
                               "name": "IERC20",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 2260,
+                              "referencedDeclaration": 2271,
                               "src": "10229:6:2",
                               "typeDescriptions": {
-                                "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                                "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                                 "typeString": "type(contract IERC20)"
                               }
                             },
-                            "id": 1692,
+                            "id": 1703,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -16029,25 +16029,25 @@
                             "nodeType": "FunctionCall",
                             "src": "10229:14:2",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_contract$_IERC20_$2260",
+                              "typeIdentifier": "t_contract$_IERC20_$2271",
                               "typeString": "contract IERC20"
                             }
                           },
-                          "id": 1693,
+                          "id": 1704,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "memberName": "balanceOf",
                           "nodeType": "MemberAccess",
-                          "referencedDeclaration": 2221,
+                          "referencedDeclaration": 2232,
                           "src": "10229:24:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                             "typeString": "function (address) view external returns (uint256)"
                           }
                         },
-                        "id": 1697,
+                        "id": 1708,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -16069,14 +16069,14 @@
                             "arguments": [
                               {
                                 "argumentTypes": null,
-                                "id": 1703,
+                                "id": 1714,
                                 "name": "this",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2518,
+                                "referencedDeclaration": 2529,
                                 "src": "10303:4:2",
                                 "typeDescriptions": {
-                                  "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                  "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                   "typeString": "contract DXswapPair"
                                 }
                               }
@@ -16084,11 +16084,11 @@
                             "expression": {
                               "argumentTypes": [
                                 {
-                                  "typeIdentifier": "t_contract$_DXswapPair_$1712",
+                                  "typeIdentifier": "t_contract$_DXswapPair_$1723",
                                   "typeString": "contract DXswapPair"
                                 }
                               ],
-                              "id": 1702,
+                              "id": 1713,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
@@ -16101,7 +16101,7 @@
                               },
                               "typeName": "address"
                             },
-                            "id": 1704,
+                            "id": 1715,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -16128,11 +16128,11 @@
                             "arguments": [
                               {
                                 "argumentTypes": null,
-                                "id": 1699,
+                                "id": 1710,
                                 "name": "token1",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 669,
+                                "referencedDeclaration": 680,
                                 "src": "10277:6:2",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_address",
@@ -16147,18 +16147,18 @@
                                   "typeString": "address"
                                 }
                               ],
-                              "id": 1698,
+                              "id": 1709,
                               "name": "IERC20",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 2260,
+                              "referencedDeclaration": 2271,
                               "src": "10270:6:2",
                               "typeDescriptions": {
-                                "typeIdentifier": "t_type$_t_contract$_IERC20_$2260_$",
+                                "typeIdentifier": "t_type$_t_contract$_IERC20_$2271_$",
                                 "typeString": "type(contract IERC20)"
                               }
                             },
-                            "id": 1700,
+                            "id": 1711,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -16168,25 +16168,25 @@
                             "nodeType": "FunctionCall",
                             "src": "10270:14:2",
                             "typeDescriptions": {
-                              "typeIdentifier": "t_contract$_IERC20_$2260",
+                              "typeIdentifier": "t_contract$_IERC20_$2271",
                               "typeString": "contract IERC20"
                             }
                           },
-                          "id": 1701,
+                          "id": 1712,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "memberName": "balanceOf",
                           "nodeType": "MemberAccess",
-                          "referencedDeclaration": 2221,
+                          "referencedDeclaration": 2232,
                           "src": "10270:24:2",
                           "typeDescriptions": {
                             "typeIdentifier": "t_function_external_view$_t_address_$returns$_t_uint256_$",
                             "typeString": "function (address) view external returns (uint256)"
                           }
                         },
-                        "id": 1705,
+                        "id": 1716,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -16202,11 +16202,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1706,
+                        "id": 1717,
                         "name": "reserve0",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 671,
+                        "referencedDeclaration": 682,
                         "src": "10311:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -16215,11 +16215,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 1707,
+                        "id": 1718,
                         "name": "reserve1",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 673,
+                        "referencedDeclaration": 684,
                         "src": "10321:8:2",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint112",
@@ -16246,18 +16246,18 @@
                           "typeString": "uint112"
                         }
                       ],
-                      "id": 1689,
+                      "id": 1700,
                       "name": "_update",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 974,
+                      "referencedDeclaration": 985,
                       "src": "10221:7:2",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_internal_nonpayable$_t_uint256_$_t_uint256_$_t_uint112_$_t_uint112_$returns$__$",
                         "typeString": "function (uint256,uint256,uint112,uint112)"
                       }
                     },
-                    "id": 1708,
+                    "id": 1719,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -16271,27 +16271,27 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 1709,
+                  "id": 1720,
                   "nodeType": "ExpressionStatement",
                   "src": "10221:109:2"
                 }
               ]
             },
             "documentation": null,
-            "id": 1711,
+            "id": 1722,
             "implemented": true,
             "kind": "function",
             "modifiers": [
               {
                 "arguments": null,
-                "id": 1687,
+                "id": 1698,
                 "modifierName": {
                   "argumentTypes": null,
-                  "id": 1686,
+                  "id": 1697,
                   "name": "lock",
                   "nodeType": "Identifier",
                   "overloadedDeclarations": [],
-                  "referencedDeclaration": 706,
+                  "referencedDeclaration": 717,
                   "src": "10206:4:2",
                   "typeDescriptions": {
                     "typeIdentifier": "t_modifier$__$",
@@ -16305,25 +16305,25 @@
             "name": "sync",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1685,
+              "id": 1696,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "10194:2:2"
             },
             "returnParameters": {
-              "id": 1688,
+              "id": 1699,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "10211:0:2"
             },
-            "scope": 1712,
+            "scope": 1723,
             "src": "10181:156:2",
             "stateMutability": "nonpayable",
-            "superFunction": 2163,
+            "superFunction": 2174,
             "visibility": "external"
           }
         ],
-        "scope": 1713,
+        "scope": 1724,
         "src": "278:10061:2"
       }
     ],

--- a/build/contracts/ERC20.json
+++ b/build/contracts/ERC20.json
@@ -359,14 +359,14 @@
     "absolutePath": "contracts/test/ERC20.sol",
     "exportedSymbols": {
       "ERC20": [
-        2471
+        2482
       ]
     },
-    "id": 2472,
+    "id": 2483,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 2455,
+        "id": 2466,
         "literals": [
           "solidity",
           "=",
@@ -379,9 +379,9 @@
       {
         "absolutePath": "contracts/DXswapERC20.sol",
         "file": "../DXswapERC20.sol",
-        "id": 2456,
+        "id": 2467,
         "nodeType": "ImportDirective",
-        "scope": 2472,
+        "scope": 2483,
         "sourceUnit": 385,
         "src": "26:28:11",
         "symbolAliases": [],
@@ -393,7 +393,7 @@
             "arguments": null,
             "baseName": {
               "contractScope": null,
-              "id": 2457,
+              "id": 2468,
               "name": "DXswapERC20",
               "nodeType": "UserDefinedTypeName",
               "referencedDeclaration": 384,
@@ -403,30 +403,30 @@
                 "typeString": "contract DXswapERC20"
               }
             },
-            "id": 2458,
+            "id": 2469,
             "nodeType": "InheritanceSpecifier",
             "src": "74:11:11"
           }
         ],
         "contractDependencies": [
           384,
-          1844
+          1855
         ],
         "contractKind": "contract",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 2471,
+        "id": 2482,
         "linearizedBaseContracts": [
-          2471,
+          2482,
           384,
-          1844
+          1855
         ],
         "name": "ERC20",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "body": {
-              "id": 2469,
+              "id": 2480,
               "nodeType": "Block",
               "src": "130:48:11",
               "statements": [
@@ -438,18 +438,18 @@
                         "argumentTypes": null,
                         "expression": {
                           "argumentTypes": null,
-                          "id": 2464,
+                          "id": 2475,
                           "name": "msg",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2486,
+                          "referencedDeclaration": 2497,
                           "src": "146:3:11",
                           "typeDescriptions": {
                             "typeIdentifier": "t_magic_message",
                             "typeString": "msg"
                           }
                         },
-                        "id": 2465,
+                        "id": 2476,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -465,11 +465,11 @@
                       },
                       {
                         "argumentTypes": null,
-                        "id": 2466,
+                        "id": 2477,
                         "name": "_totalSupply",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 2460,
+                        "referencedDeclaration": 2471,
                         "src": "158:12:11",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -488,7 +488,7 @@
                           "typeString": "uint256"
                         }
                       ],
-                      "id": 2463,
+                      "id": 2474,
                       "name": "_mint",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
@@ -499,7 +499,7 @@
                         "typeString": "function (address,uint256)"
                       }
                     },
-                    "id": 2467,
+                    "id": 2478,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -513,29 +513,29 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 2468,
+                  "id": 2479,
                   "nodeType": "ExpressionStatement",
                   "src": "140:31:11"
                 }
               ]
             },
             "documentation": null,
-            "id": 2470,
+            "id": 2481,
             "implemented": true,
             "kind": "constructor",
             "modifiers": [],
             "name": "",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2461,
+              "id": 2472,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2460,
+                  "id": 2471,
                   "name": "_totalSupply",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2470,
+                  "scope": 2481,
                   "src": "104:17:11",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -544,7 +544,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2459,
+                    "id": 2470,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "104:4:11",
@@ -560,19 +560,19 @@
               "src": "103:19:11"
             },
             "returnParameters": {
-              "id": 2462,
+              "id": 2473,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "130:0:11"
             },
-            "scope": 2471,
+            "scope": 2482,
             "src": "92:86:11",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "public"
           }
         ],
-        "scope": 2472,
+        "scope": 2483,
         "src": "56:124:11"
       }
     ],

--- a/build/contracts/IDXswapCallee.json
+++ b/build/contracts/IDXswapCallee.json
@@ -41,14 +41,14 @@
     "absolutePath": "contracts/interfaces/IDXswapCallee.sol",
     "exportedSymbols": {
       "IDXswapCallee": [
-        1726
+        1737
       ]
     },
-    "id": 1727,
+    "id": 1738,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 1714,
+        "id": 1725,
         "literals": [
           "solidity",
           ">=",
@@ -64,9 +64,9 @@
         "contractKind": "interface",
         "documentation": null,
         "fullyImplemented": false,
-        "id": 1726,
+        "id": 1737,
         "linearizedBaseContracts": [
-          1726
+          1737
         ],
         "name": "IDXswapCallee",
         "nodeType": "ContractDefinition",
@@ -74,22 +74,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1725,
+            "id": 1736,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "DXswapCall",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1723,
+              "id": 1734,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1716,
+                  "id": 1727,
                   "name": "sender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1725,
+                  "scope": 1736,
                   "src": "76:14:3",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -98,7 +98,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1715,
+                    "id": 1726,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "76:7:3",
@@ -113,10 +113,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1718,
+                  "id": 1729,
                   "name": "amount0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1725,
+                  "scope": 1736,
                   "src": "92:12:3",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -125,7 +125,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1717,
+                    "id": 1728,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "92:4:3",
@@ -139,10 +139,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1720,
+                  "id": 1731,
                   "name": "amount1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1725,
+                  "scope": 1736,
                   "src": "106:12:3",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -151,7 +151,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1719,
+                    "id": 1730,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "106:4:3",
@@ -165,10 +165,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1722,
+                  "id": 1733,
                   "name": "data",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1725,
+                  "scope": 1736,
                   "src": "120:19:3",
                   "stateVariable": false,
                   "storageLocation": "calldata",
@@ -177,7 +177,7 @@
                     "typeString": "bytes"
                   },
                   "typeName": {
-                    "id": 1721,
+                    "id": 1732,
                     "name": "bytes",
                     "nodeType": "ElementaryTypeName",
                     "src": "120:5:3",
@@ -193,19 +193,19 @@
               "src": "75:65:3"
             },
             "returnParameters": {
-              "id": 1724,
+              "id": 1735,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "149:0:3"
             },
-            "scope": 1726,
+            "scope": 1737,
             "src": "56:94:3",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "external"
           }
         ],
-        "scope": 1727,
+        "scope": 1738,
         "src": "26:126:3"
       }
     ],

--- a/build/contracts/IDXswapERC20.json
+++ b/build/contracts/IDXswapERC20.json
@@ -347,14 +347,14 @@
     "absolutePath": "contracts/interfaces/IDXswapERC20.sol",
     "exportedSymbols": {
       "IDXswapERC20": [
-        1844
+        1855
       ]
     },
-    "id": 1845,
+    "id": 1856,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 1728,
+        "id": 1739,
         "literals": [
           "solidity",
           ">=",
@@ -370,9 +370,9 @@
         "contractKind": "interface",
         "documentation": null,
         "fullyImplemented": false,
-        "id": 1844,
+        "id": 1855,
         "linearizedBaseContracts": [
-          1844
+          1855
         ],
         "name": "IDXswapERC20",
         "nodeType": "ContractDefinition",
@@ -380,20 +380,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 1736,
+            "id": 1747,
             "name": "Approval",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 1735,
+              "id": 1746,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1730,
+                  "id": 1741,
                   "indexed": true,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1736,
+                  "scope": 1747,
                   "src": "70:21:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -402,7 +402,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1729,
+                    "id": 1740,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "70:7:4",
@@ -417,11 +417,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 1732,
+                  "id": 1743,
                   "indexed": true,
                   "name": "spender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1736,
+                  "scope": 1747,
                   "src": "93:23:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -430,7 +430,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1731,
+                    "id": 1742,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "93:7:4",
@@ -445,11 +445,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 1734,
+                  "id": 1745,
                   "indexed": false,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1736,
+                  "scope": 1747,
                   "src": "118:10:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -458,7 +458,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1733,
+                    "id": 1744,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "118:4:4",
@@ -478,20 +478,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 1744,
+            "id": 1755,
             "name": "Transfer",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 1743,
+              "id": 1754,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1738,
+                  "id": 1749,
                   "indexed": true,
                   "name": "from",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1744,
+                  "scope": 1755,
                   "src": "150:20:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -500,7 +500,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1737,
+                    "id": 1748,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "150:7:4",
@@ -515,11 +515,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 1740,
+                  "id": 1751,
                   "indexed": true,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1744,
+                  "scope": 1755,
                   "src": "172:18:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -528,7 +528,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1739,
+                    "id": 1750,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "172:7:4",
@@ -543,11 +543,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 1742,
+                  "id": 1753,
                   "indexed": false,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1744,
+                  "scope": 1755,
                   "src": "192:10:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -556,7 +556,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1741,
+                    "id": 1752,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "192:4:4",
@@ -576,28 +576,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1749,
+            "id": 1760,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "name",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1745,
+              "id": 1756,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "223:2:4"
             },
             "returnParameters": {
-              "id": 1748,
+              "id": 1759,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1747,
+                  "id": 1758,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1749,
+                  "scope": 1760,
                   "src": "249:13:4",
                   "stateVariable": false,
                   "storageLocation": "memory",
@@ -606,7 +606,7 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 1746,
+                    "id": 1757,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
                     "src": "249:6:4",
@@ -621,37 +621,37 @@
               ],
               "src": "248:15:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "210:54:4",
             "stateMutability": "pure",
-            "superFunction": 1947,
+            "superFunction": 1958,
             "visibility": "external"
           },
           {
             "body": null,
             "documentation": null,
-            "id": 1754,
+            "id": 1765,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "symbol",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1750,
+              "id": 1761,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "284:2:4"
             },
             "returnParameters": {
-              "id": 1753,
+              "id": 1764,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1752,
+                  "id": 1763,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1754,
+                  "scope": 1765,
                   "src": "310:13:4",
                   "stateVariable": false,
                   "storageLocation": "memory",
@@ -660,7 +660,7 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 1751,
+                    "id": 1762,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
                     "src": "310:6:4",
@@ -675,37 +675,37 @@
               ],
               "src": "309:15:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "269:56:4",
             "stateMutability": "pure",
-            "superFunction": 1952,
+            "superFunction": 1963,
             "visibility": "external"
           },
           {
             "body": null,
             "documentation": null,
-            "id": 1759,
+            "id": 1770,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "decimals",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1755,
+              "id": 1766,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "347:2:4"
             },
             "returnParameters": {
-              "id": 1758,
+              "id": 1769,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1757,
+                  "id": 1768,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1759,
+                  "scope": 1770,
                   "src": "373:5:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -714,7 +714,7 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 1756,
+                    "id": 1767,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
                     "src": "373:5:4",
@@ -729,37 +729,37 @@
               ],
               "src": "372:7:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "330:50:4",
             "stateMutability": "pure",
-            "superFunction": 1957,
+            "superFunction": 1968,
             "visibility": "external"
           },
           {
             "body": null,
             "documentation": null,
-            "id": 1764,
+            "id": 1775,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "totalSupply",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1760,
+              "id": 1771,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "405:2:4"
             },
             "returnParameters": {
-              "id": 1763,
+              "id": 1774,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1762,
+                  "id": 1773,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1764,
+                  "scope": 1775,
                   "src": "431:4:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -768,7 +768,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1761,
+                    "id": 1772,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "431:4:4",
@@ -783,31 +783,31 @@
               ],
               "src": "430:6:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "385:52:4",
             "stateMutability": "view",
-            "superFunction": 1962,
+            "superFunction": 1973,
             "visibility": "external"
           },
           {
             "body": null,
             "documentation": null,
-            "id": 1771,
+            "id": 1782,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "balanceOf",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1767,
+              "id": 1778,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1766,
+                  "id": 1777,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1771,
+                  "scope": 1782,
                   "src": "461:13:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -816,7 +816,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1765,
+                    "id": 1776,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "461:7:4",
@@ -833,15 +833,15 @@
               "src": "460:15:4"
             },
             "returnParameters": {
-              "id": 1770,
+              "id": 1781,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1769,
+                  "id": 1780,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1771,
+                  "scope": 1782,
                   "src": "499:4:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -850,7 +850,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1768,
+                    "id": 1779,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "499:4:4",
@@ -865,31 +865,31 @@
               ],
               "src": "498:6:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "442:63:4",
             "stateMutability": "view",
-            "superFunction": 1969,
+            "superFunction": 1980,
             "visibility": "external"
           },
           {
             "body": null,
             "documentation": null,
-            "id": 1780,
+            "id": 1791,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "allowance",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1776,
+              "id": 1787,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1773,
+                  "id": 1784,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1780,
+                  "scope": 1791,
                   "src": "529:13:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -898,7 +898,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1772,
+                    "id": 1783,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "529:7:4",
@@ -913,10 +913,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1775,
+                  "id": 1786,
                   "name": "spender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1780,
+                  "scope": 1791,
                   "src": "544:15:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -925,7 +925,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1774,
+                    "id": 1785,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "544:7:4",
@@ -942,15 +942,15 @@
               "src": "528:32:4"
             },
             "returnParameters": {
-              "id": 1779,
+              "id": 1790,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1778,
+                  "id": 1789,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1780,
+                  "scope": 1791,
                   "src": "584:4:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -959,7 +959,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1777,
+                    "id": 1788,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "584:4:4",
@@ -974,31 +974,31 @@
               ],
               "src": "583:6:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "510:80:4",
             "stateMutability": "view",
-            "superFunction": 1978,
+            "superFunction": 1989,
             "visibility": "external"
           },
           {
             "body": null,
             "documentation": null,
-            "id": 1789,
+            "id": 1800,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "approve",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1785,
+              "id": 1796,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1782,
+                  "id": 1793,
                   "name": "spender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1789,
+                  "scope": 1800,
                   "src": "613:15:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1007,7 +1007,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1781,
+                    "id": 1792,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "613:7:4",
@@ -1022,10 +1022,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1784,
+                  "id": 1795,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1789,
+                  "scope": 1800,
                   "src": "630:10:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1034,7 +1034,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1783,
+                    "id": 1794,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "630:4:4",
@@ -1050,15 +1050,15 @@
               "src": "612:29:4"
             },
             "returnParameters": {
-              "id": 1788,
+              "id": 1799,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1787,
+                  "id": 1798,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1789,
+                  "scope": 1800,
                   "src": "660:4:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1067,7 +1067,7 @@
                     "typeString": "bool"
                   },
                   "typeName": {
-                    "id": 1786,
+                    "id": 1797,
                     "name": "bool",
                     "nodeType": "ElementaryTypeName",
                     "src": "660:4:4",
@@ -1082,118 +1082,10 @@
               ],
               "src": "659:6:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "596:70:4",
             "stateMutability": "nonpayable",
-            "superFunction": 1987,
-            "visibility": "external"
-          },
-          {
-            "body": null,
-            "documentation": null,
-            "id": 1798,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "transfer",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 1794,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 1791,
-                  "name": "to",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 1798,
-                  "src": "689:10:4",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 1790,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "689:7:4",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 1793,
-                  "name": "value",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 1798,
-                  "src": "701:10:4",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 1792,
-                    "name": "uint",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "701:4:4",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                }
-              ],
-              "src": "688:24:4"
-            },
-            "returnParameters": {
-              "id": 1797,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 1796,
-                  "name": "",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 1798,
-                  "src": "731:4:4",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_bool",
-                    "typeString": "bool"
-                  },
-                  "typeName": {
-                    "id": 1795,
-                    "name": "bool",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "731:4:4",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_bool",
-                      "typeString": "bool"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                }
-              ],
-              "src": "730:6:4"
-            },
-            "scope": 1844,
-            "src": "671:66:4",
-            "stateMutability": "nonpayable",
-            "superFunction": 1996,
+            "superFunction": 1998,
             "visibility": "external"
           },
           {
@@ -1203,7 +1095,7 @@
             "implemented": false,
             "kind": "function",
             "modifiers": [],
-            "name": "transferFrom",
+            "name": "transfer",
             "nodeType": "FunctionDefinition",
             "parameters": {
               "id": 1805,
@@ -1211,38 +1103,11 @@
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1800,
-                  "name": "from",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 1809,
-                  "src": "764:12:4",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 1799,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "764:7:4",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
                   "id": 1802,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
                   "scope": 1809,
-                  "src": "778:10:4",
+                  "src": "689:10:4",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1253,7 +1118,7 @@
                     "id": 1801,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "778:7:4",
+                    "src": "689:7:4",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -1269,7 +1134,7 @@
                   "name": "value",
                   "nodeType": "VariableDeclaration",
                   "scope": 1809,
-                  "src": "790:10:4",
+                  "src": "701:10:4",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1278,6 +1143,141 @@
                   },
                   "typeName": {
                     "id": 1803,
+                    "name": "uint",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "701:4:4",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "688:24:4"
+            },
+            "returnParameters": {
+              "id": 1808,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1807,
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1809,
+                  "src": "731:4:4",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  },
+                  "typeName": {
+                    "id": 1806,
+                    "name": "bool",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "731:4:4",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "730:6:4"
+            },
+            "scope": 1855,
+            "src": "671:66:4",
+            "stateMutability": "nonpayable",
+            "superFunction": 2007,
+            "visibility": "external"
+          },
+          {
+            "body": null,
+            "documentation": null,
+            "id": 1820,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "transferFrom",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 1816,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 1811,
+                  "name": "from",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1820,
+                  "src": "764:12:4",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 1810,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "764:7:4",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1813,
+                  "name": "to",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1820,
+                  "src": "778:10:4",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 1812,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "778:7:4",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 1815,
+                  "name": "value",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 1820,
+                  "src": "790:10:4",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 1814,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "790:4:4",
@@ -1293,15 +1293,15 @@
               "src": "763:38:4"
             },
             "returnParameters": {
-              "id": 1808,
+              "id": 1819,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1807,
+                  "id": 1818,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1809,
+                  "scope": 1820,
                   "src": "820:4:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1310,7 +1310,7 @@
                     "typeString": "bool"
                   },
                   "typeName": {
-                    "id": 1806,
+                    "id": 1817,
                     "name": "bool",
                     "nodeType": "ElementaryTypeName",
                     "src": "820:4:4",
@@ -1325,37 +1325,37 @@
               ],
               "src": "819:6:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "742:84:4",
             "stateMutability": "nonpayable",
-            "superFunction": 2007,
+            "superFunction": 2018,
             "visibility": "external"
           },
           {
             "body": null,
             "documentation": null,
-            "id": 1814,
+            "id": 1825,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "DOMAIN_SEPARATOR",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1810,
+              "id": 1821,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "857:2:4"
             },
             "returnParameters": {
-              "id": 1813,
+              "id": 1824,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1812,
+                  "id": 1823,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1814,
+                  "scope": 1825,
                   "src": "883:7:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1364,7 +1364,7 @@
                     "typeString": "bytes32"
                   },
                   "typeName": {
-                    "id": 1811,
+                    "id": 1822,
                     "name": "bytes32",
                     "nodeType": "ElementaryTypeName",
                     "src": "883:7:4",
@@ -1379,37 +1379,37 @@
               ],
               "src": "882:9:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "832:60:4",
             "stateMutability": "view",
-            "superFunction": 2012,
+            "superFunction": 2023,
             "visibility": "external"
           },
           {
             "body": null,
             "documentation": null,
-            "id": 1819,
+            "id": 1830,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "PERMIT_TYPEHASH",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1815,
+              "id": 1826,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "921:2:4"
             },
             "returnParameters": {
-              "id": 1818,
+              "id": 1829,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1817,
+                  "id": 1828,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1819,
+                  "scope": 1830,
                   "src": "947:7:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1418,7 +1418,7 @@
                     "typeString": "bytes32"
                   },
                   "typeName": {
-                    "id": 1816,
+                    "id": 1827,
                     "name": "bytes32",
                     "nodeType": "ElementaryTypeName",
                     "src": "947:7:4",
@@ -1433,31 +1433,31 @@
               ],
               "src": "946:9:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "897:59:4",
             "stateMutability": "pure",
-            "superFunction": 2017,
+            "superFunction": 2028,
             "visibility": "external"
           },
           {
             "body": null,
             "documentation": null,
-            "id": 1826,
+            "id": 1837,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "nonces",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1822,
+              "id": 1833,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1821,
+                  "id": 1832,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1826,
+                  "scope": 1837,
                   "src": "977:13:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1466,7 +1466,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1820,
+                    "id": 1831,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "977:7:4",
@@ -1483,15 +1483,15 @@
               "src": "976:15:4"
             },
             "returnParameters": {
-              "id": 1825,
+              "id": 1836,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1824,
+                  "id": 1835,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1826,
+                  "scope": 1837,
                   "src": "1015:4:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1500,7 +1500,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1823,
+                    "id": 1834,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1015:4:4",
@@ -1515,31 +1515,31 @@
               ],
               "src": "1014:6:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "961:60:4",
             "stateMutability": "view",
-            "superFunction": 2024,
+            "superFunction": 2035,
             "visibility": "external"
           },
           {
             "body": null,
             "documentation": null,
-            "id": 1843,
+            "id": 1854,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "permit",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1841,
+              "id": 1852,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1828,
+                  "id": 1839,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1843,
+                  "scope": 1854,
                   "src": "1043:13:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1548,7 +1548,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1827,
+                    "id": 1838,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1043:7:4",
@@ -1563,10 +1563,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1830,
+                  "id": 1841,
                   "name": "spender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1843,
+                  "scope": 1854,
                   "src": "1058:15:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1575,7 +1575,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1829,
+                    "id": 1840,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1058:7:4",
@@ -1590,10 +1590,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1832,
+                  "id": 1843,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1843,
+                  "scope": 1854,
                   "src": "1075:10:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1602,7 +1602,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1831,
+                    "id": 1842,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1075:4:4",
@@ -1616,10 +1616,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1834,
+                  "id": 1845,
                   "name": "deadline",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1843,
+                  "scope": 1854,
                   "src": "1087:13:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1628,7 +1628,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1833,
+                    "id": 1844,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1087:4:4",
@@ -1642,10 +1642,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1836,
+                  "id": 1847,
                   "name": "v",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1843,
+                  "scope": 1854,
                   "src": "1102:7:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1654,7 +1654,7 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 1835,
+                    "id": 1846,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
                     "src": "1102:5:4",
@@ -1668,10 +1668,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1838,
+                  "id": 1849,
                   "name": "r",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1843,
+                  "scope": 1854,
                   "src": "1111:9:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1680,7 +1680,7 @@
                     "typeString": "bytes32"
                   },
                   "typeName": {
-                    "id": 1837,
+                    "id": 1848,
                     "name": "bytes32",
                     "nodeType": "ElementaryTypeName",
                     "src": "1111:7:4",
@@ -1694,10 +1694,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1840,
+                  "id": 1851,
                   "name": "s",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1843,
+                  "scope": 1854,
                   "src": "1122:9:4",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1706,7 +1706,7 @@
                     "typeString": "bytes32"
                   },
                   "typeName": {
-                    "id": 1839,
+                    "id": 1850,
                     "name": "bytes32",
                     "nodeType": "ElementaryTypeName",
                     "src": "1122:7:4",
@@ -1722,19 +1722,19 @@
               "src": "1042:90:4"
             },
             "returnParameters": {
-              "id": 1842,
+              "id": 1853,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1141:0:4"
             },
-            "scope": 1844,
+            "scope": 1855,
             "src": "1027:115:4",
             "stateMutability": "nonpayable",
-            "superFunction": 2041,
+            "superFunction": 2052,
             "visibility": "external"
           }
         ],
-        "scope": 1845,
+        "scope": 1856,
         "src": "26:1118:4"
       }
     ],

--- a/build/contracts/IDXswapFactory.json
+++ b/build/contracts/IDXswapFactory.json
@@ -240,14 +240,14 @@
     "absolutePath": "contracts/interfaces/IDXswapFactory.sol",
     "exportedSymbols": {
       "IDXswapFactory": [
-        1924
+        1935
       ]
     },
-    "id": 1925,
+    "id": 1936,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 1846,
+        "id": 1857,
         "literals": [
           "solidity",
           ">=",
@@ -263,9 +263,9 @@
         "contractKind": "interface",
         "documentation": null,
         "fullyImplemented": false,
-        "id": 1924,
+        "id": 1935,
         "linearizedBaseContracts": [
-          1924
+          1935
         ],
         "name": "IDXswapFactory",
         "nodeType": "ContractDefinition",
@@ -273,20 +273,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 1856,
+            "id": 1867,
             "name": "PairCreated",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 1855,
+              "id": 1866,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1848,
+                  "id": 1859,
                   "indexed": true,
                   "name": "token0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1856,
+                  "scope": 1867,
                   "src": "75:22:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -295,7 +295,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1847,
+                    "id": 1858,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "75:7:5",
@@ -310,11 +310,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 1850,
+                  "id": 1861,
                   "indexed": true,
                   "name": "token1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1856,
+                  "scope": 1867,
                   "src": "99:22:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -323,7 +323,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1849,
+                    "id": 1860,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "99:7:5",
@@ -338,11 +338,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 1852,
+                  "id": 1863,
                   "indexed": false,
                   "name": "pair",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1856,
+                  "scope": 1867,
                   "src": "123:12:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -351,7 +351,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1851,
+                    "id": 1862,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "123:7:5",
@@ -366,11 +366,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 1854,
+                  "id": 1865,
                   "indexed": false,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1856,
+                  "scope": 1867,
                   "src": "137:4:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -379,7 +379,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1853,
+                    "id": 1864,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "137:4:5",
@@ -399,28 +399,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1861,
+            "id": 1872,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "feeTo",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1857,
+              "id": 1868,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "163:2:5"
             },
             "returnParameters": {
-              "id": 1860,
+              "id": 1871,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1859,
+                  "id": 1870,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1861,
+                  "scope": 1872,
                   "src": "189:7:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -429,7 +429,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1858,
+                    "id": 1869,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "189:7:5",
@@ -445,7 +445,7 @@
               ],
               "src": "188:9:5"
             },
-            "scope": 1924,
+            "scope": 1935,
             "src": "149:49:5",
             "stateMutability": "view",
             "superFunction": null,
@@ -454,28 +454,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1866,
+            "id": 1877,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "protocolFeeDenominator",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1862,
+              "id": 1873,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "234:2:5"
             },
             "returnParameters": {
-              "id": 1865,
+              "id": 1876,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1864,
+                  "id": 1875,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1866,
+                  "scope": 1877,
                   "src": "260:5:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -484,7 +484,7 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 1863,
+                    "id": 1874,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
                     "src": "260:5:5",
@@ -499,7 +499,7 @@
               ],
               "src": "259:7:5"
             },
-            "scope": 1924,
+            "scope": 1935,
             "src": "203:64:5",
             "stateMutability": "view",
             "superFunction": null,
@@ -508,28 +508,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1871,
+            "id": 1882,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "feeToSetter",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1867,
+              "id": 1878,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "292:2:5"
             },
             "returnParameters": {
-              "id": 1870,
+              "id": 1881,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1869,
+                  "id": 1880,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1871,
+                  "scope": 1882,
                   "src": "318:7:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -538,7 +538,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1868,
+                    "id": 1879,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "318:7:5",
@@ -554,7 +554,7 @@
               ],
               "src": "317:9:5"
             },
-            "scope": 1924,
+            "scope": 1935,
             "src": "272:55:5",
             "stateMutability": "view",
             "superFunction": null,
@@ -563,22 +563,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1880,
+            "id": 1891,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "getPair",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1876,
+              "id": 1887,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1873,
+                  "id": 1884,
                   "name": "tokenA",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1880,
+                  "scope": 1891,
                   "src": "350:14:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -587,7 +587,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1872,
+                    "id": 1883,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "350:7:5",
@@ -602,10 +602,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1875,
+                  "id": 1886,
                   "name": "tokenB",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1880,
+                  "scope": 1891,
                   "src": "366:14:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -614,7 +614,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1874,
+                    "id": 1885,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "366:7:5",
@@ -631,15 +631,15 @@
               "src": "349:32:5"
             },
             "returnParameters": {
-              "id": 1879,
+              "id": 1890,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1878,
+                  "id": 1889,
                   "name": "pair",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1880,
+                  "scope": 1891,
                   "src": "405:12:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -648,7 +648,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1877,
+                    "id": 1888,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "405:7:5",
@@ -664,7 +664,7 @@
               ],
               "src": "404:14:5"
             },
-            "scope": 1924,
+            "scope": 1935,
             "src": "333:86:5",
             "stateMutability": "view",
             "superFunction": null,
@@ -673,22 +673,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1887,
+            "id": 1898,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "allPairs",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1883,
+              "id": 1894,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1882,
+                  "id": 1893,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1887,
+                  "scope": 1898,
                   "src": "442:4:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -697,7 +697,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1881,
+                    "id": 1892,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "442:4:5",
@@ -713,15 +713,15 @@
               "src": "441:6:5"
             },
             "returnParameters": {
-              "id": 1886,
+              "id": 1897,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1885,
+                  "id": 1896,
                   "name": "pair",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1887,
+                  "scope": 1898,
                   "src": "471:12:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -730,7 +730,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1884,
+                    "id": 1895,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "471:7:5",
@@ -746,7 +746,7 @@
               ],
               "src": "470:14:5"
             },
-            "scope": 1924,
+            "scope": 1935,
             "src": "424:61:5",
             "stateMutability": "view",
             "superFunction": null,
@@ -755,28 +755,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1892,
+            "id": 1903,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "allPairsLength",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1888,
+              "id": 1899,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "513:2:5"
             },
             "returnParameters": {
-              "id": 1891,
+              "id": 1902,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1890,
+                  "id": 1901,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1892,
+                  "scope": 1903,
                   "src": "539:4:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -785,7 +785,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1889,
+                    "id": 1900,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "539:4:5",
@@ -800,7 +800,7 @@
               ],
               "src": "538:6:5"
             },
-            "scope": 1924,
+            "scope": 1935,
             "src": "490:55:5",
             "stateMutability": "view",
             "superFunction": null,
@@ -809,22 +809,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1901,
+            "id": 1912,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "createPair",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1897,
+              "id": 1908,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1894,
+                  "id": 1905,
                   "name": "tokenA",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1901,
+                  "scope": 1912,
                   "src": "571:14:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -833,7 +833,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1893,
+                    "id": 1904,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "571:7:5",
@@ -848,10 +848,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1896,
+                  "id": 1907,
                   "name": "tokenB",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1901,
+                  "scope": 1912,
                   "src": "587:14:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -860,7 +860,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1895,
+                    "id": 1906,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "587:7:5",
@@ -877,15 +877,15 @@
               "src": "570:32:5"
             },
             "returnParameters": {
-              "id": 1900,
+              "id": 1911,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1899,
+                  "id": 1910,
                   "name": "pair",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1901,
+                  "scope": 1912,
                   "src": "621:12:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -894,7 +894,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1898,
+                    "id": 1909,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "621:7:5",
@@ -910,7 +910,7 @@
               ],
               "src": "620:14:5"
             },
-            "scope": 1924,
+            "scope": 1935,
             "src": "551:84:5",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -919,22 +919,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1906,
+            "id": 1917,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "setFeeTo",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1904,
+              "id": 1915,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1903,
+                  "id": 1914,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1906,
+                  "scope": 1917,
                   "src": "659:7:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -943,7 +943,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1902,
+                    "id": 1913,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "659:7:5",
@@ -960,12 +960,12 @@
               "src": "658:9:5"
             },
             "returnParameters": {
-              "id": 1905,
+              "id": 1916,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "676:0:5"
             },
-            "scope": 1924,
+            "scope": 1935,
             "src": "641:36:5",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -974,22 +974,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1911,
+            "id": 1922,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "setFeeToSetter",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1909,
+              "id": 1920,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1908,
+                  "id": 1919,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1911,
+                  "scope": 1922,
                   "src": "706:7:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -998,7 +998,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1907,
+                    "id": 1918,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "706:7:5",
@@ -1015,12 +1015,12 @@
               "src": "705:9:5"
             },
             "returnParameters": {
-              "id": 1910,
+              "id": 1921,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "723:0:5"
             },
-            "scope": 1924,
+            "scope": 1935,
             "src": "682:42:5",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -1029,22 +1029,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1916,
+            "id": 1927,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "setProtocolFee",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1914,
+              "id": 1925,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1913,
+                  "id": 1924,
                   "name": "_protocolFee",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1916,
+                  "scope": 1927,
                   "src": "753:18:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1053,7 +1053,7 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 1912,
+                    "id": 1923,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
                     "src": "753:5:5",
@@ -1069,12 +1069,12 @@
               "src": "752:20:5"
             },
             "returnParameters": {
-              "id": 1915,
+              "id": 1926,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "781:0:5"
             },
-            "scope": 1924,
+            "scope": 1935,
             "src": "729:53:5",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -1083,22 +1083,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1923,
+            "id": 1934,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "setSwapFee",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1921,
+              "id": 1932,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1918,
+                  "id": 1929,
                   "name": "pair",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1923,
+                  "scope": 1934,
                   "src": "807:12:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1107,7 +1107,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1917,
+                    "id": 1928,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "807:7:5",
@@ -1122,10 +1122,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1920,
+                  "id": 1931,
                   "name": "swapFee",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1923,
+                  "scope": 1934,
                   "src": "821:13:5",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1134,7 +1134,7 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 1919,
+                    "id": 1930,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
                     "src": "821:5:5",
@@ -1150,19 +1150,19 @@
               "src": "806:29:5"
             },
             "returnParameters": {
-              "id": 1922,
+              "id": 1933,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "844:0:5"
             },
-            "scope": 1924,
+            "scope": 1935,
             "src": "787:58:5",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "external"
           }
         ],
-        "scope": 1925,
+        "scope": 1936,
         "src": "26:821:5"
       }
     ],

--- a/build/contracts/IDXswapPair.json
+++ b/build/contracts/IDXswapPair.json
@@ -746,14 +746,14 @@
     "absolutePath": "contracts/interfaces/IDXswapPair.sol",
     "exportedSymbols": {
       "IDXswapPair": [
-        2176
+        2187
       ]
     },
-    "id": 2177,
+    "id": 2188,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 1926,
+        "id": 1937,
         "literals": [
           "solidity",
           ">=",
@@ -769,9 +769,9 @@
         "contractKind": "interface",
         "documentation": null,
         "fullyImplemented": false,
-        "id": 2176,
+        "id": 2187,
         "linearizedBaseContracts": [
-          2176
+          2187
         ],
         "name": "IDXswapPair",
         "nodeType": "ContractDefinition",
@@ -779,20 +779,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 1934,
+            "id": 1945,
             "name": "Approval",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 1933,
+              "id": 1944,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1928,
+                  "id": 1939,
                   "indexed": true,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1934,
+                  "scope": 1945,
                   "src": "69:21:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -801,7 +801,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1927,
+                    "id": 1938,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "69:7:6",
@@ -816,11 +816,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 1930,
+                  "id": 1941,
                   "indexed": true,
                   "name": "spender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1934,
+                  "scope": 1945,
                   "src": "92:23:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -829,7 +829,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1929,
+                    "id": 1940,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "92:7:6",
@@ -844,11 +844,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 1932,
+                  "id": 1943,
                   "indexed": false,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1934,
+                  "scope": 1945,
                   "src": "117:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -857,7 +857,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1931,
+                    "id": 1942,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "117:4:6",
@@ -877,20 +877,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 1942,
+            "id": 1953,
             "name": "Transfer",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 1941,
+              "id": 1952,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1936,
+                  "id": 1947,
                   "indexed": true,
                   "name": "from",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1942,
+                  "scope": 1953,
                   "src": "149:20:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -899,7 +899,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1935,
+                    "id": 1946,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "149:7:6",
@@ -914,11 +914,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 1938,
+                  "id": 1949,
                   "indexed": true,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1942,
+                  "scope": 1953,
                   "src": "171:18:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -927,7 +927,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1937,
+                    "id": 1948,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "171:7:6",
@@ -942,11 +942,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 1940,
+                  "id": 1951,
                   "indexed": false,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1942,
+                  "scope": 1953,
                   "src": "191:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -955,7 +955,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1939,
+                    "id": 1950,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "191:4:6",
@@ -975,28 +975,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1947,
+            "id": 1958,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "name",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1943,
+              "id": 1954,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "222:2:6"
             },
             "returnParameters": {
-              "id": 1946,
+              "id": 1957,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1945,
+                  "id": 1956,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1947,
+                  "scope": 1958,
                   "src": "248:13:6",
                   "stateVariable": false,
                   "storageLocation": "memory",
@@ -1005,7 +1005,7 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 1944,
+                    "id": 1955,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
                     "src": "248:6:6",
@@ -1020,7 +1020,7 @@
               ],
               "src": "247:15:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "209:54:6",
             "stateMutability": "pure",
             "superFunction": null,
@@ -1029,28 +1029,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1952,
+            "id": 1963,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "symbol",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1948,
+              "id": 1959,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "283:2:6"
             },
             "returnParameters": {
-              "id": 1951,
+              "id": 1962,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1950,
+                  "id": 1961,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1952,
+                  "scope": 1963,
                   "src": "309:13:6",
                   "stateVariable": false,
                   "storageLocation": "memory",
@@ -1059,7 +1059,7 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 1949,
+                    "id": 1960,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
                     "src": "309:6:6",
@@ -1074,7 +1074,7 @@
               ],
               "src": "308:15:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "268:56:6",
             "stateMutability": "pure",
             "superFunction": null,
@@ -1083,28 +1083,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1957,
+            "id": 1968,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "decimals",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1953,
+              "id": 1964,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "346:2:6"
             },
             "returnParameters": {
-              "id": 1956,
+              "id": 1967,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1955,
+                  "id": 1966,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1957,
+                  "scope": 1968,
                   "src": "372:5:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1113,7 +1113,7 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 1954,
+                    "id": 1965,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
                     "src": "372:5:6",
@@ -1128,7 +1128,7 @@
               ],
               "src": "371:7:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "329:50:6",
             "stateMutability": "pure",
             "superFunction": null,
@@ -1137,28 +1137,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1962,
+            "id": 1973,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "totalSupply",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1958,
+              "id": 1969,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "404:2:6"
             },
             "returnParameters": {
-              "id": 1961,
+              "id": 1972,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1960,
+                  "id": 1971,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1962,
+                  "scope": 1973,
                   "src": "430:4:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1167,7 +1167,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1959,
+                    "id": 1970,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "430:4:6",
@@ -1182,7 +1182,7 @@
               ],
               "src": "429:6:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "384:52:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -1191,22 +1191,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1969,
+            "id": 1980,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "balanceOf",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1965,
+              "id": 1976,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1964,
+                  "id": 1975,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1969,
+                  "scope": 1980,
                   "src": "460:13:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1215,7 +1215,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1963,
+                    "id": 1974,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "460:7:6",
@@ -1232,15 +1232,15 @@
               "src": "459:15:6"
             },
             "returnParameters": {
-              "id": 1968,
+              "id": 1979,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1967,
+                  "id": 1978,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1969,
+                  "scope": 1980,
                   "src": "498:4:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1249,7 +1249,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1966,
+                    "id": 1977,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "498:4:6",
@@ -1264,7 +1264,7 @@
               ],
               "src": "497:6:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "441:63:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -1273,22 +1273,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1978,
+            "id": 1989,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "allowance",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1974,
+              "id": 1985,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1971,
+                  "id": 1982,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1978,
+                  "scope": 1989,
                   "src": "528:13:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1297,7 +1297,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1970,
+                    "id": 1981,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "528:7:6",
@@ -1312,10 +1312,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1973,
+                  "id": 1984,
                   "name": "spender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1978,
+                  "scope": 1989,
                   "src": "543:15:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1324,7 +1324,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1972,
+                    "id": 1983,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "543:7:6",
@@ -1341,15 +1341,15 @@
               "src": "527:32:6"
             },
             "returnParameters": {
-              "id": 1977,
+              "id": 1988,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1976,
+                  "id": 1987,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1978,
+                  "scope": 1989,
                   "src": "583:4:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1358,7 +1358,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1975,
+                    "id": 1986,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "583:4:6",
@@ -1373,7 +1373,7 @@
               ],
               "src": "582:6:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "509:80:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -1382,22 +1382,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 1987,
+            "id": 1998,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "approve",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 1983,
+              "id": 1994,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1980,
+                  "id": 1991,
                   "name": "spender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1987,
+                  "scope": 1998,
                   "src": "612:15:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1406,7 +1406,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 1979,
+                    "id": 1990,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "612:7:6",
@@ -1421,10 +1421,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 1982,
+                  "id": 1993,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1987,
+                  "scope": 1998,
                   "src": "629:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1433,7 +1433,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 1981,
+                    "id": 1992,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "629:4:6",
@@ -1449,15 +1449,15 @@
               "src": "611:29:6"
             },
             "returnParameters": {
-              "id": 1986,
+              "id": 1997,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1985,
+                  "id": 1996,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 1987,
+                  "scope": 1998,
                   "src": "659:4:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1466,7 +1466,7 @@
                     "typeString": "bool"
                   },
                   "typeName": {
-                    "id": 1984,
+                    "id": 1995,
                     "name": "bool",
                     "nodeType": "ElementaryTypeName",
                     "src": "659:4:6",
@@ -1481,116 +1481,8 @@
               ],
               "src": "658:6:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "595:70:6",
-            "stateMutability": "nonpayable",
-            "superFunction": null,
-            "visibility": "external"
-          },
-          {
-            "body": null,
-            "documentation": null,
-            "id": 1996,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "transfer",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 1992,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 1989,
-                  "name": "to",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 1996,
-                  "src": "688:10:6",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 1988,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "688:7:6",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 1991,
-                  "name": "value",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 1996,
-                  "src": "700:10:6",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 1990,
-                    "name": "uint",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "700:4:6",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                }
-              ],
-              "src": "687:24:6"
-            },
-            "returnParameters": {
-              "id": 1995,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 1994,
-                  "name": "",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 1996,
-                  "src": "730:4:6",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_bool",
-                    "typeString": "bool"
-                  },
-                  "typeName": {
-                    "id": 1993,
-                    "name": "bool",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "730:4:6",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_bool",
-                      "typeString": "bool"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                }
-              ],
-              "src": "729:6:6"
-            },
-            "scope": 2176,
-            "src": "670:66:6",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "external"
@@ -1602,7 +1494,7 @@
             "implemented": false,
             "kind": "function",
             "modifiers": [],
-            "name": "transferFrom",
+            "name": "transfer",
             "nodeType": "FunctionDefinition",
             "parameters": {
               "id": 2003,
@@ -1610,38 +1502,11 @@
               "parameters": [
                 {
                   "constant": false,
-                  "id": 1998,
-                  "name": "from",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 2007,
-                  "src": "763:12:6",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 1997,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "763:7:6",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
                   "id": 2000,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
                   "scope": 2007,
-                  "src": "777:10:6",
+                  "src": "688:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1652,7 +1517,7 @@
                     "id": 1999,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "777:7:6",
+                    "src": "688:7:6",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -1668,7 +1533,7 @@
                   "name": "value",
                   "nodeType": "VariableDeclaration",
                   "scope": 2007,
-                  "src": "789:10:6",
+                  "src": "700:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1677,6 +1542,141 @@
                   },
                   "typeName": {
                     "id": 2001,
+                    "name": "uint",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "700:4:6",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "687:24:6"
+            },
+            "returnParameters": {
+              "id": 2006,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 2005,
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 2007,
+                  "src": "730:4:6",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  },
+                  "typeName": {
+                    "id": 2004,
+                    "name": "bool",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "730:4:6",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "729:6:6"
+            },
+            "scope": 2187,
+            "src": "670:66:6",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "external"
+          },
+          {
+            "body": null,
+            "documentation": null,
+            "id": 2018,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "transferFrom",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 2014,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 2009,
+                  "name": "from",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 2018,
+                  "src": "763:12:6",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 2008,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "763:7:6",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 2011,
+                  "name": "to",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 2018,
+                  "src": "777:10:6",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 2010,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "777:7:6",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 2013,
+                  "name": "value",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 2018,
+                  "src": "789:10:6",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 2012,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "789:4:6",
@@ -1692,15 +1692,15 @@
               "src": "762:38:6"
             },
             "returnParameters": {
-              "id": 2006,
+              "id": 2017,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2005,
+                  "id": 2016,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2007,
+                  "scope": 2018,
                   "src": "819:4:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1709,7 +1709,7 @@
                     "typeString": "bool"
                   },
                   "typeName": {
-                    "id": 2004,
+                    "id": 2015,
                     "name": "bool",
                     "nodeType": "ElementaryTypeName",
                     "src": "819:4:6",
@@ -1724,7 +1724,7 @@
               ],
               "src": "818:6:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "741:84:6",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -1733,28 +1733,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2012,
+            "id": 2023,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "DOMAIN_SEPARATOR",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2008,
+              "id": 2019,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "856:2:6"
             },
             "returnParameters": {
-              "id": 2011,
+              "id": 2022,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2010,
+                  "id": 2021,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2012,
+                  "scope": 2023,
                   "src": "882:7:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1763,7 +1763,7 @@
                     "typeString": "bytes32"
                   },
                   "typeName": {
-                    "id": 2009,
+                    "id": 2020,
                     "name": "bytes32",
                     "nodeType": "ElementaryTypeName",
                     "src": "882:7:6",
@@ -1778,7 +1778,7 @@
               ],
               "src": "881:9:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "831:60:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -1787,28 +1787,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2017,
+            "id": 2028,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "PERMIT_TYPEHASH",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2013,
+              "id": 2024,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "920:2:6"
             },
             "returnParameters": {
-              "id": 2016,
+              "id": 2027,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2015,
+                  "id": 2026,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2017,
+                  "scope": 2028,
                   "src": "946:7:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1817,7 +1817,7 @@
                     "typeString": "bytes32"
                   },
                   "typeName": {
-                    "id": 2014,
+                    "id": 2025,
                     "name": "bytes32",
                     "nodeType": "ElementaryTypeName",
                     "src": "946:7:6",
@@ -1832,7 +1832,7 @@
               ],
               "src": "945:9:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "896:59:6",
             "stateMutability": "pure",
             "superFunction": null,
@@ -1841,22 +1841,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2024,
+            "id": 2035,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "nonces",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2020,
+              "id": 2031,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2019,
+                  "id": 2030,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2024,
+                  "scope": 2035,
                   "src": "976:13:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1865,7 +1865,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2018,
+                    "id": 2029,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "976:7:6",
@@ -1882,15 +1882,15 @@
               "src": "975:15:6"
             },
             "returnParameters": {
-              "id": 2023,
+              "id": 2034,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2022,
+                  "id": 2033,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2024,
+                  "scope": 2035,
                   "src": "1014:4:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1899,7 +1899,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2021,
+                    "id": 2032,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1014:4:6",
@@ -1914,7 +1914,7 @@
               ],
               "src": "1013:6:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "960:60:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -1923,22 +1923,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2041,
+            "id": 2052,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "permit",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2039,
+              "id": 2050,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2026,
+                  "id": 2037,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2041,
+                  "scope": 2052,
                   "src": "1042:13:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1947,7 +1947,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2025,
+                    "id": 2036,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1042:7:6",
@@ -1962,10 +1962,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2028,
+                  "id": 2039,
                   "name": "spender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2041,
+                  "scope": 2052,
                   "src": "1057:15:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1974,7 +1974,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2027,
+                    "id": 2038,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1057:7:6",
@@ -1989,10 +1989,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2030,
+                  "id": 2041,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2041,
+                  "scope": 2052,
                   "src": "1074:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2001,7 +2001,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2029,
+                    "id": 2040,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1074:4:6",
@@ -2015,10 +2015,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2032,
+                  "id": 2043,
                   "name": "deadline",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2041,
+                  "scope": 2052,
                   "src": "1086:13:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2027,7 +2027,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2031,
+                    "id": 2042,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1086:4:6",
@@ -2041,10 +2041,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2034,
+                  "id": 2045,
                   "name": "v",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2041,
+                  "scope": 2052,
                   "src": "1101:7:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2053,7 +2053,7 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 2033,
+                    "id": 2044,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
                     "src": "1101:5:6",
@@ -2067,10 +2067,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2036,
+                  "id": 2047,
                   "name": "r",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2041,
+                  "scope": 2052,
                   "src": "1110:9:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2079,7 +2079,7 @@
                     "typeString": "bytes32"
                   },
                   "typeName": {
-                    "id": 2035,
+                    "id": 2046,
                     "name": "bytes32",
                     "nodeType": "ElementaryTypeName",
                     "src": "1110:7:6",
@@ -2093,10 +2093,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2038,
+                  "id": 2049,
                   "name": "s",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2041,
+                  "scope": 2052,
                   "src": "1121:9:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2105,7 +2105,7 @@
                     "typeString": "bytes32"
                   },
                   "typeName": {
-                    "id": 2037,
+                    "id": 2048,
                     "name": "bytes32",
                     "nodeType": "ElementaryTypeName",
                     "src": "1121:7:6",
@@ -2121,12 +2121,12 @@
               "src": "1041:90:6"
             },
             "returnParameters": {
-              "id": 2040,
+              "id": 2051,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1140:0:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "1026:115:6",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -2135,20 +2135,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 2049,
+            "id": 2060,
             "name": "Mint",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 2048,
+              "id": 2059,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2043,
+                  "id": 2054,
                   "indexed": true,
                   "name": "sender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2049,
+                  "scope": 2060,
                   "src": "1158:22:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2157,7 +2157,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2042,
+                    "id": 2053,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1158:7:6",
@@ -2172,11 +2172,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2045,
+                  "id": 2056,
                   "indexed": false,
                   "name": "amount0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2049,
+                  "scope": 2060,
                   "src": "1182:12:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2185,7 +2185,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2044,
+                    "id": 2055,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1182:4:6",
@@ -2199,11 +2199,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2047,
+                  "id": 2058,
                   "indexed": false,
                   "name": "amount1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2049,
+                  "scope": 2060,
                   "src": "1196:12:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2212,7 +2212,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2046,
+                    "id": 2057,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1196:4:6",
@@ -2232,20 +2232,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 2059,
+            "id": 2070,
             "name": "Burn",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 2058,
+              "id": 2069,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2051,
+                  "id": 2062,
                   "indexed": true,
                   "name": "sender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2059,
+                  "scope": 2070,
                   "src": "1226:22:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2254,7 +2254,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2050,
+                    "id": 2061,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1226:7:6",
@@ -2269,11 +2269,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2053,
+                  "id": 2064,
                   "indexed": false,
                   "name": "amount0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2059,
+                  "scope": 2070,
                   "src": "1250:12:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2282,7 +2282,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2052,
+                    "id": 2063,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1250:4:6",
@@ -2296,11 +2296,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2055,
+                  "id": 2066,
                   "indexed": false,
                   "name": "amount1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2059,
+                  "scope": 2070,
                   "src": "1264:12:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2309,7 +2309,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2054,
+                    "id": 2065,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1264:4:6",
@@ -2323,11 +2323,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2057,
+                  "id": 2068,
                   "indexed": true,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2059,
+                  "scope": 2070,
                   "src": "1278:18:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2336,7 +2336,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2056,
+                    "id": 2067,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1278:7:6",
@@ -2357,20 +2357,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 2073,
+            "id": 2084,
             "name": "Swap",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 2072,
+              "id": 2083,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2061,
+                  "id": 2072,
                   "indexed": true,
                   "name": "sender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2073,
+                  "scope": 2084,
                   "src": "1323:22:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2379,7 +2379,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2060,
+                    "id": 2071,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1323:7:6",
@@ -2394,11 +2394,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2063,
+                  "id": 2074,
                   "indexed": false,
                   "name": "amount0In",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2073,
+                  "scope": 2084,
                   "src": "1355:14:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2407,7 +2407,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2062,
+                    "id": 2073,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1355:4:6",
@@ -2421,11 +2421,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2065,
+                  "id": 2076,
                   "indexed": false,
                   "name": "amount1In",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2073,
+                  "scope": 2084,
                   "src": "1379:14:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2434,7 +2434,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2064,
+                    "id": 2075,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1379:4:6",
@@ -2448,11 +2448,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2067,
+                  "id": 2078,
                   "indexed": false,
                   "name": "amount0Out",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2073,
+                  "scope": 2084,
                   "src": "1403:15:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2461,7 +2461,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2066,
+                    "id": 2077,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1403:4:6",
@@ -2475,11 +2475,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2069,
+                  "id": 2080,
                   "indexed": false,
                   "name": "amount1Out",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2073,
+                  "scope": 2084,
                   "src": "1428:15:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2488,7 +2488,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2068,
+                    "id": 2079,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1428:4:6",
@@ -2502,11 +2502,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2071,
+                  "id": 2082,
                   "indexed": true,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2073,
+                  "scope": 2084,
                   "src": "1453:18:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2515,7 +2515,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2070,
+                    "id": 2081,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1453:7:6",
@@ -2536,20 +2536,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 2079,
+            "id": 2090,
             "name": "Sync",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 2078,
+              "id": 2089,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2075,
+                  "id": 2086,
                   "indexed": false,
                   "name": "reserve0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2079,
+                  "scope": 2090,
                   "src": "1494:16:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2558,7 +2558,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 2074,
+                    "id": 2085,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "1494:7:6",
@@ -2572,11 +2572,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2077,
+                  "id": 2088,
                   "indexed": false,
                   "name": "reserve1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2079,
+                  "scope": 2090,
                   "src": "1512:16:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2585,7 +2585,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 2076,
+                    "id": 2087,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "1512:7:6",
@@ -2605,28 +2605,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2084,
+            "id": 2095,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "MINIMUM_LIQUIDITY",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2080,
+              "id": 2091,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1562:2:6"
             },
             "returnParameters": {
-              "id": 2083,
+              "id": 2094,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2082,
+                  "id": 2093,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2084,
+                  "scope": 2095,
                   "src": "1588:4:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2635,7 +2635,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2081,
+                    "id": 2092,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1588:4:6",
@@ -2650,7 +2650,7 @@
               ],
               "src": "1587:6:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "1536:58:6",
             "stateMutability": "pure",
             "superFunction": null,
@@ -2659,28 +2659,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2089,
+            "id": 2100,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "factory",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2085,
+              "id": 2096,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1615:2:6"
             },
             "returnParameters": {
-              "id": 2088,
+              "id": 2099,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2087,
+                  "id": 2098,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2089,
+                  "scope": 2100,
                   "src": "1641:7:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2689,7 +2689,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2086,
+                    "id": 2097,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1641:7:6",
@@ -2705,7 +2705,7 @@
               ],
               "src": "1640:9:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "1599:51:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -2714,28 +2714,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2094,
+            "id": 2105,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "token0",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2090,
+              "id": 2101,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1670:2:6"
             },
             "returnParameters": {
-              "id": 2093,
+              "id": 2104,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2092,
+                  "id": 2103,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2094,
+                  "scope": 2105,
                   "src": "1696:7:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2744,7 +2744,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2091,
+                    "id": 2102,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1696:7:6",
@@ -2760,7 +2760,7 @@
               ],
               "src": "1695:9:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "1655:50:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -2769,28 +2769,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2099,
+            "id": 2110,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "token1",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2095,
+              "id": 2106,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1725:2:6"
             },
             "returnParameters": {
-              "id": 2098,
+              "id": 2109,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2097,
+                  "id": 2108,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2099,
+                  "scope": 2110,
                   "src": "1751:7:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2799,7 +2799,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2096,
+                    "id": 2107,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "1751:7:6",
@@ -2815,7 +2815,7 @@
               ],
               "src": "1750:9:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "1710:50:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -2824,28 +2824,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2108,
+            "id": 2119,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "getReserves",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2100,
+              "id": 2111,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1785:2:6"
             },
             "returnParameters": {
-              "id": 2107,
+              "id": 2118,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2102,
+                  "id": 2113,
                   "name": "reserve0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2108,
+                  "scope": 2119,
                   "src": "1811:16:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2854,7 +2854,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 2101,
+                    "id": 2112,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "1811:7:6",
@@ -2868,10 +2868,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2104,
+                  "id": 2115,
                   "name": "reserve1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2108,
+                  "scope": 2119,
                   "src": "1829:16:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2880,7 +2880,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 2103,
+                    "id": 2114,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "1829:7:6",
@@ -2894,10 +2894,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2106,
+                  "id": 2117,
                   "name": "blockTimestampLast",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2108,
+                  "scope": 2119,
                   "src": "1847:25:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2906,7 +2906,7 @@
                     "typeString": "uint32"
                   },
                   "typeName": {
-                    "id": 2105,
+                    "id": 2116,
                     "name": "uint32",
                     "nodeType": "ElementaryTypeName",
                     "src": "1847:6:6",
@@ -2921,7 +2921,7 @@
               ],
               "src": "1810:63:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "1765:109:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -2930,28 +2930,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2113,
+            "id": 2124,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "price0CumulativeLast",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2109,
+              "id": 2120,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1908:2:6"
             },
             "returnParameters": {
-              "id": 2112,
+              "id": 2123,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2111,
+                  "id": 2122,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2113,
+                  "scope": 2124,
                   "src": "1934:4:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -2960,7 +2960,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2110,
+                    "id": 2121,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "1934:4:6",
@@ -2975,7 +2975,7 @@
               ],
               "src": "1933:6:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "1879:61:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -2984,28 +2984,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2118,
+            "id": 2129,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "price1CumulativeLast",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2114,
+              "id": 2125,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "1974:2:6"
             },
             "returnParameters": {
-              "id": 2117,
+              "id": 2128,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2116,
+                  "id": 2127,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2118,
+                  "scope": 2129,
                   "src": "2000:4:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3014,7 +3014,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2115,
+                    "id": 2126,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2000:4:6",
@@ -3029,7 +3029,7 @@
               ],
               "src": "1999:6:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "1945:61:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -3038,28 +3038,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2123,
+            "id": 2134,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "kLast",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2119,
+              "id": 2130,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2025:2:6"
             },
             "returnParameters": {
-              "id": 2122,
+              "id": 2133,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2121,
+                  "id": 2132,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2123,
+                  "scope": 2134,
                   "src": "2051:4:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3068,7 +3068,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2120,
+                    "id": 2131,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2051:4:6",
@@ -3083,7 +3083,7 @@
               ],
               "src": "2050:6:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "2011:46:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -3092,28 +3092,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2128,
+            "id": 2139,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "swapFee",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2124,
+              "id": 2135,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2078:2:6"
             },
             "returnParameters": {
-              "id": 2127,
+              "id": 2138,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2126,
+                  "id": 2137,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2128,
+                  "scope": 2139,
                   "src": "2104:5:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3122,7 +3122,7 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 2125,
+                    "id": 2136,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
                     "src": "2104:5:6",
@@ -3137,7 +3137,7 @@
               ],
               "src": "2103:7:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "2062:49:6",
             "stateMutability": "view",
             "superFunction": null,
@@ -3146,22 +3146,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2135,
+            "id": 2146,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "mint",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2131,
+              "id": 2142,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2130,
+                  "id": 2141,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2135,
+                  "scope": 2146,
                   "src": "2131:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3170,7 +3170,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2129,
+                    "id": 2140,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "2131:7:6",
@@ -3187,15 +3187,15 @@
               "src": "2130:12:6"
             },
             "returnParameters": {
-              "id": 2134,
+              "id": 2145,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2133,
+                  "id": 2144,
                   "name": "liquidity",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2135,
+                  "scope": 2146,
                   "src": "2161:14:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3204,7 +3204,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2132,
+                    "id": 2143,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2161:4:6",
@@ -3219,7 +3219,7 @@
               ],
               "src": "2160:16:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "2117:60:6",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -3228,22 +3228,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2144,
+            "id": 2155,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "burn",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2138,
+              "id": 2149,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2137,
+                  "id": 2148,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2144,
+                  "scope": 2155,
                   "src": "2196:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3252,7 +3252,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2136,
+                    "id": 2147,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "2196:7:6",
@@ -3269,15 +3269,15 @@
               "src": "2195:12:6"
             },
             "returnParameters": {
-              "id": 2143,
+              "id": 2154,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2140,
+                  "id": 2151,
                   "name": "amount0",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2144,
+                  "scope": 2155,
                   "src": "2226:12:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3286,7 +3286,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2139,
+                    "id": 2150,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2226:4:6",
@@ -3300,10 +3300,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2142,
+                  "id": 2153,
                   "name": "amount1",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2144,
+                  "scope": 2155,
                   "src": "2240:12:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3312,7 +3312,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2141,
+                    "id": 2152,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2240:4:6",
@@ -3327,7 +3327,7 @@
               ],
               "src": "2225:28:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "2182:72:6",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -3336,22 +3336,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2155,
+            "id": 2166,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "swap",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2153,
+              "id": 2164,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2146,
+                  "id": 2157,
                   "name": "amount0Out",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2155,
+                  "scope": 2166,
                   "src": "2273:15:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3360,7 +3360,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2145,
+                    "id": 2156,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2273:4:6",
@@ -3374,10 +3374,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2148,
+                  "id": 2159,
                   "name": "amount1Out",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2155,
+                  "scope": 2166,
                   "src": "2290:15:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3386,7 +3386,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2147,
+                    "id": 2158,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "2290:4:6",
@@ -3400,10 +3400,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2150,
+                  "id": 2161,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2155,
+                  "scope": 2166,
                   "src": "2307:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3412,7 +3412,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2149,
+                    "id": 2160,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "2307:7:6",
@@ -3427,10 +3427,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2152,
+                  "id": 2163,
                   "name": "data",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2155,
+                  "scope": 2166,
                   "src": "2319:19:6",
                   "stateVariable": false,
                   "storageLocation": "calldata",
@@ -3439,7 +3439,7 @@
                     "typeString": "bytes"
                   },
                   "typeName": {
-                    "id": 2151,
+                    "id": 2162,
                     "name": "bytes",
                     "nodeType": "ElementaryTypeName",
                     "src": "2319:5:6",
@@ -3455,12 +3455,12 @@
               "src": "2272:67:6"
             },
             "returnParameters": {
-              "id": 2154,
+              "id": 2165,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2348:0:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "2259:90:6",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -3469,22 +3469,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2160,
+            "id": 2171,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "skim",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2158,
+              "id": 2169,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2157,
+                  "id": 2168,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2160,
+                  "scope": 2171,
                   "src": "2368:10:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3493,7 +3493,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2156,
+                    "id": 2167,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "2368:7:6",
@@ -3510,12 +3510,12 @@
               "src": "2367:12:6"
             },
             "returnParameters": {
-              "id": 2159,
+              "id": 2170,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2388:0:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "2354:35:6",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -3524,25 +3524,25 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2163,
+            "id": 2174,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "sync",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2161,
+              "id": 2172,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2407:2:6"
             },
             "returnParameters": {
-              "id": 2162,
+              "id": 2173,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2418:0:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "2394:25:6",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -3551,22 +3551,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2170,
+            "id": 2181,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "initialize",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2168,
+              "id": 2179,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2165,
+                  "id": 2176,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2170,
+                  "scope": 2181,
                   "src": "2445:7:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3575,7 +3575,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2164,
+                    "id": 2175,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "2445:7:6",
@@ -3590,10 +3590,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2167,
+                  "id": 2178,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2170,
+                  "scope": 2181,
                   "src": "2454:7:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3602,7 +3602,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2166,
+                    "id": 2177,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "2454:7:6",
@@ -3619,12 +3619,12 @@
               "src": "2444:18:6"
             },
             "returnParameters": {
-              "id": 2169,
+              "id": 2180,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2471:0:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "2425:47:6",
             "stateMutability": "nonpayable",
             "superFunction": null,
@@ -3633,22 +3633,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2175,
+            "id": 2186,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "setSwapFee",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2173,
+              "id": 2184,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2172,
+                  "id": 2183,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2175,
+                  "scope": 2186,
                   "src": "2497:5:6",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -3657,7 +3657,7 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 2171,
+                    "id": 2182,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
                     "src": "2497:5:6",
@@ -3673,19 +3673,19 @@
               "src": "2496:7:6"
             },
             "returnParameters": {
-              "id": 2174,
+              "id": 2185,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "2512:0:6"
             },
-            "scope": 2176,
+            "scope": 2187,
             "src": "2477:36:6",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "external"
           }
         ],
-        "scope": 2177,
+        "scope": 2188,
         "src": "26:2489:6"
       }
     ],

--- a/build/contracts/IERC20.json
+++ b/build/contracts/IERC20.json
@@ -251,14 +251,14 @@
     "absolutePath": "contracts/interfaces/IERC20.sol",
     "exportedSymbols": {
       "IERC20": [
-        2260
+        2271
       ]
     },
-    "id": 2261,
+    "id": 2272,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 2178,
+        "id": 2189,
         "literals": [
           "solidity",
           ">=",
@@ -274,9 +274,9 @@
         "contractKind": "interface",
         "documentation": null,
         "fullyImplemented": false,
-        "id": 2260,
+        "id": 2271,
         "linearizedBaseContracts": [
-          2260
+          2271
         ],
         "name": "IERC20",
         "nodeType": "ContractDefinition",
@@ -284,20 +284,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 2186,
+            "id": 2197,
             "name": "Approval",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 2185,
+              "id": 2196,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2180,
+                  "id": 2191,
                   "indexed": true,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2186,
+                  "scope": 2197,
                   "src": "64:21:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -306,7 +306,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2179,
+                    "id": 2190,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "64:7:7",
@@ -321,11 +321,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2182,
+                  "id": 2193,
                   "indexed": true,
                   "name": "spender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2186,
+                  "scope": 2197,
                   "src": "87:23:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -334,7 +334,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2181,
+                    "id": 2192,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "87:7:7",
@@ -349,11 +349,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2184,
+                  "id": 2195,
                   "indexed": false,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2186,
+                  "scope": 2197,
                   "src": "112:10:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -362,7 +362,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2183,
+                    "id": 2194,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "112:4:7",
@@ -382,20 +382,20 @@
           {
             "anonymous": false,
             "documentation": null,
-            "id": 2194,
+            "id": 2205,
             "name": "Transfer",
             "nodeType": "EventDefinition",
             "parameters": {
-              "id": 2193,
+              "id": 2204,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2188,
+                  "id": 2199,
                   "indexed": true,
                   "name": "from",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2194,
+                  "scope": 2205,
                   "src": "144:20:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -404,7 +404,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2187,
+                    "id": 2198,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "144:7:7",
@@ -419,11 +419,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2190,
+                  "id": 2201,
                   "indexed": true,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2194,
+                  "scope": 2205,
                   "src": "166:18:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -432,7 +432,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2189,
+                    "id": 2200,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "166:7:7",
@@ -447,11 +447,11 @@
                 },
                 {
                   "constant": false,
-                  "id": 2192,
+                  "id": 2203,
                   "indexed": false,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2194,
+                  "scope": 2205,
                   "src": "186:10:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -460,7 +460,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2191,
+                    "id": 2202,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "186:4:7",
@@ -480,28 +480,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2199,
+            "id": 2210,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "name",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2195,
+              "id": 2206,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "217:2:7"
             },
             "returnParameters": {
-              "id": 2198,
+              "id": 2209,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2197,
+                  "id": 2208,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2199,
+                  "scope": 2210,
                   "src": "243:13:7",
                   "stateVariable": false,
                   "storageLocation": "memory",
@@ -510,7 +510,7 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 2196,
+                    "id": 2207,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
                     "src": "243:6:7",
@@ -525,7 +525,7 @@
               ],
               "src": "242:15:7"
             },
-            "scope": 2260,
+            "scope": 2271,
             "src": "204:54:7",
             "stateMutability": "view",
             "superFunction": null,
@@ -534,28 +534,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2204,
+            "id": 2215,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "symbol",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2200,
+              "id": 2211,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "278:2:7"
             },
             "returnParameters": {
-              "id": 2203,
+              "id": 2214,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2202,
+                  "id": 2213,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2204,
+                  "scope": 2215,
                   "src": "304:13:7",
                   "stateVariable": false,
                   "storageLocation": "memory",
@@ -564,7 +564,7 @@
                     "typeString": "string"
                   },
                   "typeName": {
-                    "id": 2201,
+                    "id": 2212,
                     "name": "string",
                     "nodeType": "ElementaryTypeName",
                     "src": "304:6:7",
@@ -579,7 +579,7 @@
               ],
               "src": "303:15:7"
             },
-            "scope": 2260,
+            "scope": 2271,
             "src": "263:56:7",
             "stateMutability": "view",
             "superFunction": null,
@@ -588,28 +588,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2209,
+            "id": 2220,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "decimals",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2205,
+              "id": 2216,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "341:2:7"
             },
             "returnParameters": {
-              "id": 2208,
+              "id": 2219,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2207,
+                  "id": 2218,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2209,
+                  "scope": 2220,
                   "src": "367:5:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -618,7 +618,7 @@
                     "typeString": "uint8"
                   },
                   "typeName": {
-                    "id": 2206,
+                    "id": 2217,
                     "name": "uint8",
                     "nodeType": "ElementaryTypeName",
                     "src": "367:5:7",
@@ -633,7 +633,7 @@
               ],
               "src": "366:7:7"
             },
-            "scope": 2260,
+            "scope": 2271,
             "src": "324:50:7",
             "stateMutability": "view",
             "superFunction": null,
@@ -642,28 +642,28 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2214,
+            "id": 2225,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "totalSupply",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2210,
+              "id": 2221,
               "nodeType": "ParameterList",
               "parameters": [],
               "src": "399:2:7"
             },
             "returnParameters": {
-              "id": 2213,
+              "id": 2224,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2212,
+                  "id": 2223,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2214,
+                  "scope": 2225,
                   "src": "425:4:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -672,7 +672,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2211,
+                    "id": 2222,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "425:4:7",
@@ -687,7 +687,7 @@
               ],
               "src": "424:6:7"
             },
-            "scope": 2260,
+            "scope": 2271,
             "src": "379:52:7",
             "stateMutability": "view",
             "superFunction": null,
@@ -696,22 +696,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2221,
+            "id": 2232,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "balanceOf",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2217,
+              "id": 2228,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2216,
+                  "id": 2227,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2221,
+                  "scope": 2232,
                   "src": "455:13:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -720,7 +720,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2215,
+                    "id": 2226,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "455:7:7",
@@ -737,15 +737,15 @@
               "src": "454:15:7"
             },
             "returnParameters": {
-              "id": 2220,
+              "id": 2231,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2219,
+                  "id": 2230,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2221,
+                  "scope": 2232,
                   "src": "493:4:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -754,7 +754,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2218,
+                    "id": 2229,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "493:4:7",
@@ -769,7 +769,7 @@
               ],
               "src": "492:6:7"
             },
-            "scope": 2260,
+            "scope": 2271,
             "src": "436:63:7",
             "stateMutability": "view",
             "superFunction": null,
@@ -778,22 +778,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2230,
+            "id": 2241,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "allowance",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2226,
+              "id": 2237,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2223,
+                  "id": 2234,
                   "name": "owner",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2230,
+                  "scope": 2241,
                   "src": "523:13:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -802,7 +802,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2222,
+                    "id": 2233,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "523:7:7",
@@ -817,10 +817,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2225,
+                  "id": 2236,
                   "name": "spender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2230,
+                  "scope": 2241,
                   "src": "538:15:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -829,7 +829,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2224,
+                    "id": 2235,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "538:7:7",
@@ -846,15 +846,15 @@
               "src": "522:32:7"
             },
             "returnParameters": {
-              "id": 2229,
+              "id": 2240,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2228,
+                  "id": 2239,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2230,
+                  "scope": 2241,
                   "src": "578:4:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -863,7 +863,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2227,
+                    "id": 2238,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "578:4:7",
@@ -878,7 +878,7 @@
               ],
               "src": "577:6:7"
             },
-            "scope": 2260,
+            "scope": 2271,
             "src": "504:80:7",
             "stateMutability": "view",
             "superFunction": null,
@@ -887,22 +887,22 @@
           {
             "body": null,
             "documentation": null,
-            "id": 2239,
+            "id": 2250,
             "implemented": false,
             "kind": "function",
             "modifiers": [],
             "name": "approve",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2235,
+              "id": 2246,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2232,
+                  "id": 2243,
                   "name": "spender",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2239,
+                  "scope": 2250,
                   "src": "607:15:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -911,7 +911,7 @@
                     "typeString": "address"
                   },
                   "typeName": {
-                    "id": 2231,
+                    "id": 2242,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
                     "src": "607:7:7",
@@ -926,10 +926,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2234,
+                  "id": 2245,
                   "name": "value",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2239,
+                  "scope": 2250,
                   "src": "624:10:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -938,7 +938,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2233,
+                    "id": 2244,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "624:4:7",
@@ -954,15 +954,15 @@
               "src": "606:29:7"
             },
             "returnParameters": {
-              "id": 2238,
+              "id": 2249,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2237,
+                  "id": 2248,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2239,
+                  "scope": 2250,
                   "src": "654:4:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -971,7 +971,7 @@
                     "typeString": "bool"
                   },
                   "typeName": {
-                    "id": 2236,
+                    "id": 2247,
                     "name": "bool",
                     "nodeType": "ElementaryTypeName",
                     "src": "654:4:7",
@@ -986,116 +986,8 @@
               ],
               "src": "653:6:7"
             },
-            "scope": 2260,
+            "scope": 2271,
             "src": "590:70:7",
-            "stateMutability": "nonpayable",
-            "superFunction": null,
-            "visibility": "external"
-          },
-          {
-            "body": null,
-            "documentation": null,
-            "id": 2248,
-            "implemented": false,
-            "kind": "function",
-            "modifiers": [],
-            "name": "transfer",
-            "nodeType": "FunctionDefinition",
-            "parameters": {
-              "id": 2244,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 2241,
-                  "name": "to",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 2248,
-                  "src": "683:10:7",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 2240,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "683:7:7",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 2243,
-                  "name": "value",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 2248,
-                  "src": "695:10:7",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 2242,
-                    "name": "uint",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "695:4:7",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                }
-              ],
-              "src": "682:24:7"
-            },
-            "returnParameters": {
-              "id": 2247,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 2246,
-                  "name": "",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 2248,
-                  "src": "725:4:7",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_bool",
-                    "typeString": "bool"
-                  },
-                  "typeName": {
-                    "id": 2245,
-                    "name": "bool",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "725:4:7",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_bool",
-                      "typeString": "bool"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                }
-              ],
-              "src": "724:6:7"
-            },
-            "scope": 2260,
-            "src": "665:66:7",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "external"
@@ -1107,7 +999,7 @@
             "implemented": false,
             "kind": "function",
             "modifiers": [],
-            "name": "transferFrom",
+            "name": "transfer",
             "nodeType": "FunctionDefinition",
             "parameters": {
               "id": 2255,
@@ -1115,38 +1007,11 @@
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2250,
-                  "name": "from",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 2259,
-                  "src": "758:12:7",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 2249,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "758:7:7",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "value": null,
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
                   "id": 2252,
                   "name": "to",
                   "nodeType": "VariableDeclaration",
                   "scope": 2259,
-                  "src": "772:10:7",
+                  "src": "683:10:7",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1157,7 +1022,7 @@
                     "id": 2251,
                     "name": "address",
                     "nodeType": "ElementaryTypeName",
-                    "src": "772:7:7",
+                    "src": "683:7:7",
                     "stateMutability": "nonpayable",
                     "typeDescriptions": {
                       "typeIdentifier": "t_address",
@@ -1173,7 +1038,7 @@
                   "name": "value",
                   "nodeType": "VariableDeclaration",
                   "scope": 2259,
-                  "src": "784:10:7",
+                  "src": "695:10:7",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -1182,6 +1047,141 @@
                   },
                   "typeName": {
                     "id": 2253,
+                    "name": "uint",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "695:4:7",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "682:24:7"
+            },
+            "returnParameters": {
+              "id": 2258,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 2257,
+                  "name": "",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 2259,
+                  "src": "725:4:7",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  },
+                  "typeName": {
+                    "id": 2256,
+                    "name": "bool",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "725:4:7",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                }
+              ],
+              "src": "724:6:7"
+            },
+            "scope": 2271,
+            "src": "665:66:7",
+            "stateMutability": "nonpayable",
+            "superFunction": null,
+            "visibility": "external"
+          },
+          {
+            "body": null,
+            "documentation": null,
+            "id": 2270,
+            "implemented": false,
+            "kind": "function",
+            "modifiers": [],
+            "name": "transferFrom",
+            "nodeType": "FunctionDefinition",
+            "parameters": {
+              "id": 2266,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 2261,
+                  "name": "from",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 2270,
+                  "src": "758:12:7",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 2260,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "758:7:7",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 2263,
+                  "name": "to",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 2270,
+                  "src": "772:10:7",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 2262,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "772:7:7",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "value": null,
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 2265,
+                  "name": "value",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 2270,
+                  "src": "784:10:7",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 2264,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "784:4:7",
@@ -1197,15 +1197,15 @@
               "src": "757:38:7"
             },
             "returnParameters": {
-              "id": 2258,
+              "id": 2269,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2257,
+                  "id": 2268,
                   "name": "",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2259,
+                  "scope": 2270,
                   "src": "814:4:7",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1214,7 +1214,7 @@
                     "typeString": "bool"
                   },
                   "typeName": {
-                    "id": 2256,
+                    "id": 2267,
                     "name": "bool",
                     "nodeType": "ElementaryTypeName",
                     "src": "814:4:7",
@@ -1229,14 +1229,14 @@
               ],
               "src": "813:6:7"
             },
-            "scope": 2260,
+            "scope": 2271,
             "src": "736:84:7",
             "stateMutability": "nonpayable",
             "superFunction": null,
             "visibility": "external"
           }
         ],
-        "scope": 2261,
+        "scope": 2272,
         "src": "26:796:7"
       }
     ],

--- a/build/contracts/Math.json
+++ b/build/contracts/Math.json
@@ -10,14 +10,14 @@
     "absolutePath": "contracts/libraries/Math.sol",
     "exportedSymbols": {
       "Math": [
-        2336
+        2347
       ]
     },
-    "id": 2337,
+    "id": 2348,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 2262,
+        "id": 2273,
         "literals": [
           "solidity",
           "=",
@@ -33,34 +33,34 @@
         "contractKind": "library",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 2336,
+        "id": 2347,
         "linearizedBaseContracts": [
-          2336
+          2347
         ],
         "name": "Math",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "body": {
-              "id": 2280,
+              "id": 2291,
               "nodeType": "Block",
               "src": "158:34:8",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 2278,
+                    "id": 2289,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 2271,
+                      "id": 2282,
                       "name": "z",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 2269,
+                      "referencedDeclaration": 2280,
                       "src": "168:1:8",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
@@ -77,18 +77,18 @@
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         },
-                        "id": 2274,
+                        "id": 2285,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
                         "lValueRequested": false,
                         "leftExpression": {
                           "argumentTypes": null,
-                          "id": 2272,
+                          "id": 2283,
                           "name": "x",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2264,
+                          "referencedDeclaration": 2275,
                           "src": "172:1:8",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -99,11 +99,11 @@
                         "operator": "<",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 2273,
+                          "id": 2284,
                           "name": "y",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2266,
+                          "referencedDeclaration": 2277,
                           "src": "176:1:8",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -118,18 +118,18 @@
                       },
                       "falseExpression": {
                         "argumentTypes": null,
-                        "id": 2276,
+                        "id": 2287,
                         "name": "y",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 2266,
+                        "referencedDeclaration": 2277,
                         "src": "184:1:8",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         }
                       },
-                      "id": 2277,
+                      "id": 2288,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -138,11 +138,11 @@
                       "src": "172:13:8",
                       "trueExpression": {
                         "argumentTypes": null,
-                        "id": 2275,
+                        "id": 2286,
                         "name": "x",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 2264,
+                        "referencedDeclaration": 2275,
                         "src": "180:1:8",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -160,29 +160,29 @@
                       "typeString": "uint256"
                     }
                   },
-                  "id": 2279,
+                  "id": 2290,
                   "nodeType": "ExpressionStatement",
                   "src": "168:17:8"
                 }
               ]
             },
             "documentation": null,
-            "id": 2281,
+            "id": 2292,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "min",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2267,
+              "id": 2278,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2264,
+                  "id": 2275,
                   "name": "x",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2281,
+                  "scope": 2292,
                   "src": "111:6:8",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -191,7 +191,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2263,
+                    "id": 2274,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "111:4:8",
@@ -205,10 +205,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2266,
+                  "id": 2277,
                   "name": "y",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2281,
+                  "scope": 2292,
                   "src": "119:6:8",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -217,7 +217,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2265,
+                    "id": 2276,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "119:4:8",
@@ -233,15 +233,15 @@
               "src": "110:16:8"
             },
             "returnParameters": {
-              "id": 2270,
+              "id": 2281,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2269,
+                  "id": 2280,
                   "name": "z",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2281,
+                  "scope": 2292,
                   "src": "150:6:8",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -250,7 +250,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2268,
+                    "id": 2279,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "150:4:8",
@@ -265,7 +265,7 @@
               ],
               "src": "149:8:8"
             },
-            "scope": 2336,
+            "scope": 2347,
             "src": "98:94:8",
             "stateMutability": "pure",
             "superFunction": null,
@@ -273,7 +273,7 @@
           },
           {
             "body": {
-              "id": 2334,
+              "id": 2345,
               "nodeType": "Block",
               "src": "360:239:8",
               "statements": [
@@ -284,18 +284,18 @@
                       "typeIdentifier": "t_uint256",
                       "typeString": "uint256"
                     },
-                    "id": 2290,
+                    "id": 2301,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftExpression": {
                       "argumentTypes": null,
-                      "id": 2288,
+                      "id": 2299,
                       "name": "y",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 2283,
+                      "referencedDeclaration": 2294,
                       "src": "374:1:8",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint256",
@@ -307,7 +307,7 @@
                     "rightExpression": {
                       "argumentTypes": null,
                       "hexValue": "33",
-                      "id": 2289,
+                      "id": 2300,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": true,
@@ -335,18 +335,18 @@
                         "typeIdentifier": "t_uint256",
                         "typeString": "uint256"
                       },
-                      "id": 2326,
+                      "id": 2337,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftExpression": {
                         "argumentTypes": null,
-                        "id": 2324,
+                        "id": 2335,
                         "name": "y",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 2283,
+                        "referencedDeclaration": 2294,
                         "src": "555:1:8",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint256",
@@ -358,7 +358,7 @@
                       "rightExpression": {
                         "argumentTypes": null,
                         "hexValue": "30",
-                        "id": 2325,
+                        "id": 2336,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -380,29 +380,29 @@
                       }
                     },
                     "falseBody": null,
-                    "id": 2332,
+                    "id": 2343,
                     "nodeType": "IfStatement",
                     "src": "551:42:8",
                     "trueBody": {
-                      "id": 2331,
+                      "id": 2342,
                       "nodeType": "Block",
                       "src": "563:30:8",
                       "statements": [
                         {
                           "expression": {
                             "argumentTypes": null,
-                            "id": 2329,
+                            "id": 2340,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
                             "lValueRequested": false,
                             "leftHandSide": {
                               "argumentTypes": null,
-                              "id": 2327,
+                              "id": 2338,
                               "name": "z",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 2286,
+                              "referencedDeclaration": 2297,
                               "src": "577:1:8",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint256",
@@ -414,7 +414,7 @@
                             "rightHandSide": {
                               "argumentTypes": null,
                               "hexValue": "31",
-                              "id": 2328,
+                              "id": 2339,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
@@ -435,36 +435,36 @@
                               "typeString": "uint256"
                             }
                           },
-                          "id": 2330,
+                          "id": 2341,
                           "nodeType": "ExpressionStatement",
                           "src": "577:5:8"
                         }
                       ]
                     }
                   },
-                  "id": 2333,
+                  "id": 2344,
                   "nodeType": "IfStatement",
                   "src": "370:223:8",
                   "trueBody": {
-                    "id": 2323,
+                    "id": 2334,
                     "nodeType": "Block",
                     "src": "381:164:8",
                     "statements": [
                       {
                         "expression": {
                           "argumentTypes": null,
-                          "id": 2293,
+                          "id": 2304,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftHandSide": {
                             "argumentTypes": null,
-                            "id": 2291,
+                            "id": 2302,
                             "name": "z",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2286,
+                            "referencedDeclaration": 2297,
                             "src": "395:1:8",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -475,11 +475,11 @@
                           "operator": "=",
                           "rightHandSide": {
                             "argumentTypes": null,
-                            "id": 2292,
+                            "id": 2303,
                             "name": "y",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2283,
+                            "referencedDeclaration": 2294,
                             "src": "399:1:8",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -492,21 +492,21 @@
                             "typeString": "uint256"
                           }
                         },
-                        "id": 2294,
+                        "id": 2305,
                         "nodeType": "ExpressionStatement",
                         "src": "395:5:8"
                       },
                       {
                         "assignments": [
-                          2296
+                          2307
                         ],
                         "declarations": [
                           {
                             "constant": false,
-                            "id": 2296,
+                            "id": 2307,
                             "name": "x",
                             "nodeType": "VariableDeclaration",
-                            "scope": 2323,
+                            "scope": 2334,
                             "src": "414:6:8",
                             "stateVariable": false,
                             "storageLocation": "default",
@@ -515,7 +515,7 @@
                               "typeString": "uint256"
                             },
                             "typeName": {
-                              "id": 2295,
+                              "id": 2306,
                               "name": "uint",
                               "nodeType": "ElementaryTypeName",
                               "src": "414:4:8",
@@ -528,14 +528,14 @@
                             "visibility": "internal"
                           }
                         ],
-                        "id": 2302,
+                        "id": 2313,
                         "initialValue": {
                           "argumentTypes": null,
                           "commonType": {
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 2301,
+                          "id": 2312,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -546,18 +546,18 @@
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             },
-                            "id": 2299,
+                            "id": 2310,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
                             "lValueRequested": false,
                             "leftExpression": {
                               "argumentTypes": null,
-                              "id": 2297,
+                              "id": 2308,
                               "name": "y",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 2283,
+                              "referencedDeclaration": 2294,
                               "src": "423:1:8",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint256",
@@ -569,7 +569,7 @@
                             "rightExpression": {
                               "argumentTypes": null,
                               "hexValue": "32",
-                              "id": 2298,
+                              "id": 2309,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": true,
@@ -595,7 +595,7 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "31",
-                            "id": 2300,
+                            "id": 2311,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -621,25 +621,25 @@
                       },
                       {
                         "body": {
-                          "id": 2321,
+                          "id": 2332,
                           "nodeType": "Block",
                           "src": "460:75:8",
                           "statements": [
                             {
                               "expression": {
                                 "argumentTypes": null,
-                                "id": 2308,
+                                "id": 2319,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
                                 "lValueRequested": false,
                                 "leftHandSide": {
                                   "argumentTypes": null,
-                                  "id": 2306,
+                                  "id": 2317,
                                   "name": "z",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2286,
+                                  "referencedDeclaration": 2297,
                                   "src": "478:1:8",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_uint256",
@@ -650,11 +650,11 @@
                                 "operator": "=",
                                 "rightHandSide": {
                                   "argumentTypes": null,
-                                  "id": 2307,
+                                  "id": 2318,
                                   "name": "x",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2296,
+                                  "referencedDeclaration": 2307,
                                   "src": "482:1:8",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_uint256",
@@ -667,25 +667,25 @@
                                   "typeString": "uint256"
                                 }
                               },
-                              "id": 2309,
+                              "id": 2320,
                               "nodeType": "ExpressionStatement",
                               "src": "478:5:8"
                             },
                             {
                               "expression": {
                                 "argumentTypes": null,
-                                "id": 2319,
+                                "id": 2330,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
                                 "lValueRequested": false,
                                 "leftHandSide": {
                                   "argumentTypes": null,
-                                  "id": 2310,
+                                  "id": 2321,
                                   "name": "x",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2296,
+                                  "referencedDeclaration": 2307,
                                   "src": "501:1:8",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_uint256",
@@ -700,7 +700,7 @@
                                     "typeIdentifier": "t_uint256",
                                     "typeString": "uint256"
                                   },
-                                  "id": 2318,
+                                  "id": 2329,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
@@ -714,7 +714,7 @@
                                           "typeIdentifier": "t_uint256",
                                           "typeString": "uint256"
                                         },
-                                        "id": 2315,
+                                        "id": 2326,
                                         "isConstant": false,
                                         "isLValue": false,
                                         "isPure": false,
@@ -725,18 +725,18 @@
                                             "typeIdentifier": "t_uint256",
                                             "typeString": "uint256"
                                           },
-                                          "id": 2313,
+                                          "id": 2324,
                                           "isConstant": false,
                                           "isLValue": false,
                                           "isPure": false,
                                           "lValueRequested": false,
                                           "leftExpression": {
                                             "argumentTypes": null,
-                                            "id": 2311,
+                                            "id": 2322,
                                             "name": "y",
                                             "nodeType": "Identifier",
                                             "overloadedDeclarations": [],
-                                            "referencedDeclaration": 2283,
+                                            "referencedDeclaration": 2294,
                                             "src": "506:1:8",
                                             "typeDescriptions": {
                                               "typeIdentifier": "t_uint256",
@@ -747,11 +747,11 @@
                                           "operator": "/",
                                           "rightExpression": {
                                             "argumentTypes": null,
-                                            "id": 2312,
+                                            "id": 2323,
                                             "name": "x",
                                             "nodeType": "Identifier",
                                             "overloadedDeclarations": [],
-                                            "referencedDeclaration": 2296,
+                                            "referencedDeclaration": 2307,
                                             "src": "510:1:8",
                                             "typeDescriptions": {
                                               "typeIdentifier": "t_uint256",
@@ -768,11 +768,11 @@
                                         "operator": "+",
                                         "rightExpression": {
                                           "argumentTypes": null,
-                                          "id": 2314,
+                                          "id": 2325,
                                           "name": "x",
                                           "nodeType": "Identifier",
                                           "overloadedDeclarations": [],
-                                          "referencedDeclaration": 2296,
+                                          "referencedDeclaration": 2307,
                                           "src": "514:1:8",
                                           "typeDescriptions": {
                                             "typeIdentifier": "t_uint256",
@@ -786,7 +786,7 @@
                                         }
                                       }
                                     ],
-                                    "id": 2316,
+                                    "id": 2327,
                                     "isConstant": false,
                                     "isInlineArray": false,
                                     "isLValue": false,
@@ -804,7 +804,7 @@
                                   "rightExpression": {
                                     "argumentTypes": null,
                                     "hexValue": "32",
-                                    "id": 2317,
+                                    "id": 2328,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": true,
@@ -831,7 +831,7 @@
                                   "typeString": "uint256"
                                 }
                               },
-                              "id": 2320,
+                              "id": 2331,
                               "nodeType": "ExpressionStatement",
                               "src": "501:19:8"
                             }
@@ -843,18 +843,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 2305,
+                          "id": 2316,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 2303,
+                            "id": 2314,
                             "name": "x",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2296,
+                            "referencedDeclaration": 2307,
                             "src": "453:1:8",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -865,11 +865,11 @@
                           "operator": "<",
                           "rightExpression": {
                             "argumentTypes": null,
-                            "id": 2304,
+                            "id": 2315,
                             "name": "z",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2286,
+                            "referencedDeclaration": 2297,
                             "src": "457:1:8",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -882,7 +882,7 @@
                             "typeString": "bool"
                           }
                         },
-                        "id": 2322,
+                        "id": 2333,
                         "nodeType": "WhileStatement",
                         "src": "446:89:8"
                       }
@@ -892,22 +892,22 @@
               ]
             },
             "documentation": null,
-            "id": 2335,
+            "id": 2346,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "sqrt",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2284,
+              "id": 2295,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2283,
+                  "id": 2294,
                   "name": "y",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2335,
+                  "scope": 2346,
                   "src": "321:6:8",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -916,7 +916,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2282,
+                    "id": 2293,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "321:4:8",
@@ -932,15 +932,15 @@
               "src": "320:8:8"
             },
             "returnParameters": {
-              "id": 2287,
+              "id": 2298,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2286,
+                  "id": 2297,
                   "name": "z",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2335,
+                  "scope": 2346,
                   "src": "352:6:8",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -949,7 +949,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2285,
+                    "id": 2296,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "352:4:8",
@@ -964,14 +964,14 @@
               ],
               "src": "351:8:8"
             },
-            "scope": 2336,
+            "scope": 2347,
             "src": "307:292:8",
             "stateMutability": "pure",
             "superFunction": null,
             "visibility": "internal"
           }
         ],
-        "scope": 2337,
+        "scope": 2348,
         "src": "79:522:8"
       }
     ],

--- a/build/contracts/SafeMath.json
+++ b/build/contracts/SafeMath.json
@@ -10,14 +10,14 @@
     "absolutePath": "contracts/libraries/SafeMath.sol",
     "exportedSymbols": {
       "SafeMath": [
-        2411
+        2422
       ]
     },
-    "id": 2412,
+    "id": 2423,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 2338,
+        "id": 2349,
         "literals": [
           "solidity",
           "=",
@@ -33,16 +33,16 @@
         "contractKind": "library",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 2411,
+        "id": 2422,
         "linearizedBaseContracts": [
-          2411
+          2422
         ],
         "name": "SafeMath",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "body": {
-              "id": 2359,
+              "id": 2370,
               "nodeType": "Block",
               "src": "215:66:9",
               "statements": [
@@ -56,7 +56,7 @@
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         },
-                        "id": 2355,
+                        "id": 2366,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -66,18 +66,18 @@
                           "components": [
                             {
                               "argumentTypes": null,
-                              "id": 2352,
+                              "id": 2363,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
                               "lValueRequested": false,
                               "leftHandSide": {
                                 "argumentTypes": null,
-                                "id": 2348,
+                                "id": 2359,
                                 "name": "z",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2345,
+                                "referencedDeclaration": 2356,
                                 "src": "234:1:9",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_uint256",
@@ -92,18 +92,18 @@
                                   "typeIdentifier": "t_uint256",
                                   "typeString": "uint256"
                                 },
-                                "id": 2351,
+                                "id": 2362,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
                                 "lValueRequested": false,
                                 "leftExpression": {
                                   "argumentTypes": null,
-                                  "id": 2349,
+                                  "id": 2360,
                                   "name": "x",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2340,
+                                  "referencedDeclaration": 2351,
                                   "src": "238:1:9",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_uint256",
@@ -114,11 +114,11 @@
                                 "operator": "+",
                                 "rightExpression": {
                                   "argumentTypes": null,
-                                  "id": 2350,
+                                  "id": 2361,
                                   "name": "y",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2342,
+                                  "referencedDeclaration": 2353,
                                   "src": "242:1:9",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_uint256",
@@ -138,7 +138,7 @@
                               }
                             }
                           ],
-                          "id": 2353,
+                          "id": 2364,
                           "isConstant": false,
                           "isInlineArray": false,
                           "isLValue": false,
@@ -155,11 +155,11 @@
                         "operator": ">=",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 2354,
+                          "id": 2365,
                           "name": "x",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2340,
+                          "referencedDeclaration": 2351,
                           "src": "248:1:9",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -175,7 +175,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "64732d6d6174682d6164642d6f766572666c6f77",
-                        "id": 2356,
+                        "id": 2367,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -202,21 +202,21 @@
                           "typeString": "literal_string \"ds-math-add-overflow\""
                         }
                       ],
-                      "id": 2347,
+                      "id": 2358,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "225:7:9",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 2357,
+                    "id": 2368,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -230,29 +230,29 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 2358,
+                  "id": 2369,
                   "nodeType": "ExpressionStatement",
                   "src": "225:49:9"
                 }
               ]
             },
             "documentation": null,
-            "id": 2360,
+            "id": 2371,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "add",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2343,
+              "id": 2354,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2340,
+                  "id": 2351,
                   "name": "x",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2360,
+                  "scope": 2371,
                   "src": "168:6:9",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -261,7 +261,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2339,
+                    "id": 2350,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "168:4:9",
@@ -275,10 +275,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2342,
+                  "id": 2353,
                   "name": "y",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2360,
+                  "scope": 2371,
                   "src": "176:6:9",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -287,7 +287,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2341,
+                    "id": 2352,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "176:4:9",
@@ -303,15 +303,15 @@
               "src": "167:16:9"
             },
             "returnParameters": {
-              "id": 2346,
+              "id": 2357,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2345,
+                  "id": 2356,
                   "name": "z",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2360,
+                  "scope": 2371,
                   "src": "207:6:9",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -320,7 +320,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2344,
+                    "id": 2355,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "207:4:9",
@@ -335,7 +335,7 @@
               ],
               "src": "206:8:9"
             },
-            "scope": 2411,
+            "scope": 2422,
             "src": "155:126:9",
             "stateMutability": "pure",
             "superFunction": null,
@@ -343,7 +343,7 @@
           },
           {
             "body": {
-              "id": 2381,
+              "id": 2392,
               "nodeType": "Block",
               "src": "347:67:9",
               "statements": [
@@ -357,7 +357,7 @@
                           "typeIdentifier": "t_uint256",
                           "typeString": "uint256"
                         },
-                        "id": 2377,
+                        "id": 2388,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -367,18 +367,18 @@
                           "components": [
                             {
                               "argumentTypes": null,
-                              "id": 2374,
+                              "id": 2385,
                               "isConstant": false,
                               "isLValue": false,
                               "isPure": false,
                               "lValueRequested": false,
                               "leftHandSide": {
                                 "argumentTypes": null,
-                                "id": 2370,
+                                "id": 2381,
                                 "name": "z",
                                 "nodeType": "Identifier",
                                 "overloadedDeclarations": [],
-                                "referencedDeclaration": 2367,
+                                "referencedDeclaration": 2378,
                                 "src": "366:1:9",
                                 "typeDescriptions": {
                                   "typeIdentifier": "t_uint256",
@@ -393,18 +393,18 @@
                                   "typeIdentifier": "t_uint256",
                                   "typeString": "uint256"
                                 },
-                                "id": 2373,
+                                "id": 2384,
                                 "isConstant": false,
                                 "isLValue": false,
                                 "isPure": false,
                                 "lValueRequested": false,
                                 "leftExpression": {
                                   "argumentTypes": null,
-                                  "id": 2371,
+                                  "id": 2382,
                                   "name": "x",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2362,
+                                  "referencedDeclaration": 2373,
                                   "src": "370:1:9",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_uint256",
@@ -415,11 +415,11 @@
                                 "operator": "-",
                                 "rightExpression": {
                                   "argumentTypes": null,
-                                  "id": 2372,
+                                  "id": 2383,
                                   "name": "y",
                                   "nodeType": "Identifier",
                                   "overloadedDeclarations": [],
-                                  "referencedDeclaration": 2364,
+                                  "referencedDeclaration": 2375,
                                   "src": "374:1:9",
                                   "typeDescriptions": {
                                     "typeIdentifier": "t_uint256",
@@ -439,7 +439,7 @@
                               }
                             }
                           ],
-                          "id": 2375,
+                          "id": 2386,
                           "isConstant": false,
                           "isInlineArray": false,
                           "isLValue": false,
@@ -456,11 +456,11 @@
                         "operator": "<=",
                         "rightExpression": {
                           "argumentTypes": null,
-                          "id": 2376,
+                          "id": 2387,
                           "name": "x",
                           "nodeType": "Identifier",
                           "overloadedDeclarations": [],
-                          "referencedDeclaration": 2362,
+                          "referencedDeclaration": 2373,
                           "src": "380:1:9",
                           "typeDescriptions": {
                             "typeIdentifier": "t_uint256",
@@ -476,7 +476,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "64732d6d6174682d7375622d756e646572666c6f77",
-                        "id": 2378,
+                        "id": 2389,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -503,21 +503,21 @@
                           "typeString": "literal_string \"ds-math-sub-underflow\""
                         }
                       ],
-                      "id": 2369,
+                      "id": 2380,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "357:7:9",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 2379,
+                    "id": 2390,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -531,29 +531,29 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 2380,
+                  "id": 2391,
                   "nodeType": "ExpressionStatement",
                   "src": "357:50:9"
                 }
               ]
             },
             "documentation": null,
-            "id": 2382,
+            "id": 2393,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "sub",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2365,
+              "id": 2376,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2362,
+                  "id": 2373,
                   "name": "x",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2382,
+                  "scope": 2393,
                   "src": "300:6:9",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -562,7 +562,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2361,
+                    "id": 2372,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "300:4:9",
@@ -576,10 +576,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2364,
+                  "id": 2375,
                   "name": "y",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2382,
+                  "scope": 2393,
                   "src": "308:6:9",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -588,7 +588,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2363,
+                    "id": 2374,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "308:4:9",
@@ -604,15 +604,15 @@
               "src": "299:16:9"
             },
             "returnParameters": {
-              "id": 2368,
+              "id": 2379,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2367,
+                  "id": 2378,
                   "name": "z",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2382,
+                  "scope": 2393,
                   "src": "339:6:9",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -621,7 +621,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2366,
+                    "id": 2377,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "339:4:9",
@@ -636,7 +636,7 @@
               ],
               "src": "338:8:9"
             },
-            "scope": 2411,
+            "scope": 2422,
             "src": "287:127:9",
             "stateMutability": "pure",
             "superFunction": null,
@@ -644,7 +644,7 @@
           },
           {
             "body": {
-              "id": 2409,
+              "id": 2420,
               "nodeType": "Block",
               "src": "480:80:9",
               "statements": [
@@ -658,7 +658,7 @@
                           "typeIdentifier": "t_bool",
                           "typeString": "bool"
                         },
-                        "id": 2405,
+                        "id": 2416,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -669,18 +669,18 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 2394,
+                          "id": 2405,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
                           "lValueRequested": false,
                           "leftExpression": {
                             "argumentTypes": null,
-                            "id": 2392,
+                            "id": 2403,
                             "name": "y",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2386,
+                            "referencedDeclaration": 2397,
                             "src": "498:1:9",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -692,7 +692,7 @@
                           "rightExpression": {
                             "argumentTypes": null,
                             "hexValue": "30",
-                            "id": 2393,
+                            "id": 2404,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": true,
@@ -721,7 +721,7 @@
                             "typeIdentifier": "t_uint256",
                             "typeString": "uint256"
                           },
-                          "id": 2404,
+                          "id": 2415,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": false,
@@ -732,7 +732,7 @@
                               "typeIdentifier": "t_uint256",
                               "typeString": "uint256"
                             },
-                            "id": 2402,
+                            "id": 2413,
                             "isConstant": false,
                             "isLValue": false,
                             "isPure": false,
@@ -742,18 +742,18 @@
                               "components": [
                                 {
                                   "argumentTypes": null,
-                                  "id": 2399,
+                                  "id": 2410,
                                   "isConstant": false,
                                   "isLValue": false,
                                   "isPure": false,
                                   "lValueRequested": false,
                                   "leftHandSide": {
                                     "argumentTypes": null,
-                                    "id": 2395,
+                                    "id": 2406,
                                     "name": "z",
                                     "nodeType": "Identifier",
                                     "overloadedDeclarations": [],
-                                    "referencedDeclaration": 2389,
+                                    "referencedDeclaration": 2400,
                                     "src": "509:1:9",
                                     "typeDescriptions": {
                                       "typeIdentifier": "t_uint256",
@@ -768,18 +768,18 @@
                                       "typeIdentifier": "t_uint256",
                                       "typeString": "uint256"
                                     },
-                                    "id": 2398,
+                                    "id": 2409,
                                     "isConstant": false,
                                     "isLValue": false,
                                     "isPure": false,
                                     "lValueRequested": false,
                                     "leftExpression": {
                                       "argumentTypes": null,
-                                      "id": 2396,
+                                      "id": 2407,
                                       "name": "x",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 2384,
+                                      "referencedDeclaration": 2395,
                                       "src": "513:1:9",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint256",
@@ -790,11 +790,11 @@
                                     "operator": "*",
                                     "rightExpression": {
                                       "argumentTypes": null,
-                                      "id": 2397,
+                                      "id": 2408,
                                       "name": "y",
                                       "nodeType": "Identifier",
                                       "overloadedDeclarations": [],
-                                      "referencedDeclaration": 2386,
+                                      "referencedDeclaration": 2397,
                                       "src": "517:1:9",
                                       "typeDescriptions": {
                                         "typeIdentifier": "t_uint256",
@@ -814,7 +814,7 @@
                                   }
                                 }
                               ],
-                              "id": 2400,
+                              "id": 2411,
                               "isConstant": false,
                               "isInlineArray": false,
                               "isLValue": false,
@@ -831,11 +831,11 @@
                             "operator": "/",
                             "rightExpression": {
                               "argumentTypes": null,
-                              "id": 2401,
+                              "id": 2412,
                               "name": "y",
                               "nodeType": "Identifier",
                               "overloadedDeclarations": [],
-                              "referencedDeclaration": 2386,
+                              "referencedDeclaration": 2397,
                               "src": "522:1:9",
                               "typeDescriptions": {
                                 "typeIdentifier": "t_uint256",
@@ -852,11 +852,11 @@
                           "operator": "==",
                           "rightExpression": {
                             "argumentTypes": null,
-                            "id": 2403,
+                            "id": 2414,
                             "name": "x",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2384,
+                            "referencedDeclaration": 2395,
                             "src": "527:1:9",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint256",
@@ -878,7 +878,7 @@
                       {
                         "argumentTypes": null,
                         "hexValue": "64732d6d6174682d6d756c2d6f766572666c6f77",
-                        "id": 2406,
+                        "id": 2417,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": true,
@@ -905,21 +905,21 @@
                           "typeString": "literal_string \"ds-math-mul-overflow\""
                         }
                       ],
-                      "id": 2391,
+                      "id": 2402,
                       "name": "require",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [
-                        2489,
-                        2490
+                        2500,
+                        2501
                       ],
-                      "referencedDeclaration": 2490,
+                      "referencedDeclaration": 2501,
                       "src": "490:7:9",
                       "typeDescriptions": {
                         "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
                         "typeString": "function (bool,string memory) pure"
                       }
                     },
-                    "id": 2407,
+                    "id": 2418,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
@@ -933,29 +933,29 @@
                       "typeString": "tuple()"
                     }
                   },
-                  "id": 2408,
+                  "id": 2419,
                   "nodeType": "ExpressionStatement",
                   "src": "490:63:9"
                 }
               ]
             },
             "documentation": null,
-            "id": 2410,
+            "id": 2421,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "mul",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2387,
+              "id": 2398,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2384,
+                  "id": 2395,
                   "name": "x",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2410,
+                  "scope": 2421,
                   "src": "433:6:9",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -964,7 +964,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2383,
+                    "id": 2394,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "433:4:9",
@@ -978,10 +978,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2386,
+                  "id": 2397,
                   "name": "y",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2410,
+                  "scope": 2421,
                   "src": "441:6:9",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -990,7 +990,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2385,
+                    "id": 2396,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "441:4:9",
@@ -1006,15 +1006,15 @@
               "src": "432:16:9"
             },
             "returnParameters": {
-              "id": 2390,
+              "id": 2401,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2389,
+                  "id": 2400,
                   "name": "z",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2410,
+                  "scope": 2421,
                   "src": "472:6:9",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -1023,7 +1023,7 @@
                     "typeString": "uint256"
                   },
                   "typeName": {
-                    "id": 2388,
+                    "id": 2399,
                     "name": "uint",
                     "nodeType": "ElementaryTypeName",
                     "src": "472:4:9",
@@ -1038,14 +1038,14 @@
               ],
               "src": "471:8:9"
             },
-            "scope": 2411,
+            "scope": 2422,
             "src": "420:140:9",
             "stateMutability": "pure",
             "superFunction": null,
             "visibility": "internal"
           }
         ],
-        "scope": 2412,
+        "scope": 2423,
         "src": "132:430:9"
       }
     ],

--- a/build/contracts/UQ112x112.json
+++ b/build/contracts/UQ112x112.json
@@ -10,14 +10,14 @@
     "absolutePath": "contracts/libraries/UQ112x112.sol",
     "exportedSymbols": {
       "UQ112x112": [
-        2453
+        2464
       ]
     },
-    "id": 2454,
+    "id": 2465,
     "nodeType": "SourceUnit",
     "nodes": [
       {
-        "id": 2413,
+        "id": 2424,
         "literals": [
           "solidity",
           "=",
@@ -33,19 +33,19 @@
         "contractKind": "library",
         "documentation": null,
         "fullyImplemented": true,
-        "id": 2453,
+        "id": 2464,
         "linearizedBaseContracts": [
-          2453
+          2464
         ],
         "name": "UQ112x112",
         "nodeType": "ContractDefinition",
         "nodes": [
           {
             "constant": true,
-            "id": 2418,
+            "id": 2429,
             "name": "Q112",
             "nodeType": "VariableDeclaration",
-            "scope": 2453,
+            "scope": 2464,
             "src": "207:30:10",
             "stateVariable": true,
             "storageLocation": "default",
@@ -54,7 +54,7 @@
               "typeString": "uint224"
             },
             "typeName": {
-              "id": 2414,
+              "id": 2425,
               "name": "uint224",
               "nodeType": "ElementaryTypeName",
               "src": "207:7:10",
@@ -69,7 +69,7 @@
                 "typeIdentifier": "t_rational_5192296858534827628530496329220096_by_1",
                 "typeString": "int_const 5192...(26 digits omitted)...0096"
               },
-              "id": 2417,
+              "id": 2428,
               "isConstant": false,
               "isLValue": false,
               "isPure": true,
@@ -77,7 +77,7 @@
               "leftExpression": {
                 "argumentTypes": null,
                 "hexValue": "32",
-                "id": 2415,
+                "id": 2426,
                 "isConstant": false,
                 "isLValue": false,
                 "isPure": true,
@@ -97,7 +97,7 @@
               "rightExpression": {
                 "argumentTypes": null,
                 "hexValue": "313132",
-                "id": 2416,
+                "id": 2427,
                 "isConstant": false,
                 "isLValue": false,
                 "isPure": true,
@@ -122,25 +122,25 @@
           },
           {
             "body": {
-              "id": 2433,
+              "id": 2444,
               "nodeType": "Block",
               "src": "344:57:10",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 2431,
+                    "id": 2442,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 2425,
+                      "id": 2436,
                       "name": "z",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 2423,
+                      "referencedDeclaration": 2434,
                       "src": "354:1:10",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint224",
@@ -155,7 +155,7 @@
                         "typeIdentifier": "t_uint224",
                         "typeString": "uint224"
                       },
-                      "id": 2430,
+                      "id": 2441,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
@@ -165,11 +165,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 2427,
+                            "id": 2438,
                             "name": "y",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2420,
+                            "referencedDeclaration": 2431,
                             "src": "366:1:10",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint112",
@@ -184,7 +184,7 @@
                               "typeString": "uint112"
                             }
                           ],
-                          "id": 2426,
+                          "id": 2437,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -197,7 +197,7 @@
                           },
                           "typeName": "uint224"
                         },
-                        "id": 2428,
+                        "id": 2439,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -215,11 +215,11 @@
                       "operator": "*",
                       "rightExpression": {
                         "argumentTypes": null,
-                        "id": 2429,
+                        "id": 2440,
                         "name": "Q112",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 2418,
+                        "referencedDeclaration": 2429,
                         "src": "371:4:10",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint224",
@@ -238,29 +238,29 @@
                       "typeString": "uint224"
                     }
                   },
-                  "id": 2432,
+                  "id": 2443,
                   "nodeType": "ExpressionStatement",
                   "src": "354:21:10"
                 }
               ]
             },
             "documentation": null,
-            "id": 2434,
+            "id": 2445,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "encode",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2421,
+              "id": 2432,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2420,
+                  "id": 2431,
                   "name": "y",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2434,
+                  "scope": 2445,
                   "src": "299:9:10",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -269,7 +269,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 2419,
+                    "id": 2430,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "299:7:10",
@@ -285,15 +285,15 @@
               "src": "298:11:10"
             },
             "returnParameters": {
-              "id": 2424,
+              "id": 2435,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2423,
+                  "id": 2434,
                   "name": "z",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2434,
+                  "scope": 2445,
                   "src": "333:9:10",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -302,7 +302,7 @@
                     "typeString": "uint224"
                   },
                   "typeName": {
-                    "id": 2422,
+                    "id": 2433,
                     "name": "uint224",
                     "nodeType": "ElementaryTypeName",
                     "src": "333:7:10",
@@ -317,7 +317,7 @@
               ],
               "src": "332:11:10"
             },
-            "scope": 2453,
+            "scope": 2464,
             "src": "283:118:10",
             "stateMutability": "pure",
             "superFunction": null,
@@ -325,25 +325,25 @@
           },
           {
             "body": {
-              "id": 2451,
+              "id": 2462,
               "nodeType": "Block",
               "src": "540:35:10",
               "statements": [
                 {
                   "expression": {
                     "argumentTypes": null,
-                    "id": 2449,
+                    "id": 2460,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "argumentTypes": null,
-                      "id": 2443,
+                      "id": 2454,
                       "name": "z",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 2441,
+                      "referencedDeclaration": 2452,
                       "src": "550:1:10",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint224",
@@ -358,18 +358,18 @@
                         "typeIdentifier": "t_uint224",
                         "typeString": "uint224"
                       },
-                      "id": 2448,
+                      "id": 2459,
                       "isConstant": false,
                       "isLValue": false,
                       "isPure": false,
                       "lValueRequested": false,
                       "leftExpression": {
                         "argumentTypes": null,
-                        "id": 2444,
+                        "id": 2455,
                         "name": "x",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 2436,
+                        "referencedDeclaration": 2447,
                         "src": "554:1:10",
                         "typeDescriptions": {
                           "typeIdentifier": "t_uint224",
@@ -383,11 +383,11 @@
                         "arguments": [
                           {
                             "argumentTypes": null,
-                            "id": 2446,
+                            "id": 2457,
                             "name": "y",
                             "nodeType": "Identifier",
                             "overloadedDeclarations": [],
-                            "referencedDeclaration": 2438,
+                            "referencedDeclaration": 2449,
                             "src": "566:1:10",
                             "typeDescriptions": {
                               "typeIdentifier": "t_uint112",
@@ -402,7 +402,7 @@
                               "typeString": "uint112"
                             }
                           ],
-                          "id": 2445,
+                          "id": 2456,
                           "isConstant": false,
                           "isLValue": false,
                           "isPure": true,
@@ -415,7 +415,7 @@
                           },
                           "typeName": "uint224"
                         },
-                        "id": 2447,
+                        "id": 2458,
                         "isConstant": false,
                         "isLValue": false,
                         "isPure": false,
@@ -441,29 +441,29 @@
                       "typeString": "uint224"
                     }
                   },
-                  "id": 2450,
+                  "id": 2461,
                   "nodeType": "ExpressionStatement",
                   "src": "550:18:10"
                 }
               ]
             },
             "documentation": null,
-            "id": 2452,
+            "id": 2463,
             "implemented": true,
             "kind": "function",
             "modifiers": [],
             "name": "uqdiv",
             "nodeType": "FunctionDefinition",
             "parameters": {
-              "id": 2439,
+              "id": 2450,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2436,
+                  "id": 2447,
                   "name": "x",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2452,
+                  "scope": 2463,
                   "src": "484:9:10",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -472,7 +472,7 @@
                     "typeString": "uint224"
                   },
                   "typeName": {
-                    "id": 2435,
+                    "id": 2446,
                     "name": "uint224",
                     "nodeType": "ElementaryTypeName",
                     "src": "484:7:10",
@@ -486,10 +486,10 @@
                 },
                 {
                   "constant": false,
-                  "id": 2438,
+                  "id": 2449,
                   "name": "y",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2452,
+                  "scope": 2463,
                   "src": "495:9:10",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -498,7 +498,7 @@
                     "typeString": "uint112"
                   },
                   "typeName": {
-                    "id": 2437,
+                    "id": 2448,
                     "name": "uint112",
                     "nodeType": "ElementaryTypeName",
                     "src": "495:7:10",
@@ -514,15 +514,15 @@
               "src": "483:22:10"
             },
             "returnParameters": {
-              "id": 2442,
+              "id": 2453,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 2441,
+                  "id": 2452,
                   "name": "z",
                   "nodeType": "VariableDeclaration",
-                  "scope": 2452,
+                  "scope": 2463,
                   "src": "529:9:10",
                   "stateVariable": false,
                   "storageLocation": "default",
@@ -531,7 +531,7 @@
                     "typeString": "uint224"
                   },
                   "typeName": {
-                    "id": 2440,
+                    "id": 2451,
                     "name": "uint224",
                     "nodeType": "ElementaryTypeName",
                     "src": "529:7:10",
@@ -546,14 +546,14 @@
               ],
               "src": "528:11:10"
             },
-            "scope": 2453,
+            "scope": 2464,
             "src": "469:106:10",
             "stateMutability": "pure",
             "superFunction": null,
             "visibility": "internal"
           }
         ],
-        "scope": 2454,
+        "scope": 2465,
         "src": "183:394:10"
       }
     ],

--- a/build/types/DXswapFactory.d.ts
+++ b/build/types/DXswapFactory.d.ts
@@ -21,6 +21,8 @@ export class DXswapFactory extends Contract {
   );
   clone(): DXswapFactory;
   methods: {
+    INIT_CODE_PAIR_HASH(): TransactionObject<string>;
+
     allPairs(arg0: number | string): TransactionObject<string>;
 
     allPairsLength(): TransactionObject<string>;

--- a/contracts/DXswapFactory.sol
+++ b/contracts/DXswapFactory.sol
@@ -7,6 +7,7 @@ contract DXswapFactory is IDXswapFactory {
     address public feeTo;
     address public feeToSetter;
     uint8 public protocolFeeDenominator = 5; // uses 0.05% (1/~6 of 0.30%) per trade as default
+    bytes32 public constant INIT_CODE_PAIR_HASH = keccak256(abi.encodePacked(type(DXswapPair).creationCode));
 
     mapping(address => mapping(address => address)) public getPair;
     address[] public allPairs;

--- a/test/DXswapFactory.spec.ts
+++ b/test/DXswapFactory.spec.ts
@@ -31,10 +31,11 @@ describe('DXswapFactory', () => {
     factory = fixture.factory
   })
 
-  it('feeTo, feeToSetter, allPairsLength', async () => {
+  it('feeTo, feeToSetter, allPairsLength, INIT_CODE_PAIR_HASH', async () => {
     expect(await factory.feeTo()).to.eq(AddressZero)
     expect(await factory.feeToSetter()).to.eq(wallet.address)
     expect(await factory.allPairsLength()).to.eq(0)
+    expect(await factory.INIT_CODE_PAIR_HASH()).to.eq('0xc12df094d952118426a3680de1a396a7cfeff86597d53f897ddc5e0e4aeef5fd')
   })
 
   async function createPair(tokens: [string, string]) {


### PR DESCRIPTION
- Adds a public constant that expose the initialize hash of the DXswapPair bytecode, this is used in the create2 contract creation in the createPair function.
- Updated build and openzeppelin kovan deployment.