### PR TITLE
Swap fee 0 fix

### DIFF
--- a/contracts/DXswapPair.sol
+++ b/contracts/DXswapPair.sol
@@ -186,11 +186,9 @@ contract DXswapPair is IDXswapPair, DXswapERC20 {
         uint amount1In = balance1 > _reserve1 - amount1Out ? balance1 - (_reserve1 - amount1Out) : 0;
         require(amount0In > 0 || amount1In > 0, 'DXswapPair: INSUFFICIENT_INPUT_AMOUNT');
         { // scope for reserve{0,1}Adjusted, avoids stack too deep errors
-        if (swapFee > 0) {
           uint balance0Adjusted = balance0.mul(10000).sub(amount0In.mul(swapFee));
           uint balance1Adjusted = balance1.mul(10000).sub(amount1In.mul(swapFee));
           require(balance0Adjusted.mul(balance1Adjusted) >= uint(_reserve0).mul(_reserve1).mul(10000**2), 'DXswapPair: K');
-        }
         }
 
         _update(balance0, balance1, _reserve0, _reserve1);

--- a/test/DXswapFactory.spec.ts
+++ b/test/DXswapFactory.spec.ts
@@ -35,7 +35,7 @@ describe('DXswapFactory', () => {
     expect(await factory.feeTo()).to.eq(AddressZero)
     expect(await factory.feeToSetter()).to.eq(wallet.address)
     expect(await factory.allPairsLength()).to.eq(0)
-    expect(await factory.INIT_CODE_PAIR_HASH()).to.eq('0x4e9705def664ab284f8d926dd36c91628cc804185ca7ea83ac2c65d79f51524a')
+    expect(await factory.INIT_CODE_PAIR_HASH()).to.eq('0x2db943b381c6ef706828ea5e89f480bd449d4d3a2b98e6da97b30d0eb41fb6d6')
   })
 
   async function createPair(tokens: [string, string]) {
@@ -69,7 +69,7 @@ describe('DXswapFactory', () => {
   it('createPair:gas', async () => {
     const tx = await factory.createPair(...TEST_ADDRESSES)
     const receipt = await tx.wait()
-    expect(receipt.gasUsed).to.eq(2139149)
+    expect(receipt.gasUsed).to.eq(2136142)
   })
 
   it('setFeeTo', async () => {

--- a/test/DXswapPair.spec.ts
+++ b/test/DXswapPair.spec.ts
@@ -263,6 +263,34 @@ describe('DXswapPair', () => {
     await pair.burn(wallet.address, overrides)
     expect(await pair.totalSupply()).to.eq(MINIMUM_LIQUIDITY)
   })
+  
+  it('feeTo:off, swapFee:0 attack', async () => {
+    await factory.setSwapFee(pair.address, 0)
+    const token0Amount = expandTo18Decimals(1000)
+    const token1Amount = expandTo18Decimals(1000)
+    await addLiquidity(token0Amount, token1Amount)
+    
+    expect(await token0.balanceOf(pair.address)).to.eq(expandTo18Decimals(1000))
+    expect(await token1.balanceOf(pair.address)).to.eq(expandTo18Decimals(1000))
+    expect(await token0.balanceOf(wallet.address)).to.eq(expandTo18Decimals(9000))
+    expect(await token1.balanceOf(wallet.address)).to.eq(expandTo18Decimals(9000))    
+    
+    // Attack pool
+    await token1.transfer(pair.address, expandTo18Decimals(1))
+    await pair.swap(expandTo18Decimals(999), 0, wallet.address, '0x', overrides)
+    await token0.transfer(pair.address, expandTo18Decimals(1))
+    await pair.swap(0, expandTo18Decimals(999), wallet.address, '0x', overrides)
+
+    expect(await token0.balanceOf(pair.address)).to.eq(expandTo18Decimals(2))
+    expect(await token1.balanceOf(pair.address)).to.eq(expandTo18Decimals(2))
+    expect(await token0.balanceOf(wallet.address)).to.eq(expandTo18Decimals(9998))
+    expect(await token1.balanceOf(wallet.address)).to.eq(expandTo18Decimals(9998))
+    
+    const expectedLiquidity = expandTo18Decimals(1000)
+    await pair.transfer(pair.address, expectedLiquidity.sub(MINIMUM_LIQUIDITY))
+    await pair.burn(wallet.address, overrides)
+    expect(await pair.totalSupply()).to.eq(MINIMUM_LIQUIDITY)
+  })
 
   it('feeTo:on', async () => {
     await factory.setFeeTo(other.address)

--- a/test/DXswapPair.spec.ts
+++ b/test/DXswapPair.spec.ts
@@ -183,7 +183,7 @@ describe('DXswapPair', () => {
     await mineBlock(provider, (await provider.getBlock('latest')).timestamp + 1)
     const tx = await pair.swap(expectedOutputAmount, 0, wallet.address, '0x', overrides)
     const receipt = await tx.wait()
-    expect(receipt.gasUsed).to.eq(76473)
+    expect(receipt.gasUsed).to.eq(75647)
   })
 
   it('burn', async () => {

--- a/test/DXswapPair.spec.ts
+++ b/test/DXswapPair.spec.ts
@@ -273,18 +273,22 @@ describe('DXswapPair', () => {
     expect(await token0.balanceOf(pair.address)).to.eq(expandTo18Decimals(1000))
     expect(await token1.balanceOf(pair.address)).to.eq(expandTo18Decimals(1000))
     expect(await token0.balanceOf(wallet.address)).to.eq(expandTo18Decimals(9000))
-    expect(await token1.balanceOf(wallet.address)).to.eq(expandTo18Decimals(9000))    
+    expect(await token1.balanceOf(wallet.address)).to.eq(expandTo18Decimals(9000))
     
     // Attack pool
     await token1.transfer(pair.address, expandTo18Decimals(1))
-    await pair.swap(expandTo18Decimals(999), 0, wallet.address, '0x', overrides)
+    await expect(pair.swap(expandTo18Decimals(999), 0, wallet.address, '0x', overrides)).to.be.revertedWith(
+      'DXswapPair: K'
+    )
     await token0.transfer(pair.address, expandTo18Decimals(1))
-    await pair.swap(0, expandTo18Decimals(999), wallet.address, '0x', overrides)
+    await expect(pair.swap(0, expandTo18Decimals(999), wallet.address, '0x', overrides)).to.be.revertedWith(
+      'DXswapPair: K'
+    )
 
-    expect(await token0.balanceOf(pair.address)).to.eq(expandTo18Decimals(2))
-    expect(await token1.balanceOf(pair.address)).to.eq(expandTo18Decimals(2))
-    expect(await token0.balanceOf(wallet.address)).to.eq(expandTo18Decimals(9998))
-    expect(await token1.balanceOf(wallet.address)).to.eq(expandTo18Decimals(9998))
+    expect(await token0.balanceOf(pair.address)).to.eq(expandTo18Decimals(1001))
+    expect(await token1.balanceOf(pair.address)).to.eq(expandTo18Decimals(1001))
+    expect(await token0.balanceOf(wallet.address)).to.eq(expandTo18Decimals(8999))
+    expect(await token1.balanceOf(wallet.address)).to.eq(expandTo18Decimals(8999)) 
     
     const expectedLiquidity = expandTo18Decimals(1000)
     await pair.transfer(pair.address, expectedLiquidity.sub(MINIMUM_LIQUIDITY))


### PR DESCRIPTION
This PR fixes the only vulnerability found in the audit of dxswap-core contracts, the issue was that when the swap fee equals zero it skips the check of the new balances in the swap method, this a crucial check to verify that the new balances follows the constant-product formula from which Uniswap was designed.

The first commit creates the tests case where the attack can be reproduced and the next commits fixes the smart contract code and changes the tests to verify that the attack can no longer be reproduced.