### PR TITLE
Feat/protocol fee

### DIFF
--- a/contracts/DXswapFactory.sol
+++ b/contracts/DXswapFactory.sol
@@ -12,13 +12,13 @@ contract DXswapFactory is IDXswapFactory {
     mapping(address => mapping(address => address)) public getPair;
     address[] public allPairs;
 
-    event PairCreated(address indexed token0, address indexed token1, address pair, uint);
+    event PairCreated(address indexed token0, address indexed token1, address pair, uint256);
 
     constructor(address _feeToSetter) public {
         feeToSetter = _feeToSetter;
     }
 
-    function allPairsLength() external view returns (uint) {
+    function allPairsLength() external view returns (uint256) {
         return allPairs.length;
     }
 
@@ -48,15 +48,25 @@ contract DXswapFactory is IDXswapFactory {
         require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');
         feeToSetter = _feeToSetter;
     }
-    
+
     function setProtocolFee(uint8 _protocolFeeDenominator) external {
         require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');
         require(_protocolFeeDenominator > 0, 'DXswapFactory: FORBIDDEN_FEE');
         protocolFeeDenominator = _protocolFeeDenominator;
     }
-    
+
     function setSwapFee(address _pair, uint32 _swapFee) external {
         require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');
         IDXswapPair(_pair).setSwapFee(_swapFee);
+    }
+
+    function setExternalFeeRecipient(address _pair, address _externalFeeRecipient) external {
+        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');
+        IDXswapPair(_pair).setExternalFeeRecipient(_externalFeeRecipient);
+    }
+
+    function setPercentFeeToExternalRecipient(address _pair, uint32 _percentFeeToExternalRecipient) external {
+        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');
+        IDXswapPair(_pair).setPercentFeeToExternalRecipient(_percentFeeToExternalRecipient);
     }
 }

--- a/contracts/DXswapFeeReceiver.sol
+++ b/contracts/DXswapFeeReceiver.sol
@@ -6,18 +6,22 @@ import './interfaces/IWETH.sol';
 import './libraries/TransferHelper.sol';
 import './libraries/SafeMath.sol';
 
-
 contract DXswapFeeReceiver {
-    using SafeMath for uint;
+    using SafeMath for uint256;
 
     address public owner;
     IDXswapFactory public factory;
     address public WETH;
     address public ethReceiver;
     address public fallbackReceiver;
+    uint32 public maxSwapPriceImpact = 300; // uses default 3% (1% is 100) as max allowed price impact for takeProtocolFee swap
 
     constructor(
-        address _owner, address _factory, address _WETH, address _ethReceiver, address _fallbackReceiver
+        address _owner,
+        address _factory,
+        address _WETH,
+        address _ethReceiver,
+        address _fallbackReceiver
     ) public {
         owner = _owner;
         factory = IDXswapFactory(_factory);
@@ -25,32 +29,34 @@ contract DXswapFeeReceiver {
         ethReceiver = _ethReceiver;
         fallbackReceiver = _fallbackReceiver;
     }
-    
+
     function() external payable {}
 
     function transferOwnership(address newOwner) external {
         require(msg.sender == owner, 'DXswapFeeReceiver: FORBIDDEN');
         owner = newOwner;
     }
-    
+
     function changeReceivers(address _ethReceiver, address _fallbackReceiver) external {
         require(msg.sender == owner, 'DXswapFeeReceiver: FORBIDDEN');
         ethReceiver = _ethReceiver;
         fallbackReceiver = _fallbackReceiver;
     }
-    
+
     // Returns sorted token addresses, used to handle return values from pairs sorted in this order
     function sortTokens(address tokenA, address tokenB) internal pure returns (address token0, address token1) {
         require(tokenA != tokenB, 'DXswapFeeReceiver: IDENTICAL_ADDRESSES');
         (token0, token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
         require(token0 != address(0), 'DXswapFeeReceiver: ZERO_ADDRESS');
     }
-    
+
     // Helper function to know if an address is a contract, extcodesize returns the size of the code of a smart
     //  contract in a specific address
-    function isContract(address addr) internal returns (bool) {
-        uint size;
-        assembly { size := extcodesize(addr) }
+    function isContract(address addr) internal view returns (bool) {
+        uint256 size;
+        assembly {
+            size := extcodesize(addr)
+        }
         return size > 0;
     }
 
@@ -58,70 +64,123 @@ contract DXswapFeeReceiver {
     // Taken from DXswapLibrary, removed the factory parameter
     function pairFor(address tokenA, address tokenB) internal view returns (address pair) {
         (address token0, address token1) = sortTokens(tokenA, tokenB);
-        pair = address(uint(keccak256(abi.encodePacked(
-            hex'ff',
-            factory,
-            keccak256(abi.encodePacked(token0, token1)),
-            hex'd306a548755b9295ee49cc729e13ca4a45e00199bbd890fa146da43a50571776' // init code hash
-        ))));
+        pair = address(
+            uint256(
+                keccak256(
+                    abi.encodePacked(
+                        hex'ff',
+                        factory,
+                        keccak256(abi.encodePacked(token0, token1)),
+                        hex'd306a548755b9295ee49cc729e13ca4a45e00199bbd890fa146da43a50571776' // init code hash
+                    )
+                )
+            )
+        );
     }
-    
+
     // Done with code form DXswapRouter and DXswapLibrary, removed the deadline argument
-    function _swapTokensForETH(uint amountIn, address fromToken)
-        internal
-    {
+    function _swapTokensForETH(uint256 amountIn, address fromToken) internal returns (uint256 amountOut) {
         IDXswapPair pairToUse = IDXswapPair(pairFor(fromToken, WETH));
-        
-        (uint reserve0, uint reserve1,) = pairToUse.getReserves();
-        (uint reserveIn, uint reserveOut) = fromToken < WETH ? (reserve0, reserve1) : (reserve1, reserve0);
 
-        require(reserveIn > 0 && reserveOut > 0, 'DXswapFeeReceiver: INSUFFICIENT_LIQUIDITY');
-        uint amountInWithFee = amountIn.mul(uint(10000).sub(pairToUse.swapFee()));
-        uint numerator = amountInWithFee.mul(reserveOut);
-        uint denominator = reserveIn.mul(10000).add(amountInWithFee);
-        uint amountOut = numerator / denominator;
-        
-        TransferHelper.safeTransfer(
-            fromToken, address(pairToUse), amountIn
-        );
-        
-        (uint amount0Out, uint amount1Out) = fromToken < WETH ? (uint(0), amountOut) : (amountOut, uint(0));
-        
-        pairToUse.swap(
-            amount0Out, amount1Out, address(this), new bytes(0)
-        );
-        
-        IWETH(WETH).withdraw(amountOut);
-        TransferHelper.safeTransferETH(ethReceiver, amountOut);
+        (uint256 reserve0, uint256 reserve1, ) = pairToUse.getReserves();
+        (uint256 reserveIn, uint256 reserveOut) = fromToken < WETH ? (reserve0, reserve1) : (reserve1, reserve0);
+
+        uint256 amountInWithFee = amountIn.mul(uint256(10000).sub(pairToUse.swapFee()));
+        uint256 numerator = amountInWithFee.mul(reserveOut);
+        uint256 denominator = reserveIn.mul(10000).add(amountInWithFee);
+        amountOut = numerator / denominator;
+
+        TransferHelper.safeTransfer(fromToken, address(pairToUse), amountIn);
+
+        (uint256 amount0Out, uint256 amount1Out) = fromToken < WETH ? (uint256(0), amountOut) : (amountOut, uint256(0));
+
+        pairToUse.swap(amount0Out, amount1Out, address(this), new bytes(0));
+
+        return amountOut;
     }
 
-    // Transfer to the owner address the token converted into ETH if possible, if not just transfer the token.
-    function _takeETHorToken(address token, uint amount) internal {
-      if (token == WETH) {
-        // If it is WETH, transfer directly to ETH receiver
-        IWETH(WETH).withdraw(amount);
-        TransferHelper.safeTransferETH(ethReceiver, amount);
-      } else if (isContract(pairFor(token, WETH))) {
-        // If it is not WETH and there is a direct path to WETH, swap and transfer WETH to ETH receiver
-        _swapTokensForETH(amount, token);
-      } else {
-        // If it is not WETH and there is not a direct path to WETH, transfer tokens directly to fallback receiver
-        TransferHelper.safeTransfer(token, fallbackReceiver, amount);
-      }
+    // Helper function to know if token-WETH pool exists and has enough liquidity
+    function _isSwapPossible(
+        address token0,
+        address token1,
+        uint256 amount
+    ) internal view returns (bool) {
+        address pair = pairFor(token0, token1);
+        if (!isContract(pair)) return false;
+
+        (uint256 reserve0, uint256 reserve1, ) = IDXswapPair(pair).getReserves();
+        (uint256 reserveIn, uint256 reserveOut) = token0 < token1 ? (reserve0, reserve1) : (reserve1, reserve0);
+        if (reserveIn == 0 || reserveOut == 0) return false;
+
+        uint256 priceImpact = amount.mul(10000) / reserveIn; // simplified formula
+        if (priceImpact > maxSwapPriceImpact) return false;
+
+        return true;
     }
-    
-    // Take what was charged as protocol fee from the DXswap pair liquidity
-    function takeProtocolFee(IDXswapPair[] calldata pairs) external {
-        for (uint i = 0; i < pairs.length; i++) {
-            address token0 = pairs[i].token0();
-            address token1 = pairs[i].token1();
-            pairs[i].transfer(address(pairs[i]), pairs[i].balanceOf(address(this)));
-            (uint amount0, uint amount1) = pairs[i].burn(address(this));
-            if (amount0 > 0)
-                _takeETHorToken(token0, amount0);
-            if (amount1 > 0)
-                _takeETHorToken(token1, amount1);
+
+    // Checks if LP has an extra external address which participates in the distrubution of protocol fee
+    // External recipient address has to be defined and fee % > 0 to transfer tokens
+    function _splitAndTransferFee(
+        address pair,
+        address token,
+        uint256 amount
+    ) internal {
+        if (
+            IDXswapPair(pair).percentFeeToExternalRecipient() > 0 &&
+            IDXswapPair(pair).externalFeeRecipient() != address(0)
+        ) {
+            uint256 percent = IDXswapPair(pair).percentFeeToExternalRecipient();
+            uint256 feeToExternalRecipient = amount.mul(percent) / 10000;
+            uint256 feeToEthReceiver = amount.sub(feeToExternalRecipient);
+            if (token == WETH) {
+                IWETH(WETH).withdraw(amount);
+                TransferHelper.safeTransferETH(IDXswapPair(pair).externalFeeRecipient(), feeToExternalRecipient);
+                TransferHelper.safeTransferETH(ethReceiver, feeToEthReceiver);
+            } else {
+                TransferHelper.safeTransfer(token, IDXswapPair(pair).externalFeeRecipient(), feeToExternalRecipient);
+                TransferHelper.safeTransfer(token, fallbackReceiver, feeToEthReceiver);
+            }
+        } else {
+            if (token == WETH) {
+                IWETH(WETH).withdraw(amount);
+                TransferHelper.safeTransferETH(ethReceiver, amount);
+            } else {
+                TransferHelper.safeTransfer(token, fallbackReceiver, amount);
+            }
         }
     }
 
+    // Convert tokens into ETH if possible, if not just transfer the token
+    function _takeETHorToken(
+        address pair,
+        address token,
+        uint256 amount
+    ) internal {
+        if (token != WETH && _isSwapPossible(token, WETH, amount)) {
+            // If it is not WETH and there is a direct path to WETH, swap tokens
+            uint256 amountOut = _swapTokensForETH(amount, token);
+            _splitAndTransferFee(pair, WETH, amountOut);
+        } else {
+            // If it is WETH or there is not a direct path from token to WETH, transfer tokens
+            _splitAndTransferFee(pair, token, amount);
+        }
+    }
+
+    // Take what was charged as protocol fee from the DXswap pair liquidity
+    function takeProtocolFee(IDXswapPair[] calldata pairs) external {
+        for (uint256 i = 0; i < pairs.length; i++) {
+            address token0 = pairs[i].token0();
+            address token1 = pairs[i].token1();
+            pairs[i].transfer(address(pairs[i]), pairs[i].balanceOf(address(this)));
+            (uint256 amount0, uint256 amount1) = pairs[i].burn(address(this));
+            if (amount0 > 0) _takeETHorToken(address(pairs[i]), token0, amount0);
+            if (amount1 > 0) _takeETHorToken(address(pairs[i]), token1, amount1);
+        }
+    }
+
+    function setMaxSwapPriceImpact(uint32 _maxSwapPriceImpact) external {
+        require(msg.sender == owner, 'DXswapFeeReceiver: CALLER_NOT_OWNER');
+        require(_maxSwapPriceImpact > 0 && _maxSwapPriceImpact < 10000, 'DXswapFeeReceiver: FORBIDDEN_PRICE_IMPACT');
+        maxSwapPriceImpact = _maxSwapPriceImpact;
+    }
 }

--- a/contracts/DXswapFeeReceiver.sol
+++ b/contracts/DXswapFeeReceiver.sol
@@ -16,6 +16,8 @@ contract DXswapFeeReceiver {
     address public fallbackReceiver;
     uint32 public maxSwapPriceImpact = 100; // uses default 1% as max allowed price impact for takeProtocolFee swap
 
+    event TakeProtocolFee(address indexed sender, address indexed to, uint256 NumberOfPairs);
+
     constructor(
         address _owner,
         address _factory,
@@ -178,6 +180,7 @@ contract DXswapFeeReceiver {
             if (amount0 > 0) _takeETHorToken(address(pairs[i]), token0, amount0);
             if (amount1 > 0) _takeETHorToken(address(pairs[i]), token1, amount1);
         }
+        emit TakeProtocolFee(msg.sender, ethReceiver, pairs.length);
     }
 
     // called by the owner to set maximum swap price impact allowed for single token-weth swap

--- a/contracts/DXswapFeeReceiver.sol
+++ b/contracts/DXswapFeeReceiver.sol
@@ -71,7 +71,7 @@ contract DXswapFeeReceiver {
                         hex'ff',
                         factory,
                         keccak256(abi.encodePacked(token0, token1)),
-                        hex'd306a548755b9295ee49cc729e13ca4a45e00199bbd890fa146da43a50571776' // init code hash
+                        hex'0a6294cc1920e3a117b957dadd1262548bec1c7b7f22ddfcd3311623d88004b3' // INIT_CODE_PAIR_HASH
                     )
                 )
             )

--- a/contracts/DXswapFeeSetter.sol
+++ b/contracts/DXswapFeeSetter.sol
@@ -6,7 +6,7 @@ contract DXswapFeeSetter {
     address public owner;
     mapping(address => address) public pairOwners;
     IDXswapFactory public factory;
-  
+
     constructor(address _owner, address _factory) public {
         owner = _owner;
         factory = IDXswapFactory(_factory);
@@ -16,7 +16,7 @@ contract DXswapFeeSetter {
         require(msg.sender == owner, 'DXswapFeeSetter: FORBIDDEN');
         owner = newOwner;
     }
-    
+
     function transferPairOwnership(address pair, address newOwner) external {
         require(msg.sender == owner, 'DXswapFeeSetter: FORBIDDEN');
         pairOwners[pair] = newOwner;
@@ -31,14 +31,24 @@ contract DXswapFeeSetter {
         require(msg.sender == owner, 'DXswapFeeSetter: FORBIDDEN');
         factory.setFeeToSetter(feeToSetter);
     }
-    
+
     function setProtocolFee(uint8 protocolFeeDenominator) external {
         require(msg.sender == owner, 'DXswapFeeSetter: FORBIDDEN');
         factory.setProtocolFee(protocolFeeDenominator);
     }
-    
+
     function setSwapFee(address pair, uint32 swapFee) external {
         require((msg.sender == owner) || ((msg.sender == pairOwners[pair])), 'DXswapFeeSetter: FORBIDDEN');
         factory.setSwapFee(pair, swapFee);
+    }
+
+    function setExternalFeeRecipient(address pair, address externalFeeRecipient) external {
+        require((msg.sender == owner) || ((msg.sender == pairOwners[pair])), 'DXswapFeeSetter: FORBIDDEN');
+        factory.setExternalFeeRecipient(pair, externalFeeRecipient);
+    }
+
+    function setPercentFeeToExternalRecipient(address pair, uint32 swapFee) external {
+        require((msg.sender == owner) || ((msg.sender == pairOwners[pair])), 'DXswapFeeSetter: FORBIDDEN');
+        factory.setPercentFeeToExternalRecipient(pair, swapFee);
     }
 }

--- a/contracts/DXswapPair.sol
+++ b/contracts/DXswapPair.sol
@@ -9,26 +9,29 @@ import './interfaces/IDXswapFactory.sol';
 import './interfaces/IDXswapCallee.sol';
 
 contract DXswapPair is IDXswapPair, DXswapERC20 {
-    using SafeMath  for uint;
+    using SafeMath for uint256;
     using UQ112x112 for uint224;
 
-    uint public constant MINIMUM_LIQUIDITY = 10**3;
+    uint256 public constant MINIMUM_LIQUIDITY = 10**3;
     bytes4 private constant SELECTOR = bytes4(keccak256(bytes('transfer(address,uint256)')));
 
     address public factory;
     address public token0;
     address public token1;
 
-    uint112 private reserve0;           // uses single storage slot, accessible via getReserves
-    uint112 private reserve1;           // uses single storage slot, accessible via getReserves
-    uint32  private blockTimestampLast; // uses single storage slot, accessible via getReserves
+    uint112 private reserve0; // uses single storage slot, accessible via getReserves
+    uint112 private reserve1; // uses single storage slot, accessible via getReserves
+    uint32 private blockTimestampLast; // uses single storage slot, accessible via getReserves
 
-    uint public price0CumulativeLast;
-    uint public price1CumulativeLast;
-    uint public kLast; // reserve0 * reserve1, as of immediately after the most recent liquidity event
+    uint256 public price0CumulativeLast;
+    uint256 public price1CumulativeLast;
+    uint256 public kLast; // reserve0 * reserve1, as of immediately after the most recent liquidity event
     uint32 public swapFee = 25; // uses 0.25% fee as default
-    
-    uint private unlocked = 1;
+
+    address public externalFeeRecipient; // if needed set address of external project which can get some % of total earned protocol fee
+    uint32 public percentFeeToExternalRecipient = 0; // % of all protocol fee to external project (100 means 1%)
+
+    uint256 private unlocked = 1;
     modifier lock() {
         require(unlocked == 1, 'DXswapPair: LOCKED');
         unlocked = 0;
@@ -36,25 +39,37 @@ contract DXswapPair is IDXswapPair, DXswapERC20 {
         unlocked = 1;
     }
 
-    function getReserves() public view returns (uint112 _reserve0, uint112 _reserve1, uint32 _blockTimestampLast) {
+    function getReserves()
+        public
+        view
+        returns (
+            uint112 _reserve0,
+            uint112 _reserve1,
+            uint32 _blockTimestampLast
+        )
+    {
         _reserve0 = reserve0;
         _reserve1 = reserve1;
         _blockTimestampLast = blockTimestampLast;
     }
 
-    function _safeTransfer(address token, address to, uint value) private {
+    function _safeTransfer(
+        address token,
+        address to,
+        uint256 value
+    ) private {
         (bool success, bytes memory data) = token.call(abi.encodeWithSelector(SELECTOR, to, value));
         require(success && (data.length == 0 || abi.decode(data, (bool))), 'DXswapPair: TRANSFER_FAILED');
     }
 
-    event Mint(address indexed sender, uint amount0, uint amount1);
-    event Burn(address indexed sender, uint amount0, uint amount1, address indexed to);
+    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+    event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
     event Swap(
         address indexed sender,
-        uint amount0In,
-        uint amount1In,
-        uint amount0Out,
-        uint amount1Out,
+        uint256 amount0In,
+        uint256 amount1In,
+        uint256 amount0Out,
+        uint256 amount1Out,
         address indexed to
     );
     event Sync(uint112 reserve0, uint112 reserve1);
@@ -69,7 +84,7 @@ contract DXswapPair is IDXswapPair, DXswapERC20 {
         token0 = _token0;
         token1 = _token1;
     }
-    
+
     // called by the factory to set the swapFee
     function setSwapFee(uint32 _swapFee) external {
         require(msg.sender == factory, 'DXswapPair: FORBIDDEN'); // sufficient check
@@ -77,15 +92,36 @@ contract DXswapPair is IDXswapPair, DXswapERC20 {
         swapFee = _swapFee;
     }
 
+    // called by the factory to set external recipient address
+    function setExternalFeeRecipient(address _externalFeeRecipient) external {
+        require(msg.sender == factory, 'DXswapPair: FORBIDDEN'); // sufficient check
+        externalFeeRecipient = _externalFeeRecipient;
+    }
+
+    // called by the factory to set % of total protocol fee which should be sent to project address
+    function setPercentFeeToExternalRecipient(uint32 _percentFeeToExternalRecipient) external {
+        require(msg.sender == factory, 'DXswapPair: FORBIDDEN'); // sufficient check
+        require(
+            _percentFeeToExternalRecipient >= 0 && _percentFeeToExternalRecipient <= 5000,
+            'DXswapPair: FORBIDDEN_FEE_SPLIT'
+        ); // sufficient check
+        percentFeeToExternalRecipient = _percentFeeToExternalRecipient;
+    }
+
     // update reserves and, on the first call per block, price accumulators
-    function _update(uint balance0, uint balance1, uint112 _reserve0, uint112 _reserve1) private {
+    function _update(
+        uint256 balance0,
+        uint256 balance1,
+        uint112 _reserve0,
+        uint112 _reserve1
+    ) private {
         require(balance0 <= uint112(-1) && balance1 <= uint112(-1), 'DXswapPair: OVERFLOW');
         uint32 blockTimestamp = uint32(block.timestamp % 2**32);
         uint32 timeElapsed = blockTimestamp - blockTimestampLast; // overflow is desired
         if (timeElapsed > 0 && _reserve0 != 0 && _reserve1 != 0) {
             // * never overflows, and + overflow is desired
-            price0CumulativeLast += uint(UQ112x112.encode(_reserve1).uqdiv(_reserve0)) * timeElapsed;
-            price1CumulativeLast += uint(UQ112x112.encode(_reserve0).uqdiv(_reserve1)) * timeElapsed;
+            price0CumulativeLast += uint256(UQ112x112.encode(_reserve1).uqdiv(_reserve0)) * timeElapsed;
+            price1CumulativeLast += uint256(UQ112x112.encode(_reserve0).uqdiv(_reserve1)) * timeElapsed;
         }
         reserve0 = uint112(balance0);
         reserve1 = uint112(balance1);
@@ -98,15 +134,15 @@ contract DXswapPair is IDXswapPair, DXswapERC20 {
         address feeTo = IDXswapFactory(factory).feeTo();
         uint8 protocolFeeDenominator = IDXswapFactory(factory).protocolFeeDenominator();
         feeOn = feeTo != address(0);
-        uint _kLast = kLast; // gas savings
+        uint256 _kLast = kLast; // gas savings
         if (feeOn) {
             if (_kLast != 0) {
-                uint rootK = Math.sqrt(uint(_reserve0).mul(_reserve1));
-                uint rootKLast = Math.sqrt(_kLast);
+                uint256 rootK = Math.sqrt(uint256(_reserve0).mul(_reserve1));
+                uint256 rootKLast = Math.sqrt(_kLast);
                 if (rootK > rootKLast) {
-                    uint numerator = totalSupply.mul(rootK.sub(rootKLast));
-                    uint denominator = rootK.mul(protocolFeeDenominator).add(rootKLast);
-                    uint liquidity = numerator / denominator;
+                    uint256 numerator = totalSupply.mul(rootK.sub(rootKLast));
+                    uint256 denominator = rootK.mul(protocolFeeDenominator).add(rootKLast);
+                    uint256 liquidity = numerator / denominator;
                     if (liquidity > 0) _mint(feeTo, liquidity);
                 }
             }
@@ -116,18 +152,18 @@ contract DXswapPair is IDXswapPair, DXswapERC20 {
     }
 
     // this low-level function should be called from a contract which performs important safety checks
-    function mint(address to) external lock returns (uint liquidity) {
-        (uint112 _reserve0, uint112 _reserve1,) = getReserves(); // gas savings
-        uint balance0 = IERC20(token0).balanceOf(address(this));
-        uint balance1 = IERC20(token1).balanceOf(address(this));
-        uint amount0 = balance0.sub(_reserve0);
-        uint amount1 = balance1.sub(_reserve1);
+    function mint(address to) external lock returns (uint256 liquidity) {
+        (uint112 _reserve0, uint112 _reserve1, ) = getReserves(); // gas savings
+        uint256 balance0 = IERC20(token0).balanceOf(address(this));
+        uint256 balance1 = IERC20(token1).balanceOf(address(this));
+        uint256 amount0 = balance0.sub(_reserve0);
+        uint256 amount1 = balance1.sub(_reserve1);
 
         bool feeOn = _mintFee(_reserve0, _reserve1);
-        uint _totalSupply = totalSupply; // gas savings, must be defined here since totalSupply can update in _mintFee
+        uint256 _totalSupply = totalSupply; // gas savings, must be defined here since totalSupply can update in _mintFee
         if (_totalSupply == 0) {
             liquidity = Math.sqrt(amount0.mul(amount1)).sub(MINIMUM_LIQUIDITY);
-           _mint(address(0), MINIMUM_LIQUIDITY); // permanently lock the first MINIMUM_LIQUIDITY tokens
+            _mint(address(0), MINIMUM_LIQUIDITY); // permanently lock the first MINIMUM_LIQUIDITY tokens
         } else {
             liquidity = Math.min(amount0.mul(_totalSupply) / _reserve0, amount1.mul(_totalSupply) / _reserve1);
         }
@@ -135,21 +171,21 @@ contract DXswapPair is IDXswapPair, DXswapERC20 {
         _mint(to, liquidity);
 
         _update(balance0, balance1, _reserve0, _reserve1);
-        if (feeOn) kLast = uint(reserve0).mul(reserve1); // reserve0 and reserve1 are up-to-date
+        if (feeOn) kLast = uint256(reserve0).mul(reserve1); // reserve0 and reserve1 are up-to-date
         emit Mint(msg.sender, amount0, amount1);
     }
 
     // this low-level function should be called from a contract which performs important safety checks
-    function burn(address to) external lock returns (uint amount0, uint amount1) {
-        (uint112 _reserve0, uint112 _reserve1,) = getReserves(); // gas savings
-        address _token0 = token0;                                // gas savings
-        address _token1 = token1;                                // gas savings
-        uint balance0 = IERC20(_token0).balanceOf(address(this));
-        uint balance1 = IERC20(_token1).balanceOf(address(this));
-        uint liquidity = balanceOf[address(this)];
+    function burn(address to) external lock returns (uint256 amount0, uint256 amount1) {
+        (uint112 _reserve0, uint112 _reserve1, ) = getReserves(); // gas savings
+        address _token0 = token0; // gas savings
+        address _token1 = token1; // gas savings
+        uint256 balance0 = IERC20(_token0).balanceOf(address(this));
+        uint256 balance1 = IERC20(_token1).balanceOf(address(this));
+        uint256 liquidity = balanceOf[address(this)];
 
         bool feeOn = _mintFee(_reserve0, _reserve1);
-        uint _totalSupply = totalSupply; // gas savings, must be defined here since totalSupply can update in _mintFee
+        uint256 _totalSupply = totalSupply; // gas savings, must be defined here since totalSupply can update in _mintFee
         amount0 = liquidity.mul(balance0) / _totalSupply; // using balances ensures pro-rata distribution
         amount1 = liquidity.mul(balance1) / _totalSupply; // using balances ensures pro-rata distribution
         require(amount0 > 0 && amount1 > 0, 'DXswapPair: INSUFFICIENT_LIQUIDITY_BURNED');
@@ -160,35 +196,45 @@ contract DXswapPair is IDXswapPair, DXswapERC20 {
         balance1 = IERC20(_token1).balanceOf(address(this));
 
         _update(balance0, balance1, _reserve0, _reserve1);
-        if (feeOn) kLast = uint(reserve0).mul(reserve1); // reserve0 and reserve1 are up-to-date
+        if (feeOn) kLast = uint256(reserve0).mul(reserve1); // reserve0 and reserve1 are up-to-date
         emit Burn(msg.sender, amount0, amount1, to);
     }
 
     // this low-level function should be called from a contract which performs important safety checks
-    function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external lock {
+    function swap(
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address to,
+        bytes calldata data
+    ) external lock {
         require(amount0Out > 0 || amount1Out > 0, 'DXswapPair: INSUFFICIENT_OUTPUT_AMOUNT');
-        (uint112 _reserve0, uint112 _reserve1,) = getReserves(); // gas savings
+        (uint112 _reserve0, uint112 _reserve1, ) = getReserves(); // gas savings
         require(amount0Out < _reserve0 && amount1Out < _reserve1, 'DXswapPair: INSUFFICIENT_LIQUIDITY');
 
-        uint balance0;
-        uint balance1;
-        { // scope for _token{0,1}, avoids stack too deep errors
-        address _token0 = token0;
-        address _token1 = token1;
-        require(to != _token0 && to != _token1, 'DXswapPair: INVALID_TO');
-        if (amount0Out > 0) _safeTransfer(_token0, to, amount0Out); // optimistically transfer tokens
-        if (amount1Out > 0) _safeTransfer(_token1, to, amount1Out); // optimistically transfer tokens
-        if (data.length > 0) IDXswapCallee(to).DXswapCall(msg.sender, amount0Out, amount1Out, data);
-        balance0 = IERC20(_token0).balanceOf(address(this));
-        balance1 = IERC20(_token1).balanceOf(address(this));
+        uint256 balance0;
+        uint256 balance1;
+        {
+            // scope for _token{0,1}, avoids stack too deep errors
+            address _token0 = token0;
+            address _token1 = token1;
+            require(to != _token0 && to != _token1, 'DXswapPair: INVALID_TO');
+            if (amount0Out > 0) _safeTransfer(_token0, to, amount0Out); // optimistically transfer tokens
+            if (amount1Out > 0) _safeTransfer(_token1, to, amount1Out); // optimistically transfer tokens
+            if (data.length > 0) IDXswapCallee(to).DXswapCall(msg.sender, amount0Out, amount1Out, data);
+            balance0 = IERC20(_token0).balanceOf(address(this));
+            balance1 = IERC20(_token1).balanceOf(address(this));
         }
-        uint amount0In = balance0 > _reserve0 - amount0Out ? balance0 - (_reserve0 - amount0Out) : 0;
-        uint amount1In = balance1 > _reserve1 - amount1Out ? balance1 - (_reserve1 - amount1Out) : 0;
+        uint256 amount0In = balance0 > _reserve0 - amount0Out ? balance0 - (_reserve0 - amount0Out) : 0;
+        uint256 amount1In = balance1 > _reserve1 - amount1Out ? balance1 - (_reserve1 - amount1Out) : 0;
         require(amount0In > 0 || amount1In > 0, 'DXswapPair: INSUFFICIENT_INPUT_AMOUNT');
-        { // scope for reserve{0,1}Adjusted, avoids stack too deep errors
-          uint balance0Adjusted = balance0.mul(10000).sub(amount0In.mul(swapFee));
-          uint balance1Adjusted = balance1.mul(10000).sub(amount1In.mul(swapFee));
-          require(balance0Adjusted.mul(balance1Adjusted) >= uint(_reserve0).mul(_reserve1).mul(10000**2), 'DXswapPair: K');
+        {
+            // scope for reserve{0,1}Adjusted, avoids stack too deep errors
+            uint256 balance0Adjusted = balance0.mul(10000).sub(amount0In.mul(swapFee));
+            uint256 balance1Adjusted = balance1.mul(10000).sub(amount1In.mul(swapFee));
+            require(
+                balance0Adjusted.mul(balance1Adjusted) >= uint256(_reserve0).mul(_reserve1).mul(10000**2),
+                'DXswapPair: K'
+            );
         }
 
         _update(balance0, balance1, _reserve0, _reserve1);

--- a/contracts/DXswapPair.sol
+++ b/contracts/DXswapPair.sol
@@ -28,8 +28,8 @@ contract DXswapPair is IDXswapPair, DXswapERC20 {
     uint256 public kLast; // reserve0 * reserve1, as of immediately after the most recent liquidity event
     uint32 public swapFee = 25; // uses 0.25% fee as default
 
-    address public externalFeeRecipient; // if needed set address of external project which can get some % of total earned protocol fee
-    uint32 public percentFeeToExternalRecipient = 0; // % of all protocol fee to external project (100 means 1%)
+    address public externalFeeRecipient; // if needed set address of external project which can get % of total earned protocol fee
+    uint32 public percentFeeToExternalRecipient = 0; // % of total protocol fee to external project (100 means 1%), range <0, 50>
 
     uint256 private unlocked = 1;
     modifier lock() {

--- a/contracts/interfaces/IDXswapFactory.sol
+++ b/contracts/interfaces/IDXswapFactory.sol
@@ -1,21 +1,33 @@
 pragma solidity >=0.5.0;
 
 interface IDXswapFactory {
-    event PairCreated(address indexed token0, address indexed token1, address pair, uint);
+    event PairCreated(address indexed token0, address indexed token1, address pair, uint256);
 
     function INIT_CODE_PAIR_HASH() external pure returns (bytes32);
+
     function feeTo() external view returns (address);
+
     function protocolFeeDenominator() external view returns (uint8);
+
     function feeToSetter() external view returns (address);
 
     function getPair(address tokenA, address tokenB) external view returns (address pair);
-    function allPairs(uint) external view returns (address pair);
-    function allPairsLength() external view returns (uint);
+
+    function allPairs(uint256) external view returns (address pair);
+
+    function allPairsLength() external view returns (uint256);
 
     function createPair(address tokenA, address tokenB) external returns (address pair);
 
     function setFeeTo(address) external;
+
     function setFeeToSetter(address) external;
-    function setProtocolFee(uint8 _protocolFee) external;
+
+    function setProtocolFee(uint8 protocolFee) external;
+
     function setSwapFee(address pair, uint32 swapFee) external;
+
+    function setExternalFeeRecipient(address pair, address externalFeeRecipient) external;
+
+    function setPercentFeeToExternalRecipient(address pair, uint32 percentFeeToExternalRecipient) external;
 }

--- a/contracts/interfaces/IDXswapPair.sol
+++ b/contracts/interfaces/IDXswapPair.sol
@@ -1,54 +1,108 @@
 pragma solidity >=0.5.0;
 
 interface IDXswapPair {
-    event Approval(address indexed owner, address indexed spender, uint value);
-    event Transfer(address indexed from, address indexed to, uint value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Transfer(address indexed from, address indexed to, uint256 value);
 
     function name() external pure returns (string memory);
-    function symbol() external pure returns (string memory);
-    function decimals() external pure returns (uint8);
-    function totalSupply() external view returns (uint);
-    function balanceOf(address owner) external view returns (uint);
-    function allowance(address owner, address spender) external view returns (uint);
 
-    function approve(address spender, uint value) external returns (bool);
-    function transfer(address to, uint value) external returns (bool);
-    function transferFrom(address from, address to, uint value) external returns (bool);
+    function symbol() external pure returns (string memory);
+
+    function decimals() external pure returns (uint8);
+
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address owner) external view returns (uint256);
+
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    function approve(address spender, uint256 value) external returns (bool);
+
+    function transfer(address to, uint256 value) external returns (bool);
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) external returns (bool);
 
     function DOMAIN_SEPARATOR() external view returns (bytes32);
+
     function PERMIT_TYPEHASH() external pure returns (bytes32);
-    function nonces(address owner) external view returns (uint);
 
-    function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
+    function nonces(address owner) external view returns (uint256);
 
-    event Mint(address indexed sender, uint amount0, uint amount1);
-    event Burn(address indexed sender, uint amount0, uint amount1, address indexed to);
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+    event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
     event Swap(
         address indexed sender,
-        uint amount0In,
-        uint amount1In,
-        uint amount0Out,
-        uint amount1Out,
+        uint256 amount0In,
+        uint256 amount1In,
+        uint256 amount0Out,
+        uint256 amount1Out,
         address indexed to
     );
     event Sync(uint112 reserve0, uint112 reserve1);
 
-    function MINIMUM_LIQUIDITY() external pure returns (uint);
+    function MINIMUM_LIQUIDITY() external pure returns (uint256);
+
     function factory() external view returns (address);
+
     function token0() external view returns (address);
+
     function token1() external view returns (address);
-    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
-    function price0CumulativeLast() external view returns (uint);
-    function price1CumulativeLast() external view returns (uint);
-    function kLast() external view returns (uint);
+
+    function getReserves()
+        external
+        view
+        returns (
+            uint112 reserve0,
+            uint112 reserve1,
+            uint32 blockTimestampLast
+        );
+
+    function price0CumulativeLast() external view returns (uint256);
+
+    function price1CumulativeLast() external view returns (uint256);
+
+    function kLast() external view returns (uint256);
+
     function swapFee() external view returns (uint32);
 
-    function mint(address to) external returns (uint liquidity);
-    function burn(address to) external returns (uint amount0, uint amount1);
-    function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external;
+    function externalFeeRecipient() external view returns (address);
+
+    function percentFeeToExternalRecipient() external view returns (uint32);
+
+    function mint(address to) external returns (uint256 liquidity);
+
+    function burn(address to) external returns (uint256 amount0, uint256 amount1);
+
+    function swap(
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address to,
+        bytes calldata data
+    ) external;
+
     function skim(address to) external;
+
     function sync() external;
 
     function initialize(address, address) external;
+
     function setSwapFee(uint32) external;
+
+    function setExternalFeeRecipient(address) external;
+
+    function setPercentFeeToExternalRecipient(uint32) external;
 }

--- a/test/DXswapDeployer.spec.ts
+++ b/test/DXswapDeployer.spec.ts
@@ -18,21 +18,21 @@ describe('DXswapDeployer', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 12000000
+    gasLimit: 15000000
   })
   const [dxdao, tokenOwner, protocolFeeReceiver, other] = provider.getWallets()
   const overrides = {
-    gasLimit: 12000000
+    gasLimit: 15000000
   }
 
   let dxSwapDeployer: Contract
   let token0: Contract
   let token1: Contract
   let token2: Contract
-  const pairBytecode = "0x"+DXswapPair.bytecode
-  
+  const pairBytecode = "0x" + DXswapPair.bytecode
+
   it('Execute migration with intial pairs', async () => {
-    
+
     // Deploy tokens 4 testing
     token0 = await deployContract(tokenOwner, ERC20, [expandTo18Decimals(20000)], overrides)
     token1 = await deployContract(tokenOwner, ERC20, [expandTo18Decimals(20000)], overrides)
@@ -41,86 +41,86 @@ describe('DXswapDeployer', () => {
     // Deploy DXswapDeployer
     dxSwapDeployer = await deployContract(
       dxdao, DXswapDeployer, [
-        protocolFeeReceiver.address,
-        dxdao.address,
-        weth.address,
-        [token0.address, token0.address, token1.address],
-        [token1.address, token2.address, token2.address],
-        [10, 20, 30],
-      ], overrides
+      protocolFeeReceiver.address,
+      dxdao.address,
+      weth.address,
+      [token0.address, token0.address, token1.address],
+      [token1.address, token2.address, token2.address],
+      [10, 20, 30],
+    ], overrides
     )
     expect(await dxSwapDeployer.state()).to.eq(0)
-    
+
     // Dont allow other address to approve deployment by sending eth
-    await expect(other.sendTransaction({to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000)}))
+    await expect(other.sendTransaction({ to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000) }))
       .to.be.revertedWith('DXswapDeployer: CALLER_NOT_FEE_TO_SETTER')
-    
+
     // Dont allow deploy before being approved by sending ETH
     await expect(dxSwapDeployer.connect(other).deploy())
       .to.be.revertedWith('DXswapDeployer: WRONG_DEPLOYER_STATE')
 
     // Send transaction with value from dxdao to approve deployment
-    await dxdao.sendTransaction({to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000)})
+    await dxdao.sendTransaction({ to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000) })
     expect(await dxSwapDeployer.state()).to.eq(1)
-    
+
     // Dont allow sending more value
-    await expect(dxdao.sendTransaction({to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000)}))
+    await expect(dxdao.sendTransaction({ to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000) }))
       .to.be.revertedWith('DXswapDeployer: WRONG_DEPLOYER_STATE')
-    await expect(other.sendTransaction({to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000)}))
+    await expect(other.sendTransaction({ to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000) }))
       .to.be.revertedWith('DXswapDeployer: WRONG_DEPLOYER_STATE')
 
     // Execute deployment transaction
     const deployTx = await dxSwapDeployer.connect(other).deploy()
     expect(await dxSwapDeployer.state()).to.eq(2)
     const deployTxReceipt = await provider.getTransactionReceipt(deployTx.hash);
-    
+
     // Dont allow sending more value
-    await expect(dxdao.sendTransaction({to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000)}))
+    await expect(dxdao.sendTransaction({ to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000) }))
       .to.be.revertedWith('DXswapDeployer: WRONG_DEPLOYER_STATE')
-    await expect(other.sendTransaction({to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000)}))
+    await expect(other.sendTransaction({ to: dxSwapDeployer.address, gasPrice: 0, value: expandTo18Decimals(10000) }))
       .to.be.revertedWith('DXswapDeployer: WRONG_DEPLOYER_STATE')
-    
+
     // Dont allow running deployment again
     await expect(dxSwapDeployer.connect(other).deploy()).to.be.revertedWith('DXswapDeployer: WRONG_DEPLOYER_STATE')
-    
+
     // Get addresses from events
-    const pairFactoryAddress = deployTxReceipt.logs != undefined 
+    const pairFactoryAddress = deployTxReceipt.logs != undefined
       ? defaultAbiCoder.decode(['address'], deployTxReceipt.logs[0].data)[0]
       : null
-    const pair01Address = deployTxReceipt.logs != undefined 
+    const pair01Address = deployTxReceipt.logs != undefined
       ? defaultAbiCoder.decode(['address'], deployTxReceipt.logs[2].data)[0]
       : null
-    const pair02Address = deployTxReceipt.logs != undefined 
+    const pair02Address = deployTxReceipt.logs != undefined
       ? defaultAbiCoder.decode(['address'], deployTxReceipt.logs[4].data)[0]
       : null
-    const pair12Address = deployTxReceipt.logs != undefined 
+    const pair12Address = deployTxReceipt.logs != undefined
       ? defaultAbiCoder.decode(['address'], deployTxReceipt.logs[6].data)[0]
       : null
-    const feeReceiverAddress = deployTxReceipt.logs != undefined 
+    const feeReceiverAddress = deployTxReceipt.logs != undefined
       ? defaultAbiCoder.decode(['address'], deployTxReceipt.logs[7].data)[0]
       : null
-    const feeSetterAddress = deployTxReceipt.logs != undefined 
+    const feeSetterAddress = deployTxReceipt.logs != undefined
       ? defaultAbiCoder.decode(['address'], deployTxReceipt.logs[8].data)[0]
       : null
-    
+
     // Instantiate contracts
     const pairFactory = new Contract(pairFactoryAddress, JSON.stringify(DXswapFactory.abi), provider);
     const pair01 = new Contract(
-      getCreate2Address(pairFactory.address, [token0.address, token1.address], pairBytecode), 
+      getCreate2Address(pairFactory.address, [token0.address, token1.address], pairBytecode),
       JSON.stringify(DXswapPair.abi),
       provider
     );
     const pair02 = new Contract(
-      getCreate2Address(pairFactory.address, [token0.address, token2.address], pairBytecode), 
+      getCreate2Address(pairFactory.address, [token0.address, token2.address], pairBytecode),
       JSON.stringify(DXswapPair.abi),
       provider
     );
     const pair12 = new Contract(
-      getCreate2Address(pairFactory.address, [token1.address, token2.address], pairBytecode), 
+      getCreate2Address(pairFactory.address, [token1.address, token2.address], pairBytecode),
       JSON.stringify(DXswapPair.abi),
       provider
     );
-    
+
     // Conpare onchain information to offchain predicted information
     expect(await pairFactory.feeTo()).to.eq(feeReceiverAddress)
     expect(await pairFactory.feeToSetter()).to.eq(feeSetterAddress)
@@ -144,7 +144,7 @@ describe('DXswapDeployer', () => {
     expect(await pair12.token0()).to.eq(token2.address)
     expect(await pair12.token1()).to.eq(token1.address)
     expect(await pair12.totalSupply()).to.eq(0)
-    
+
   })
 
 })

--- a/test/DXswapERC20.spec.ts
+++ b/test/DXswapERC20.spec.ts
@@ -18,7 +18,7 @@ describe('DXswapERC20', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 9999999
+    gasLimit: 15000000
   })
   const [wallet, other] = provider.getWallets()
 

--- a/test/DXswapFactory.spec.ts
+++ b/test/DXswapFactory.spec.ts
@@ -5,7 +5,7 @@ import { bigNumberify } from 'ethers/utils'
 import { solidity, MockProvider, createFixtureLoader } from 'ethereum-waffle'
 
 import { getCreate2Address } from './shared/utilities'
-import { factoryFixture } from './shared/fixtures'
+import { factoryFixture, pairFixture } from './shared/fixtures'
 
 import DXswapPair from '../build/DXswapPair.json'
 
@@ -31,7 +31,7 @@ describe('DXswapFactory', () => {
     const fixture = await loadFixture(factoryFixture)
     factory = fixture.factory
     feeSetter = fixture.feeSetter
-    
+
     // Set feeToSetter to wallet.address to test the factory methdos from an ETH account
     await feeSetter.setFeeTo(AddressZero);
     await feeSetter.setFeeToSetter(wallet.address);
@@ -41,11 +41,11 @@ describe('DXswapFactory', () => {
     expect(await factory.feeTo()).to.eq(AddressZero)
     expect(await factory.feeToSetter()).to.eq(wallet.address)
     expect(await factory.allPairsLength()).to.eq(0)
-    expect(await factory.INIT_CODE_PAIR_HASH()).to.eq('0xd306a548755b9295ee49cc729e13ca4a45e00199bbd890fa146da43a50571776')
+    expect(await factory.INIT_CODE_PAIR_HASH()).to.eq('0x0a6294cc1920e3a117b957dadd1262548bec1c7b7f22ddfcd3311623d88004b3')
   })
 
   async function createPair(tokens: [string, string]) {
-    const bytecode = "0x"+DXswapPair.bytecode
+    const bytecode = "0x" + DXswapPair.bytecode
     const create2Address = getCreate2Address(factory.address, tokens, bytecode)
     await expect(factory.createPair(...tokens))
       .to.emit(factory, 'PairCreated')
@@ -75,7 +75,7 @@ describe('DXswapFactory', () => {
   it('createPair:gas', async () => {
     const tx = await factory.createPair(...TEST_ADDRESSES)
     const receipt = await tx.wait()
-    expect(receipt.gasUsed).to.eq(2136142)
+    expect(receipt.gasUsed).to.eq(2241653)
   })
 
   it('setFeeTo', async () => {

--- a/test/DXswapFactory.spec.ts
+++ b/test/DXswapFactory.spec.ts
@@ -41,7 +41,7 @@ describe('DXswapFactory', () => {
     expect(await factory.feeTo()).to.eq(AddressZero)
     expect(await factory.feeToSetter()).to.eq(wallet.address)
     expect(await factory.allPairsLength()).to.eq(0)
-    expect(await factory.INIT_CODE_PAIR_HASH()).to.eq('0x0a6294cc1920e3a117b957dadd1262548bec1c7b7f22ddfcd3311623d88004b3')
+    expect(await factory.INIT_CODE_PAIR_HASH()).to.eq('0x61711fee40f324739edb0f7fc7017a47d328ee0b69e93d9a4d1e2215e7d0a2d4')
   })
 
   async function createPair(tokens: [string, string]) {

--- a/test/DXswapFactory.spec.ts
+++ b/test/DXswapFactory.spec.ts
@@ -20,7 +20,7 @@ describe('DXswapFactory', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 9999999
+    gasLimit: 15000000
   })
   const [wallet, protocolFeeReceiver, other] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [wallet, protocolFeeReceiver, other])

--- a/test/DXswapFeeReceiver.spec.ts
+++ b/test/DXswapFeeReceiver.spec.ts
@@ -25,10 +25,10 @@ describe('DXswapFeeReceiver', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 9999999
+    gasLimit: 15000000
   })
   const overrides = {
-    gasLimit: 9999999
+    gasLimit: 15000000
   }
   const [dxdao, wallet, protocolFeeReceiver, other, externalFeeRecipient] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [dxdao, wallet, protocolFeeReceiver])
@@ -81,6 +81,7 @@ describe('DXswapFeeReceiver', () => {
   let token0: Contract
   let token1: Contract
   let pair: Contract
+  let wethToken0Pair: Contract
   let wethToken1Pair: Contract
   let WETH: Contract
   let feeSetter: Contract
@@ -91,6 +92,7 @@ describe('DXswapFeeReceiver', () => {
     token0 = fixture.token0
     token1 = fixture.token1
     pair = fixture.pair
+    wethToken0Pair = fixture.wethToken0Pair
     wethToken1Pair = fixture.wethToken1Pair
     WETH = fixture.WETH
     feeSetter = fixture.feeSetter

--- a/test/DXswapFeeReceiver.spec.ts
+++ b/test/DXswapFeeReceiver.spec.ts
@@ -30,25 +30,25 @@ describe('DXswapFeeReceiver', () => {
   const overrides = {
     gasLimit: 9999999
   }
-  const [dxdao, wallet, protocolFeeReceiver, other] = provider.getWallets()
+  const [dxdao, wallet, protocolFeeReceiver, other, externalFeeRecipient] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [dxdao, wallet, protocolFeeReceiver])
-  
+
   async function getAmountOut(pair: Contract, tokenIn: string, amountIn: BigNumber) {
-    const [ reserve0, reserve1 ] = await pair.getReserves()
+    const [reserve0, reserve1] = await pair.getReserves()
     const token0 = await pair.token0()
     return getAmountOutSync(reserve0, reserve1, token0 === tokenIn, amountIn, await pair.swapFee())
   }
-  
+
   function getAmountOutSync(
     reserve0: BigNumber, reserve1: BigNumber, usingToken0: boolean, amountIn: BigNumber, swapFee: BigNumber
   ) {
     const tokenInBalance = usingToken0 ? reserve0 : reserve1
-    const tokenOutBalance = usingToken0? reserve1 : reserve0
+    const tokenOutBalance = usingToken0 ? reserve1 : reserve0
     const amountInWithFee = amountIn.mul(FEE_DENOMINATOR.sub(swapFee))
     return amountInWithFee.mul(tokenOutBalance)
       .div(tokenInBalance.mul(FEE_DENOMINATOR).add(amountInWithFee))
   }
-  
+
   // Calculate how much will be payed from liquidity as protocol fee in the next mint/burn
   async function calcProtocolFee(pair: Contract) {
     const [token0Reserve, token1Reserve, _] = await pair.getReserves()
@@ -60,7 +60,7 @@ describe('DXswapFeeReceiver', () => {
     if (feeTo != AddressZero) {
       // Check for math overflow when dealing with big big balances
       if (Math.sqrt((token0Reserve).mul(token1Reserve)) > Math.pow(10, 19)) {
-        const denominator = 10 ** ( Number(Math.log10(Math.sqrt((token0Reserve).mul(token1Reserve))).toFixed(0)) - 18);
+        const denominator = 10 ** (Number(Math.log10(Math.sqrt((token0Reserve).mul(token1Reserve))).toFixed(0)) - 18);
         rootK = bigNumberify((Math.sqrt(
           token0Reserve.mul(token1Reserve)
         ) / denominator).toString())
@@ -69,19 +69,19 @@ describe('DXswapFeeReceiver', () => {
         rootK = bigNumberify(Math.sqrt((token0Reserve).mul(token1Reserve)).toString())
         rootKLast = bigNumberify(Math.sqrt(kLast).toString())
       }
-      
+
       return (totalSupply.mul(rootK.sub(rootKLast)))
         .div(rootK.mul(protocolFeeDenominator).add(rootKLast))
     } else {
       return bigNumberify(0)
     }
-  } 
+  }
 
   let factory: Contract
   let token0: Contract
   let token1: Contract
   let pair: Contract
-  let wethPair: Contract
+  let wethToken1Pair: Contract
   let WETH: Contract
   let feeSetter: Contract
   let feeReceiver: Contract
@@ -91,400 +91,648 @@ describe('DXswapFeeReceiver', () => {
     token0 = fixture.token0
     token1 = fixture.token1
     pair = fixture.pair
-    wethPair = fixture.wethPair
+    wethToken1Pair = fixture.wethToken1Pair
     WETH = fixture.WETH
     feeSetter = fixture.feeSetter
     feeReceiver = fixture.feeReceiver
   })
-  
+
   // Where token0-token1 and token1-WETH pairs exist
   it(
     'should receive token0 to fallbackreceiver and ETH to ethReceiver when extracting fee from token0-token1',
-    async () => 
-  {
-    const tokenAmount = expandTo18Decimals(100);
-    const wethAmount = expandTo18Decimals(100);
-    const amountIn = expandTo18Decimals(10);
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const wethAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(10);
 
-    await token0.transfer(pair.address, tokenAmount)
-    await token1.transfer(pair.address, tokenAmount)
-    await pair.mint(wallet.address, overrides)
-    
-    await token1.transfer(wethPair.address, tokenAmount)
-    await WETH.transfer(wethPair.address, wethAmount)
-    await wethPair.mint(wallet.address, overrides)
-    
-    let amountOut = await getAmountOut(pair, token0.address, amountIn);
-  
-    await token0.transfer(pair.address, amountIn)
-    await pair.swap(0, amountOut, wallet.address, '0x', overrides)
+      await token0.transfer(pair.address, tokenAmount)
+      await token1.transfer(pair.address, tokenAmount)
+      await pair.mint(wallet.address, overrides)
 
-    amountOut = await getAmountOut(pair, token1.address, amountIn);
-    await token1.transfer(pair.address, amountIn)
-    await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
-        
-    const protocolFeeToReceive = await calcProtocolFee(pair);
-    
-    await token0.transfer(pair.address, expandTo18Decimals(10))
-    await token1.transfer(pair.address, expandTo18Decimals(10))
-    await pair.mint(wallet.address, overrides)
-    
-    const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
-    expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
-    .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
-    
-    const token0FromProtocolFee = protocolFeeLPToknesReceived
-    .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply()); 
-    const token1FromProtocolFee = protocolFeeLPToknesReceived
-    .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
-    
-    const wethFromToken1FromProtocolFee = await getAmountOut(wethPair, token1.address, token1FromProtocolFee);
+      await token1.transfer(wethToken1Pair.address, tokenAmount)
+      await WETH.transfer(wethToken1Pair.address, wethAmount)
+      await wethToken1Pair.mint(wallet.address, overrides)
 
-    const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
+      let amountOut = await getAmountOut(pair, token0.address, amountIn);
 
-    await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
+      await token0.transfer(pair.address, amountIn)
+      await pair.swap(0, amountOut, wallet.address, '0x', overrides)
 
-    expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
-    
-    expect((await provider.getBalance(protocolFeeReceiver.address)))
-    .to.be.eq(protocolFeeReceiverBalanceBeforeTake.add(wethFromToken1FromProtocolFee))
-    expect((await token0.balanceOf(dxdao.address)))
-      .to.be.eq(token0FromProtocolFee)
-  })
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+      const protocolFeeToReceive = await calcProtocolFee(pair);
+
+      await token0.transfer(pair.address, expandTo18Decimals(10))
+      await token1.transfer(pair.address, expandTo18Decimals(10))
+      await pair.mint(wallet.address, overrides)
+
+      const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const token0FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply());
+      const token1FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
+
+      const wethFromToken1FromProtocolFee = await getAmountOut(wethToken1Pair, token1.address, token1FromProtocolFee);
+
+      const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
+
+      expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await token0.balanceOf(dxdao.address)))
+        .to.be.eq(token0FromProtocolFee)
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalanceBeforeTake.add(wethFromToken1FromProtocolFee))
+    })
 
   it('should receive everything in ETH from one WETH-token1 pair', async () => {
-    
+
     const tokenAmount = expandTo18Decimals(100);
     const wethAmount = expandTo18Decimals(100);
     const amountIn = expandTo18Decimals(50);
-    
-    await token1.transfer(wethPair.address, tokenAmount)
-    await WETH.transfer(wethPair.address, wethAmount)
-    await wethPair.mint(wallet.address, overrides)
-    
+
+    await token1.transfer(wethToken1Pair.address, tokenAmount)
+    await WETH.transfer(wethToken1Pair.address, wethAmount)
+    await wethToken1Pair.mint(wallet.address, overrides)
+
     const token1IsFirstToken = (token1.address < WETH.address)
-      
-    let amountOut = await getAmountOut(wethPair, token1.address, amountIn);
-    await token1.transfer(wethPair.address, amountIn)
-    await wethPair.swap(
+
+    let amountOut = await getAmountOut(wethToken1Pair, token1.address, amountIn);
+    await token1.transfer(wethToken1Pair.address, amountIn)
+    await wethToken1Pair.swap(
       token1IsFirstToken ? 0 : amountOut,
       token1IsFirstToken ? amountOut : 0,
       wallet.address, '0x', overrides
     )
 
-    amountOut = await getAmountOut(wethPair, WETH.address, amountIn);
-    await WETH.transfer(wethPair.address, amountIn)
-    await wethPair.swap(
+    amountOut = await getAmountOut(wethToken1Pair, WETH.address, amountIn);
+    await WETH.transfer(wethToken1Pair.address, amountIn)
+    await wethToken1Pair.swap(
       token1IsFirstToken ? amountOut : 0,
       token1IsFirstToken ? 0 : amountOut,
       wallet.address, '0x', overrides
     )
 
-    const protocolFeeToReceive = await calcProtocolFee(wethPair);
+    const protocolFeeToReceive = await calcProtocolFee(wethToken1Pair);
 
-    await token1.transfer(wethPair.address, expandTo18Decimals(10))
-    await WETH.transfer(wethPair.address, expandTo18Decimals(10))
-    await wethPair.mint(wallet.address, overrides)
-    
-    const protocolFeeLPToknesReceived = await wethPair.balanceOf(feeReceiver.address);
+    await token1.transfer(wethToken1Pair.address, expandTo18Decimals(10))
+    await WETH.transfer(wethToken1Pair.address, expandTo18Decimals(10))
+    await wethToken1Pair.mint(wallet.address, overrides)
+
+    const protocolFeeLPToknesReceived = await wethToken1Pair.balanceOf(feeReceiver.address);
     expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
-    .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
-    
+      .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
     const token1FromProtocolFee = protocolFeeLPToknesReceived
-      .mul(await token1.balanceOf(wethPair.address)).div(await wethPair.totalSupply()); 
+      .mul(await token1.balanceOf(wethToken1Pair.address)).div(await wethToken1Pair.totalSupply());
     const wethFromProtocolFee = protocolFeeLPToknesReceived
-      .mul(await WETH.balanceOf(wethPair.address)).div(await wethPair.totalSupply());
-  
-    const token1ReserveBeforeSwap = (await token1.balanceOf(wethPair.address)).sub(token1FromProtocolFee)
-    const wethReserveBeforeSwap = (await WETH.balanceOf(wethPair.address)).sub(wethFromProtocolFee)
+      .mul(await WETH.balanceOf(wethToken1Pair.address)).div(await wethToken1Pair.totalSupply());
+
+    const token1ReserveBeforeSwap = (await token1.balanceOf(wethToken1Pair.address)).sub(token1FromProtocolFee)
+    const wethReserveBeforeSwap = (await WETH.balanceOf(wethToken1Pair.address)).sub(wethFromProtocolFee)
     const wethFromToken1FromProtocolFee = await getAmountOutSync(
       token1IsFirstToken ? token1ReserveBeforeSwap : wethReserveBeforeSwap,
       token1IsFirstToken ? wethReserveBeforeSwap : token1ReserveBeforeSwap,
       token1IsFirstToken,
       token1FromProtocolFee,
-      await wethPair.swapFee()
+      await wethToken1Pair.swapFee()
     );
-  
+
     const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
 
-    await feeReceiver.connect(wallet).takeProtocolFee([wethPair.address], overrides)
+    await feeReceiver.connect(wallet).takeProtocolFee([wethToken1Pair.address], overrides)
 
     expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
     expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await wethPair.balanceOf(feeReceiver.address)).to.eq(0)
+    expect(await wethToken1Pair.balanceOf(feeReceiver.address)).to.eq(0)
     expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
     expect(await token1.balanceOf(dxdao.address)).to.be.eq(0)
     expect((await provider.getBalance(protocolFeeReceiver.address)))
       .to.be.eq(protocolFeeReceiverBalanceBeforeTake.add(wethFromToken1FromProtocolFee).add(wethFromProtocolFee))
   })
-  
+
   it(
     'should receive only tokens when extracting fee from tokenA-tokenB pair that has no path to WETH',
-    async () => 
-  {
-    const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
-    const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
-    
-    const tokenAmount = expandTo18Decimals(100);
-    const amountIn = expandTo18Decimals(50);
-    
-    await factory.createPair(tokenA.address, tokenB.address);
-    const tokenATokenBPair = new Contract(
-      await factory.getPair(
-        (tokenA.address < tokenB.address) ? tokenA.address : tokenB.address,
-        (tokenA.address < tokenB.address) ? tokenB.address : tokenA.address
-      ), JSON.stringify(DXswapPair.abi), provider
-    ).connect(wallet)
+    async () => {
+      const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+      const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
 
-    await tokenA.transfer(tokenATokenBPair.address, tokenAmount)
-    await tokenB.transfer(tokenATokenBPair.address, tokenAmount)
-    await tokenATokenBPair.mint(wallet.address, overrides)
-  
-    let amountOut = await getAmountOut(tokenATokenBPair, tokenA.address, amountIn);
-    await tokenA.transfer(tokenATokenBPair.address, amountIn)
-    await tokenATokenBPair.swap(
-      (tokenA.address < tokenB.address) ? 0 : amountOut,
-      (tokenA.address < tokenB.address) ? amountOut : 0,
-      wallet.address, '0x', overrides
-    )
+      const tokenAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(50);
 
-    amountOut = await getAmountOut(tokenATokenBPair, tokenB.address, amountIn);
-    await tokenB.transfer(tokenATokenBPair.address, amountIn)
-    await tokenATokenBPair.swap(
-      (tokenA.address < tokenB.address) ? amountOut : 0,
-      (tokenA.address < tokenB.address) ? 0 : amountOut,
-      wallet.address, '0x', overrides
-    )
-    
-    const protocolFeeToReceive = await calcProtocolFee(tokenATokenBPair);
+      await factory.createPair(tokenA.address, tokenB.address);
+      const tokenATokenBPair = new Contract(
+        await factory.getPair(
+          (tokenA.address < tokenB.address) ? tokenA.address : tokenB.address,
+          (tokenA.address < tokenB.address) ? tokenB.address : tokenA.address
+        ), JSON.stringify(DXswapPair.abi), provider
+      ).connect(wallet)
 
-    await tokenA.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
-    await tokenB.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
-    await tokenATokenBPair.mint(wallet.address, overrides)
-    
-    const protocolFeeLPTokenAtokenBPair = await tokenATokenBPair.balanceOf(feeReceiver.address);
-    expect(protocolFeeLPTokenAtokenBPair.div(ROUND_EXCEPTION))
-    .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
-    
-    const tokenAFromProtocolFee = protocolFeeLPTokenAtokenBPair
-    .mul(await tokenA.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply()); 
-    const tokenBFromProtocolFee = protocolFeeLPTokenAtokenBPair
-    .mul(await tokenB.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+      await tokenA.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenB.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenATokenBPair.mint(wallet.address, overrides)
 
-    const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
+      let amountOut = await getAmountOut(tokenATokenBPair, tokenA.address, amountIn);
+      await tokenA.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        wallet.address, '0x', overrides
+      )
 
-    await feeReceiver.connect(wallet).takeProtocolFee([tokenATokenBPair.address], overrides)
+      amountOut = await getAmountOut(tokenATokenBPair, tokenB.address, amountIn);
+      await tokenB.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        wallet.address, '0x', overrides
+      )
 
-    expect(await tokenA.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await tokenB.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await tokenATokenBPair.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
-    
-    expect((await provider.getBalance(protocolFeeReceiver.address)))
-      .to.be.eq(protocolFeeReceiverBalance)
-    expect((await tokenA.balanceOf(dxdao.address)))
-      .to.be.eq(tokenAFromProtocolFee)
-    expect((await tokenB.balanceOf(dxdao.address)))
-      .to.be.eq(tokenBFromProtocolFee)
-  })
-  
+      const protocolFeeToReceive = await calcProtocolFee(tokenATokenBPair);
+
+      await tokenA.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenB.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenATokenBPair.mint(wallet.address, overrides)
+
+      const protocolFeeLPTokenAtokenBPair = await tokenATokenBPair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPTokenAtokenBPair.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const tokenAFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenA.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+      const tokenBFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenB.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+
+      const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([tokenATokenBPair.address], overrides)
+
+      expect(await tokenA.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenB.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenATokenBPair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalance)
+      expect((await tokenA.balanceOf(dxdao.address)))
+        .to.be.eq(tokenAFromProtocolFee)
+      expect((await tokenB.balanceOf(dxdao.address)))
+        .to.be.eq(tokenBFromProtocolFee)
+    })
+
   it(
     'should receive only tokens when extracting fee from both tokenA-tonkenB pair and tokenC-tokenD pair',
-    async () =>
-  {
-    const tokenAmount = expandTo18Decimals(100);
-    const amountIn = expandTo18Decimals(50);
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(50);
 
-    // Set up tokenA-tokenB
-    const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
-    const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
-    
-    await factory.createPair(tokenA.address, tokenB.address);
-    const tokenATokenBPair = new Contract(
-      await factory.getPair(
-        (tokenA.address < tokenB.address) ? tokenA.address : tokenB.address,
-        (tokenA.address < tokenB.address) ? tokenB.address : tokenA.address
-      ), JSON.stringify(DXswapPair.abi), provider
-    ).connect(wallet)
+      // Set up tokenA-tokenB
+      const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+      const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
 
-    await tokenA.transfer(tokenATokenBPair.address, tokenAmount)
-    await tokenB.transfer(tokenATokenBPair.address, tokenAmount)
-    await tokenATokenBPair.mint(wallet.address, overrides)
-  
-    let amountOut = await getAmountOut(tokenATokenBPair, tokenA.address, amountIn);
-    await tokenA.transfer(tokenATokenBPair.address, amountIn)
-    await tokenATokenBPair.swap(
-      (tokenA.address < tokenB.address) ? 0 : amountOut,
-      (tokenA.address < tokenB.address) ? amountOut : 0,
-      wallet.address, '0x', overrides
-    )
+      await factory.createPair(tokenA.address, tokenB.address);
+      const tokenATokenBPair = new Contract(
+        await factory.getPair(
+          (tokenA.address < tokenB.address) ? tokenA.address : tokenB.address,
+          (tokenA.address < tokenB.address) ? tokenB.address : tokenA.address
+        ), JSON.stringify(DXswapPair.abi), provider
+      ).connect(wallet)
 
-    amountOut = await getAmountOut(tokenATokenBPair, tokenB.address, amountIn);
-    await tokenB.transfer(tokenATokenBPair.address, amountIn)
-    await tokenATokenBPair.swap(
-      (tokenA.address < tokenB.address) ? amountOut : 0,
-      (tokenA.address < tokenB.address) ? 0 : amountOut,
-      wallet.address, '0x', overrides
-    )
-    
-    let protocolFeeToReceive = await calcProtocolFee(tokenATokenBPair);
-    
-    await tokenA.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
-    await tokenB.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
-    await tokenATokenBPair.mint(wallet.address, overrides)
-    
-    const protocolFeeLPTokenAtokenBPair = await tokenATokenBPair.balanceOf(feeReceiver.address);
-    expect(protocolFeeLPTokenAtokenBPair.div(ROUND_EXCEPTION))
-      .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+      await tokenA.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenB.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenATokenBPair.mint(wallet.address, overrides)
 
-    // Set up tokenC-tokenD pair
-    const tokenC = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
-    const tokenD = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
-    
-    await factory.createPair(tokenC.address, tokenD.address);
-    const tokenCTokenDPair = new Contract(
-      await factory.getPair(
-        (tokenC.address < tokenD.address) ? tokenC.address : tokenD.address,
-        (tokenC.address < tokenD.address) ? tokenD.address : tokenC.address
-      ), JSON.stringify(DXswapPair.abi), provider
-    ).connect(wallet)
+      let amountOut = await getAmountOut(tokenATokenBPair, tokenA.address, amountIn);
+      await tokenA.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        wallet.address, '0x', overrides
+      )
 
-    await tokenC.transfer(tokenCTokenDPair.address, tokenAmount)
-    await tokenD.transfer(tokenCTokenDPair.address, tokenAmount)
-    await tokenCTokenDPair.mint(wallet.address, overrides)
+      amountOut = await getAmountOut(tokenATokenBPair, tokenB.address, amountIn);
+      await tokenB.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        wallet.address, '0x', overrides
+      )
 
-    amountOut = await getAmountOut(tokenCTokenDPair, tokenC.address, amountIn);
-    await tokenC.transfer(tokenCTokenDPair.address, amountIn)
-    await tokenCTokenDPair.swap(
-      (tokenC.address < tokenD.address) ? 0 : amountOut,
-      (tokenC.address < tokenD.address) ? amountOut : 0,
-      wallet.address, '0x', overrides
-    )
+      let protocolFeeToReceive = await calcProtocolFee(tokenATokenBPair);
 
-    amountOut = await getAmountOut(tokenCTokenDPair, tokenD.address, amountIn);
-    await tokenD.transfer(tokenCTokenDPair.address, amountIn)
-    await tokenCTokenDPair.swap(
-      (tokenC.address < tokenD.address) ? amountOut : 0,
-      (tokenC.address < tokenD.address) ? 0 : amountOut,
-      wallet.address, '0x', overrides
-    )
-    
-    protocolFeeToReceive = await calcProtocolFee(tokenCTokenDPair);
+      await tokenA.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenB.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenATokenBPair.mint(wallet.address, overrides)
 
-    await tokenC.transfer(tokenCTokenDPair.address, expandTo18Decimals(10))
-    await tokenD.transfer(tokenCTokenDPair.address, expandTo18Decimals(10))
-    await tokenCTokenDPair.mint(wallet.address, overrides)
-    
-    const protocolFeeLPTokenCtokenDPair = await tokenCTokenDPair.balanceOf(feeReceiver.address);
-    expect(protocolFeeLPTokenCtokenDPair.div(ROUND_EXCEPTION))
-      .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
-    
-    const tokenAFromProtocolFee = protocolFeeLPTokenAtokenBPair
-      .mul(await tokenA.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply()); 
-    const tokenBFromProtocolFee = protocolFeeLPTokenAtokenBPair
-      .mul(await tokenB.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
-    const tokenCFromProtocolFee = protocolFeeLPTokenCtokenDPair
-      .mul(await tokenC.balanceOf(tokenCTokenDPair.address)).div(await tokenCTokenDPair.totalSupply()); 
-    const tokenDFromProtocolFee = protocolFeeLPTokenCtokenDPair
-      .mul(await tokenD.balanceOf(tokenCTokenDPair.address)).div(await tokenCTokenDPair.totalSupply());
+      const protocolFeeLPTokenAtokenBPair = await tokenATokenBPair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPTokenAtokenBPair.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
 
-    const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
+      // Set up tokenC-tokenD pair
+      const tokenC = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+      const tokenD = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
 
-    await feeReceiver.connect(wallet).takeProtocolFee([tokenATokenBPair.address, tokenCTokenDPair.address], overrides)
+      await factory.createPair(tokenC.address, tokenD.address);
+      const tokenCTokenDPair = new Contract(
+        await factory.getPair(
+          (tokenC.address < tokenD.address) ? tokenC.address : tokenD.address,
+          (tokenC.address < tokenD.address) ? tokenD.address : tokenC.address
+        ), JSON.stringify(DXswapPair.abi), provider
+      ).connect(wallet)
 
-    expect(await provider.getBalance(protocolFeeReceiver.address)).to.eq(protocolFeeReceiverBalance.toString())
+      await tokenC.transfer(tokenCTokenDPair.address, tokenAmount)
+      await tokenD.transfer(tokenCTokenDPair.address, tokenAmount)
+      await tokenCTokenDPair.mint(wallet.address, overrides)
 
-    expect(await tokenA.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await tokenB.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await tokenC.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await tokenD.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
-    
-    expect((await provider.getBalance(protocolFeeReceiver.address)))
-    .to.be.eq(protocolFeeReceiverBalance)
-    expect((await tokenA.balanceOf(dxdao.address)))
-      .to.be.eq(tokenAFromProtocolFee)
-    expect((await tokenB.balanceOf(dxdao.address)))
-      .to.be.eq(tokenBFromProtocolFee)
-    expect((await tokenC.balanceOf(dxdao.address)))
-      .to.be.eq(tokenCFromProtocolFee)
-    expect((await tokenD.balanceOf(dxdao.address)))
-      .to.be.eq(tokenDFromProtocolFee)
-  })
+      amountOut = await getAmountOut(tokenCTokenDPair, tokenC.address, amountIn);
+      await tokenC.transfer(tokenCTokenDPair.address, amountIn)
+      await tokenCTokenDPair.swap(
+        (tokenC.address < tokenD.address) ? 0 : amountOut,
+        (tokenC.address < tokenD.address) ? amountOut : 0,
+        wallet.address, '0x', overrides
+      )
+
+      amountOut = await getAmountOut(tokenCTokenDPair, tokenD.address, amountIn);
+      await tokenD.transfer(tokenCTokenDPair.address, amountIn)
+      await tokenCTokenDPair.swap(
+        (tokenC.address < tokenD.address) ? amountOut : 0,
+        (tokenC.address < tokenD.address) ? 0 : amountOut,
+        wallet.address, '0x', overrides
+      )
+
+      protocolFeeToReceive = await calcProtocolFee(tokenCTokenDPair);
+
+      await tokenC.transfer(tokenCTokenDPair.address, expandTo18Decimals(10))
+      await tokenD.transfer(tokenCTokenDPair.address, expandTo18Decimals(10))
+      await tokenCTokenDPair.mint(wallet.address, overrides)
+
+      const protocolFeeLPTokenCtokenDPair = await tokenCTokenDPair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPTokenCtokenDPair.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const tokenAFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenA.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+      const tokenBFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenB.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+      const tokenCFromProtocolFee = protocolFeeLPTokenCtokenDPair
+        .mul(await tokenC.balanceOf(tokenCTokenDPair.address)).div(await tokenCTokenDPair.totalSupply());
+      const tokenDFromProtocolFee = protocolFeeLPTokenCtokenDPair
+        .mul(await tokenD.balanceOf(tokenCTokenDPair.address)).div(await tokenCTokenDPair.totalSupply());
+
+      const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([tokenATokenBPair.address, tokenCTokenDPair.address], overrides)
+
+      expect(await provider.getBalance(protocolFeeReceiver.address)).to.eq(protocolFeeReceiverBalance.toString())
+
+      expect(await tokenA.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenB.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenC.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenD.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalance)
+      expect((await tokenA.balanceOf(dxdao.address)))
+        .to.be.eq(tokenAFromProtocolFee)
+      expect((await tokenB.balanceOf(dxdao.address)))
+        .to.be.eq(tokenBFromProtocolFee)
+      expect((await tokenC.balanceOf(dxdao.address)))
+        .to.be.eq(tokenCFromProtocolFee)
+      expect((await tokenD.balanceOf(dxdao.address)))
+        .to.be.eq(tokenDFromProtocolFee)
+    })
 
   it(
     'should only allow owner to transfer ownership',
-    async () =>
-  {
-    await expect(feeReceiver.connect(other).transferOwnership(other.address))
-      .to.be.revertedWith('DXswapFeeReceiver: FORBIDDEN')
-    await feeReceiver.connect(dxdao).transferOwnership(other.address);
-    expect(await feeReceiver.owner()).to.be.eq(other.address)
-  })
+    async () => {
+      await expect(feeReceiver.connect(other).transferOwnership(other.address))
+        .to.be.revertedWith('DXswapFeeReceiver: FORBIDDEN')
+      await feeReceiver.connect(dxdao).transferOwnership(other.address);
+      expect(await feeReceiver.owner()).to.be.eq(other.address)
+    })
 
   it(
     'should only allow owner to change receivers',
-    async () =>
-  {
-    await expect(feeReceiver.connect(other).changeReceivers(other.address, other.address))
-      .to.be.revertedWith('DXswapFeeReceiver: FORBIDDEN')
-    await feeReceiver.connect(dxdao).changeReceivers(other.address, other.address);
-    expect(await feeReceiver.ethReceiver()).to.be.eq(other.address)
-    expect(await feeReceiver.fallbackReceiver()).to.be.eq(other.address)
-  })
+    async () => {
+      await expect(feeReceiver.connect(other).changeReceivers(other.address, other.address))
+        .to.be.revertedWith('DXswapFeeReceiver: FORBIDDEN')
+      await feeReceiver.connect(dxdao).changeReceivers(other.address, other.address);
+      expect(await feeReceiver.ethReceiver()).to.be.eq(other.address)
+      expect(await feeReceiver.fallbackReceiver()).to.be.eq(other.address)
+    })
 
   it(
-    'should revert with insufficient liquidity error if there is not any liquidity in the WETH pair',
-    async () => 
-  {
-    const tokenAmount = expandTo18Decimals(100);
-    const wethAmount = expandTo18Decimals(100);
-    const amountIn = expandTo18Decimals(50);
+    'should send token to fee receiver if there is not any liquidity in the WETH pair',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(50);
 
-    await token0.transfer(pair.address, tokenAmount)
-    await token1.transfer(pair.address, tokenAmount)
-    await pair.mint(wallet.address, overrides)
-  
-    let amountOut = await getAmountOut(pair, token0.address, amountIn);
-    await token0.transfer(pair.address, amountIn)
-    await pair.swap(0, amountOut, wallet.address, '0x', overrides)
+      await token0.transfer(pair.address, tokenAmount)
+      await token1.transfer(pair.address, tokenAmount)
+      await pair.mint(wallet.address, overrides)
 
-    amountOut = await getAmountOut(pair, token1.address, amountIn);
-    await token1.transfer(pair.address, amountIn)
-    await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
-    
-    const protocolFeeToReceive = await calcProtocolFee(pair);
-        
-    await token0.transfer(pair.address, expandTo18Decimals(10))
-    await token1.transfer(pair.address, expandTo18Decimals(10))
-    await pair.mint(wallet.address, overrides)
-    
-    const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
-    expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
-      .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
-  
-    const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
+      const amountOutToken0WETH = await getAmountOut(wethToken1Pair, token0.address, expandTo18Decimals(1));
+      const amountOutToken1WETH = await getAmountOut(wethToken1Pair, token1.address, expandTo18Decimals(1));
+      expect(amountOutToken0WETH).to.be.eq(0)
+      expect(amountOutToken1WETH).to.be.eq(0)
 
-    await expect(feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)).to.be.revertedWith('DXswapFeeReceiver: INSUFFICIENT_LIQUIDITY')
+      let amountOut = await getAmountOut(pair, token0.address, amountIn);
+      await token0.transfer(pair.address, amountIn)
+      await pair.swap(0, amountOut, wallet.address, '0x', overrides)
 
-    expect(await pair.balanceOf(feeReceiver.address)).to.eq(protocolFeeLPToknesReceived)
-    expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
-    
-    expect((await provider.getBalance(protocolFeeReceiver.address)))
-      .to.be.eq(protocolFeeReceiverBalance)
-    expect((await token0.balanceOf(dxdao.address)))
-      .to.be.eq(0)
-    expect((await token1.balanceOf(dxdao.address)))
-      .to.be.eq(0)
-  })
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+      const protocolFeeToReceive = await calcProtocolFee(pair);
+
+      await token0.transfer(pair.address, expandTo18Decimals(10))
+      await token1.transfer(pair.address, expandTo18Decimals(10))
+      await pair.mint(wallet.address, overrides)
+
+      const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
+
+      const token0FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply());
+      const token1FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
+
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(protocolFeeReceiver.address)).to.eq(protocolFeeReceiverBalance)
+
+      expect((await token0.balanceOf(dxdao.address)))
+        .to.be.eq(token0FromProtocolFee)
+      expect((await token1.balanceOf(dxdao.address)))
+        .to.be.eq(token1FromProtocolFee)
+    })
+
+  // Where token0-token1 and token1-WETH pairs exist AND PRICE IMPACT TOO HIGH 
+  it(
+    'should receive token0 and token1 if price impact token1-weth pool is too high',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(1);
+      // add very small liquidity to weth-token1 pool
+      const wethTknAmount = bigNumberify(1).mul(bigNumberify(10).pow(15));
+
+      await token0.transfer(pair.address, tokenAmount)
+      await token1.transfer(pair.address, tokenAmount)
+      await pair.mint(wallet.address, overrides)
+
+      await token1.transfer(wethToken1Pair.address, wethTknAmount)
+      await WETH.transfer(wethToken1Pair.address, wethTknAmount)
+      await wethToken1Pair.mint(wallet.address, overrides)
+
+      let amountOut = await getAmountOut(pair, token0.address, amountIn);
+
+      await token0.transfer(pair.address, amountIn)
+      await pair.swap(0, amountOut, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+
+      const protocolFeeToReceive = await calcProtocolFee(pair);
+
+      await token0.transfer(pair.address, expandTo18Decimals(15))
+      await token1.transfer(pair.address, expandTo18Decimals(15))
+      await pair.mint(wallet.address, overrides)
+
+      const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const token0FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply());
+      const token1FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
+
+      const wethFromToken1FromProtocolFee = await getAmountOut(wethToken1Pair, token1.address, token1FromProtocolFee);
+
+      const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
+
+      expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalanceBeforeTake)
+      expect((await token0.balanceOf(dxdao.address)))
+        .to.be.eq(token0FromProtocolFee)
+      expect((await token1.balanceOf(dxdao.address)))
+        .to.be.eq(token1FromProtocolFee)
+    })
+
+  it(
+    'should only allow owner to set max price impact',
+    async () => {
+      await expect(feeReceiver.connect(other).setMaxSwapPriceImpact(500))
+        .to.be.revertedWith('DXswapFeeReceiver: CALLER_NOT_OWNER')
+      await feeReceiver.connect(dxdao).setMaxSwapPriceImpact(500);
+      expect(await feeReceiver.maxSwapPriceImpact()).to.be.eq(500)
+    })
+
+  it(
+    'should set max price impact within the range 0 - 10000',
+    async () => {
+      expect(await feeReceiver.maxSwapPriceImpact()).to.be.eq(300)
+      await expect(feeReceiver.connect(dxdao).setMaxSwapPriceImpact(0))
+        .to.be.revertedWith('DXswapFeeReceiver: FORBIDDEN_PRICE_IMPACT')
+      await expect(feeReceiver.connect(dxdao).setMaxSwapPriceImpact(10000))
+        .to.be.revertedWith('DXswapFeeReceiver: FORBIDDEN_PRICE_IMPACT')
+      await feeReceiver.connect(dxdao).setMaxSwapPriceImpact(500);
+      expect(await feeReceiver.maxSwapPriceImpact()).to.be.eq(500)
+    })
+
+  it(
+    'split fee: should receive tokenA & tokenB default (100%) fee to dxdao and (0%) to external fee receiver',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(50);
+
+      // Set up tokenA-tokenB
+      const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+      const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+
+      await factory.createPair(tokenA.address, tokenB.address)
+      const tokenATokenBPair = new Contract(
+        await factory.getPair(
+          (tokenA.address < tokenB.address) ? tokenA.address : tokenB.address,
+          (tokenA.address < tokenB.address) ? tokenB.address : tokenA.address
+        ), JSON.stringify(DXswapPair.abi), provider
+      ).connect(wallet)
+
+      await feeSetter.setExternalFeeRecipient(tokenATokenBPair.address, externalFeeRecipient.address)
+
+      await tokenA.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenB.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenATokenBPair.mint(wallet.address, overrides)
+
+      let amountOut = await getAmountOut(tokenATokenBPair, tokenA.address, amountIn)
+      await tokenA.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        wallet.address, '0x', overrides
+      )
+
+      amountOut = await getAmountOut(tokenATokenBPair, tokenB.address, amountIn)
+      await tokenB.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        wallet.address, '0x', overrides
+      )
+
+      let protocolFeeToReceive = await calcProtocolFee(tokenATokenBPair);
+
+      await tokenA.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenB.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenATokenBPair.mint(wallet.address, overrides)
+
+      const protocolFeeLPTokenAtokenBPair = await tokenATokenBPair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPTokenAtokenBPair.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const tokenAFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenA.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+      const tokenBFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenB.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+
+      const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([tokenATokenBPair.address], overrides)
+
+      const percentFeeToExternalRecipient = await tokenATokenBPair.percentFeeToExternalRecipient()
+      const feeToEthReceiver = (bigNumberify(10000).sub(percentFeeToExternalRecipient))
+
+      expect(await provider.getBalance(protocolFeeReceiver.address)).to.eq(protocolFeeReceiverBalance.toString())
+
+      expect(await tokenA.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenB.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalance)
+
+      expect((await tokenA.balanceOf(dxdao.address)))
+        .to.be.eq(tokenAFromProtocolFee)
+      expect((await tokenA.balanceOf(externalFeeRecipient.address)))
+        .to.be.eq(0)
+
+      expect((await tokenB.balanceOf(dxdao.address)))
+        .to.be.eq(tokenBFromProtocolFee)
+      expect((await tokenB.balanceOf(externalFeeRecipient.address)))
+        .to.be.eq(0)
+    })
+
+  it(
+    'split fee: should receive tokenA & tokenB CHANGED % fee to dxdao and external fee receiver',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(50);
+      const newPercentFeeToExternalRecipient = 2000 //20%
+
+      // Set up tokenA-tokenB
+      const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+      const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+
+      await factory.createPair(tokenA.address, tokenB.address)
+      const tokenATokenBPair = new Contract(
+        await factory.getPair(
+          (tokenA.address < tokenB.address) ? tokenA.address : tokenB.address,
+          (tokenA.address < tokenB.address) ? tokenB.address : tokenA.address
+        ), JSON.stringify(DXswapPair.abi), provider
+      ).connect(wallet)
+
+      await feeSetter.setExternalFeeRecipient(tokenATokenBPair.address, externalFeeRecipient.address)
+      await feeSetter.setPercentFeeToExternalRecipient(tokenATokenBPair.address, newPercentFeeToExternalRecipient)
+      const percentFeeToExternalRecipient = await tokenATokenBPair.percentFeeToExternalRecipient()
+      expect(percentFeeToExternalRecipient).to.eq(newPercentFeeToExternalRecipient)
+
+      await tokenA.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenB.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenATokenBPair.mint(wallet.address, overrides)
+
+      let amountOut = await getAmountOut(tokenATokenBPair, tokenA.address, amountIn)
+      await tokenA.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        wallet.address, '0x', overrides
+      )
+
+      let protocolFeeToReceive = await calcProtocolFee(tokenATokenBPair);
+
+      await tokenA.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenB.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenATokenBPair.mint(wallet.address, overrides)
+
+      const protocolFeeLPTokenAtokenBPair = await tokenATokenBPair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPTokenAtokenBPair.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const tokenAFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenA.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+      const tokenBFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenB.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+
+      const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([tokenATokenBPair.address], overrides)
+
+      const feeToEthReceiver = (bigNumberify(10000).sub(percentFeeToExternalRecipient))
+
+      expect(await provider.getBalance(protocolFeeReceiver.address)).to.eq(protocolFeeReceiverBalance.toString())
+
+      expect(await tokenA.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenB.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalance)
+
+      expect((await tokenA.balanceOf(dxdao.address)).div(ROUND_EXCEPTION))
+        .to.be.eq(tokenAFromProtocolFee.mul(feeToEthReceiver).div(10000).div(ROUND_EXCEPTION))
+      expect((await tokenA.balanceOf(externalFeeRecipient.address)).div(ROUND_EXCEPTION))
+        .to.be.eq(tokenAFromProtocolFee.mul(percentFeeToExternalRecipient).div(10000).div(ROUND_EXCEPTION))
+
+      expect((await tokenB.balanceOf(dxdao.address)).div(ROUND_EXCEPTION))
+        .to.be.eq(tokenBFromProtocolFee.mul(feeToEthReceiver).div(10000).div(ROUND_EXCEPTION))
+      expect((await tokenB.balanceOf(externalFeeRecipient.address)).div(ROUND_EXCEPTION))
+        .to.be.eq(tokenBFromProtocolFee.mul(percentFeeToExternalRecipient).div(10000).div(ROUND_EXCEPTION))
+    })
+
 })

--- a/test/DXswapFeeSetter.spec.ts
+++ b/test/DXswapFeeSetter.spec.ts
@@ -21,7 +21,7 @@ describe('DXswapFeeSetter', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 9999999
+    gasLimit: 15000000
   })
   const [dxdao, pairOwner, protocolFeeReceiver, other] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [dxdao, other, protocolFeeReceiver])
@@ -57,24 +57,24 @@ describe('DXswapFeeSetter', () => {
     await feeSetter.connect(dxdao).setFeeToSetter(other.address)
     await expect(feeSetter.connect(dxdao).setFeeTo(dxdao.address)).to.be.revertedWith('DXswapFactory: FORBIDDEN')
   })
-  
+
   it('setProtocolFee', async () => {
     // Should not allow to setProtocolFee from other address taht is not owner calling feeSetter
     await expect(feeSetter.connect(other).setProtocolFee(5)).to.be.revertedWith('DXswapFeeSetter: FORBIDDEN')
     await feeSetter.connect(dxdao).setProtocolFee(5)
     expect(await factory.protocolFeeDenominator()).to.eq(5)
-    
+
     // If feeToSetter changes it will will fail in DXswapFactory check when trying to setProtocolFee from FeeSetter.
     await feeSetter.connect(dxdao).setFeeToSetter(other.address)
     await expect(feeSetter.connect(dxdao).setProtocolFee(5)).to.be.revertedWith('DXswapFactory: FORBIDDEN')
   })
-  
+
   it('setSwapFee', async () => {
     // Should not allow to setSwapFee from other address taht is not owner calling feeSetter
     await expect(feeSetter.connect(other).setSwapFee(pair.address, 5)).to.be.revertedWith('DXswapFeeSetter: FORBIDDEN')
     await feeSetter.connect(dxdao).setSwapFee(pair.address, 5)
     expect(await pair.swapFee()).to.eq(5)
-    
+
     // If ownership of the pair is given to other address both addresses (FeeSetter owner and Pair owner) should be
     // able to change the swap fee
     await expect(feeSetter.connect(pairOwner).setSwapFee(pair.address, 5)).to.be.revertedWith('DXswapFeeSetter: FORBIDDEN')
@@ -83,7 +83,7 @@ describe('DXswapFeeSetter', () => {
     expect(await pair.swapFee()).to.eq(3)
     await feeSetter.connect(dxdao).setSwapFee(pair.address, 7)
     expect(await pair.swapFee()).to.eq(7)
-    
+
     // If ownership of the pair is removed by setting it to zero the pair owner should not be able to change the 
     // fee anymore.
     await feeSetter.connect(dxdao).transferPairOwnership(pair.address, AddressZero)
@@ -93,7 +93,7 @@ describe('DXswapFeeSetter', () => {
     await feeSetter.connect(dxdao).setFeeToSetter(other.address)
     await expect(feeSetter.connect(dxdao).setSwapFee(pair.address, 5)).to.be.revertedWith('DXswapFactory: FORBIDDEN')
   })
-  
+
   it('setFeeToSetter', async () => {
     // Should not allow to setFeeToSetter from other address taht is not owner calling feeSetter
     await expect(feeSetter.connect(other).setFeeToSetter(other.address)).to.be.revertedWith('DXswapFeeSetter: FORBIDDEN')

--- a/test/DXswapPair.spec.ts
+++ b/test/DXswapPair.spec.ts
@@ -267,18 +267,18 @@ describe('DXswapPair', () => {
     await pair.connect(wallet).burn(wallet.address, overrides)
     expect(await pair.totalSupply()).to.eq(MINIMUM_LIQUIDITY)
   })
-  
+
   it('feeTo:off, swapFee:0 attack', async () => {
     await feeSetter.setSwapFee(pair.address, 0)
     const token0Amount = expandTo18Decimals(1000)
     const token1Amount = expandTo18Decimals(1000)
     await addLiquidity(token0Amount, token1Amount)
-    
+
     expect(await token0.balanceOf(pair.address)).to.eq(expandTo18Decimals(1000))
     expect(await token1.balanceOf(pair.address)).to.eq(expandTo18Decimals(1000))
     expect(await token0.balanceOf(wallet.address)).to.eq(expandTo18Decimals(9000))
     expect(await token1.balanceOf(wallet.address)).to.eq(expandTo18Decimals(9000))
-    
+
     // Attack pool
     await token1.transfer(pair.address, expandTo18Decimals(1))
     await expect(pair.connect(wallet).swap(expandTo18Decimals(999), 0, wallet.address, '0x', overrides)).to.be.revertedWith(
@@ -292,8 +292,8 @@ describe('DXswapPair', () => {
     expect(await token0.balanceOf(pair.address)).to.eq(expandTo18Decimals(1001))
     expect(await token1.balanceOf(pair.address)).to.eq(expandTo18Decimals(1001))
     expect(await token0.balanceOf(wallet.address)).to.eq(expandTo18Decimals(8999))
-    expect(await token1.balanceOf(wallet.address)).to.eq(expandTo18Decimals(8999)) 
-    
+    expect(await token1.balanceOf(wallet.address)).to.eq(expandTo18Decimals(8999))
+
     const expectedLiquidity = expandTo18Decimals(1000)
     await pair.connect(wallet).transfer(pair.address, expectedLiquidity.sub(MINIMUM_LIQUIDITY))
     await pair.connect(wallet).burn(wallet.address, overrides)
@@ -323,7 +323,7 @@ describe('DXswapPair', () => {
     expect(await token0.balanceOf(pair.address)).to.eq(bigNumberify(1000).add('149701010218466'))
     expect(await token1.balanceOf(pair.address)).to.eq(bigNumberify(1000).add('150000112387782'))
   })
-  
+
   it('feeTo:on:0.025', async () => {
     await feeSetter.setFeeTo(other.address)
     await feeSetter.setProtocolFee(11)
@@ -354,7 +354,7 @@ describe('DXswapPair', () => {
     expect((await token1.balanceOf(pair.address)).div(ROUND_EXCEPTION))
       .to.eq(bigNumberify(1000).add('125000093656485').div(ROUND_EXCEPTION))
   })
-  
+
   it('feeTo:on:0.1:swapFee:0.20', async () => {
     await feeSetter.setFeeTo(other.address)
     await feeSetter.setProtocolFee(1)
@@ -386,7 +386,7 @@ describe('DXswapPair', () => {
     expect((await token1.balanceOf(pair.address)).div(ROUND_EXCEPTION))
       .to.eq(bigNumberify(1000).add('4759687103171089').div(ROUND_EXCEPTION))
   })
-  
+
   it('fail on trying to set swap fee higher than 10%', async () => {
     await feeSetter.setSwapFee(pair.address, 0)
     await feeSetter.setSwapFee(pair.address, 1000)
@@ -394,4 +394,30 @@ describe('DXswapPair', () => {
       'DXswapPair: FORBIDDEN_FEE'
     )
   })
+
+  it('fail on trying to set percent fee to external recipient higher than 50%', async () => {
+    expect(await pair.percentFeeToExternalRecipient())
+      .to.eq(0)
+    await feeSetter.setPercentFeeToExternalRecipient(pair.address, 5000)
+    expect(await pair.percentFeeToExternalRecipient())
+      .to.eq(5000)
+    await feeSetter.setPercentFeeToExternalRecipient(pair.address, 100)
+    expect(await pair.percentFeeToExternalRecipient())
+      .to.eq(100)
+    await expect(feeSetter.setPercentFeeToExternalRecipient(pair.address, 5001)).to.be.revertedWith(
+      'DXswapPair: FORBIDDEN_FEE_SPLIT'
+    )
+  })
+
+  it('set external fee recipient', async () => {
+    expect(await pair.externalFeeRecipient())
+      .to.eq(AddressZero)
+    await feeSetter.setExternalFeeRecipient(pair.address, other.address)
+    expect(await pair.externalFeeRecipient())
+      .to.eq(other.address)
+    await expect(feeSetter.connect(other).setExternalFeeRecipient(pair.address, wallet.address)).to.be.revertedWith(
+      'DXswapFeeSetter: FORBIDDEN'
+    )
+  })
+
 })

--- a/test/DXswapPair.spec.ts
+++ b/test/DXswapPair.spec.ts
@@ -14,14 +14,14 @@ const FEE_DENOMINATOR = bigNumberify(10).pow(4)
 chai.use(solidity)
 
 const overrides = {
-  gasLimit: 9999999
+  gasLimit: 15000000
 }
 
 describe('DXswapPair', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 9999999
+    gasLimit: 15000000
   })
   const [dxdao, wallet, protocolFeeReceiver, other] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [dxdao, wallet, protocolFeeReceiver])

--- a/test/DynamicFees.spec.ts
+++ b/test/DynamicFees.spec.ts
@@ -16,14 +16,14 @@ const ROUND_EXCEPTION = bigNumberify(10000)
 chai.use(solidity)
 
 const overrides = {
-  gasLimit: 9999999
+  gasLimit: 15000000
 }
 
 describe('DynamicFees', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 9999999
+    gasLimit: 15000000
   })
   const [dxdao, wallet, protocolFeeReceiver, other] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [dxdao, wallet, protocolFeeReceiver])
@@ -49,13 +49,13 @@ describe('DynamicFees', () => {
     await token1.transfer(pair.address, token1Amount)
     await pair.mint(wallet.address, overrides)
   }
-  
+
   // Calculate the total supply based on actual reserves
   async function calcTotalSupply() {
     const [token0Reserve, token1Reserve, _] = await pair.getReserves()
     return bigNumberify(Math.sqrt(token0Reserve.mul(token1Reserve)).toString())
-  } 
-  
+  }
+
   // Calculate how much will be payed from liquidity as protocol fee in the next mint/burn
   async function calcProtocolFee() {
     const [token0Reserve, token1Reserve, _] = await pair.getReserves()
@@ -67,7 +67,7 @@ describe('DynamicFees', () => {
     if (feeTo != AddressZero) {
       // Check for math overflow when dealing with big big balances
       if (Math.sqrt((token0Reserve).mul(token1Reserve)) > Math.pow(10, 19)) {
-        const denominator = 10 ** ( Number(Math.log10(Math.sqrt((token0Reserve).mul(token1Reserve))).toFixed(0)) - 18);
+        const denominator = 10 ** (Number(Math.log10(Math.sqrt((token0Reserve).mul(token1Reserve))).toFixed(0)) - 18);
         rootK = bigNumberify((Math.sqrt(
           token0Reserve.mul(token1Reserve)
         ) / denominator).toString())
@@ -76,22 +76,22 @@ describe('DynamicFees', () => {
         rootK = bigNumberify(Math.sqrt((token0Reserve).mul(token1Reserve)).toString())
         rootKLast = bigNumberify(Math.sqrt(kLast).toString())
       }
-      
+
       return (totalSupply.mul(rootK.sub(rootKLast)))
         .div(rootK.mul(protocolFeeDenominator).add(rootKLast))
     } else {
       return bigNumberify(0)
     }
-  } 
-  
+  }
+
   // Calculate the output of tokens for an specific input
-  async function calcOutput(token0In : BigNumber, token1In: BigNumber) {
+  async function calcOutput(token0In: BigNumber, token1In: BigNumber) {
     const reserves = await pair.getReserves()
     const token0Reserve = reserves[0]
     const token1Reserve = reserves[1]
     const swapFee = await pair.swapFee()
     const kReserve = token0Reserve.mul(token1Reserve)
-    
+
     const token0Out = token0Reserve.sub(
       kReserve.div(token1Reserve.add(token1In.mul(SWAP_DEN.sub(swapFee)).div(SWAP_DEN)))
     ).sub(bigNumberify(1))
@@ -101,18 +101,18 @@ describe('DynamicFees', () => {
 
     return [token0Out < 0 ? bigNumberify(0) : token0Out, token1Out < 0 ? bigNumberify(0) : token1Out];
   }
-  
+
   // Execute a transfer and swap, since the tokens has to be transfered before traded
-  async function execTransferAndSwap(_token0In : BigNumber, _token1In: BigNumber) {
+  async function execTransferAndSwap(_token0In: BigNumber, _token1In: BigNumber) {
     const reserveBefore = await pair.getReserves()
-  
+
     if (_token0In.gt(0))
       await token0.transfer(pair.address, _token0In)
     if (_token1In.gt(0))
       await token1.transfer(pair.address, _token1In)
     const outputs = await calcOutput(_token0In, _token1In);
     await pair.swap(outputs[0], outputs[1], wallet.address, '0x', overrides)
-    
+
     // Check value swaped between wallet and pair
     expect(await token0.balanceOf(pair.address)).to.eq(reserveBefore[0].add(_token0In).sub(outputs[0]))
     expect(await token1.balanceOf(pair.address)).to.eq(reserveBefore[1].add(_token1In).sub(outputs[1]))
@@ -122,32 +122,32 @@ describe('DynamicFees', () => {
       .to.eq(totalSupplyToken0.sub(reserveBefore[0]).sub(_token0In).add(outputs[0]))
     expect(await token1.balanceOf(wallet.address))
       .to.eq(totalSupplyToken1.sub(reserveBefore[1]).sub(_token1In).add(outputs[1]))
-    
+
     return outputs;
   }
-  
+
   it('feeTo:on, swapFee:default, protocolFeeDenominator:default', async () => {
     await feeSetter.setFeeTo(other.address)
     expect(await factory.protocolFeeDenominator()).to.eq(9)
 
     await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
-    
+
     await execTransferAndSwap(expandTo18Decimals(1), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(1));
-        
+
     const toMintForProtocol = await calcProtocolFee();
 
     await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
-    expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))    
+    expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))
   })
-  
+
   it('feeTo:on, swapFee:default, protocolFeeDenominator:0.025%', async () => {
     await feeSetter.setFeeTo(other.address)
     await feeSetter.setProtocolFee(11)
     expect(await factory.protocolFeeDenominator()).to.eq(11)
-  
+
     await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
-  
+
     await execTransferAndSwap(expandTo18Decimals(1), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(1));
     await execTransferAndSwap(expandTo18Decimals(2), bigNumberify(0));
@@ -156,14 +156,14 @@ describe('DynamicFees', () => {
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(4));
     await execTransferAndSwap(expandTo18Decimals(6), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(6));
-    
+
     const toMintForProtocol = await calcProtocolFee();
 
     await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
     expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))
-      
+
   })
-  
+
   it('feeTo:on, swapFee:0.2%, protocolFeeDenominator:0.1%', async () => {
     await feeSetter.setFeeTo(other.address)
     await feeSetter.setProtocolFee(1)
@@ -172,41 +172,41 @@ describe('DynamicFees', () => {
     expect(await pair.swapFee()).to.eq(20)
 
     await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
-  
+
     await execTransferAndSwap(expandTo18Decimals(1), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(1));
     await execTransferAndSwap(expandTo18Decimals(2), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(2));
-    
+
     const toMintForProtocol = await calcProtocolFee();
 
     await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
     expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))
   })
-  
+
   it('feeTo:on, swapFee:0.2%, protocolFeeDenominator:disabled', async () => {
     await feeSetter.setSwapFee(pair.address, 20)
     expect(await factory.protocolFeeDenominator()).to.eq(9)
     expect(await pair.swapFee()).to.eq(20)
 
     await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
-      
+
     await execTransferAndSwap(expandTo18Decimals(1), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(1));
     await execTransferAndSwap(expandTo18Decimals(2), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(2));
-    
+
     const toMintForProtocol = await calcProtocolFee();
 
     await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
     expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(0)
   })
-  
+
   it('MULTIPLE_TRADES:feeTo:on, swapFee:default, protocolFeeDenominator:default', async () => {
     await feeSetter.setFeeTo(other.address)
-  
+
     await addLiquidity(expandTo18Decimals(800), expandTo18Decimals(10))
-    
+
     await execTransferAndSwap(expandTo18Decimals(100), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(50));
     await execTransferAndSwap(expandTo18Decimals(20), bigNumberify(0));
@@ -215,22 +215,22 @@ describe('DynamicFees', () => {
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(66));
     await execTransferAndSwap(expandTo18Decimals(1), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(5));
-    
+
     const toMintForProtocol = await calcProtocolFee();
 
     await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
-    expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))  
+    expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))
   })
-  
+
   it('MULTIPLE_TRADES:feeTo:on, swapFee:0.01, protocolFeeDenominator:0.0005', async () => {
     await feeSetter.setFeeTo(other.address)
     await feeSetter.setSwapFee(pair.address, 1)
     await feeSetter.setProtocolFee(19)
     expect(await factory.protocolFeeDenominator()).to.eq(19)
     expect(await pair.swapFee()).to.eq(1)
-  
+
     await addLiquidity(expandTo18Decimals(800), expandTo18Decimals(10))
-    
+
     await execTransferAndSwap(expandTo18Decimals(100), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(50));
     await execTransferAndSwap(expandTo18Decimals(20), bigNumberify(0));
@@ -239,20 +239,20 @@ describe('DynamicFees', () => {
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(66));
     await execTransferAndSwap(expandTo18Decimals(1), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(5));
-    
+
     const toMintForProtocol = await calcProtocolFee();
 
     await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
-    expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))  
+    expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))
   })
-  
+
   it('MULTIPLE_TRADES:feeTo:on, swapFee:0, protocolFeeDenominator:default', async () => {
     await feeSetter.setFeeTo(other.address)
     await feeSetter.setSwapFee(pair.address, 0)
     expect(await pair.swapFee()).to.eq(0)
-  
+
     await addLiquidity(expandTo18Decimals(800), expandTo18Decimals(10))
-    
+
     await execTransferAndSwap(expandTo18Decimals(100), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(50));
     await execTransferAndSwap(expandTo18Decimals(20), bigNumberify(0));
@@ -261,32 +261,32 @@ describe('DynamicFees', () => {
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(66));
     await execTransferAndSwap(expandTo18Decimals(1), bigNumberify(0));
     await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(5));
-    
-    const toMintForProtocol = await calcProtocolFee();
-    
-    await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
-    expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))  
-  })
-  
-  it('MULTIPLE_TRADES:feeTo:on, swapFee:0, protocolFeeDenominator:0', async () => {
-    await feeSetter.setSwapFee(pair.address, 0)
-    expect(await pair.swapFee()).to.eq(0)
-  
-    await addLiquidity(expandTo18Decimals(800), expandTo18Decimals(10))
-    
-    await execTransferAndSwap(expandTo18Decimals(100), bigNumberify(0));
-    await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(50));
-    await execTransferAndSwap(expandTo18Decimals(20), bigNumberify(0));
-    await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(200));
-    await execTransferAndSwap(expandTo18Decimals(40), bigNumberify(0));
-    await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(66));
-    await execTransferAndSwap(expandTo18Decimals(1), bigNumberify(0));
-    await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(5));
-    
+
     const toMintForProtocol = await calcProtocolFee();
 
     await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
-    expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))  
+    expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))
   })
-  
+
+  it('MULTIPLE_TRADES:feeTo:on, swapFee:0, protocolFeeDenominator:0', async () => {
+    await feeSetter.setSwapFee(pair.address, 0)
+    expect(await pair.swapFee()).to.eq(0)
+
+    await addLiquidity(expandTo18Decimals(800), expandTo18Decimals(10))
+
+    await execTransferAndSwap(expandTo18Decimals(100), bigNumberify(0));
+    await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(50));
+    await execTransferAndSwap(expandTo18Decimals(20), bigNumberify(0));
+    await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(200));
+    await execTransferAndSwap(expandTo18Decimals(40), bigNumberify(0));
+    await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(66));
+    await execTransferAndSwap(expandTo18Decimals(1), bigNumberify(0));
+    await execTransferAndSwap(bigNumberify(0), expandTo18Decimals(5));
+
+    const toMintForProtocol = await calcProtocolFee();
+
+    await addLiquidity(expandTo18Decimals(5), expandTo18Decimals(10))
+    expect((await pair.balanceOf(other.address)).div(ROUND_EXCEPTION)).to.eq(toMintForProtocol.div(ROUND_EXCEPTION))
+  })
+
 })

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -47,6 +47,7 @@ interface PairFixture extends FactoryFixture {
   token0: Contract
   token1: Contract
   pair: Contract
+  wethToken0Pair: Contract
   wethToken1Pair: Contract
 }
 
@@ -63,9 +64,9 @@ export async function pairFixture(provider: Web3Provider, [dxdao, wallet, ethRec
     ethReceiver.address,
     dxdao.address,
     WETH.address,
-    [token0.address, token1.address],
-    [token1.address, WETH.address],
-    [15, 15],
+    [token0.address, token0.address, token1.address],
+    [token1.address, WETH.address, WETH.address],
+    [15, 15, 15],
   ], overrides
   )
 
@@ -85,10 +86,14 @@ export async function pairFixture(provider: Web3Provider, [dxdao, wallet, ethRec
     await factory.getPair(token0.address, token1.address),
     JSON.stringify(DXswapPair.abi), provider
   ).connect(dxdao)
+  const wethToken0Pair = new Contract(
+    await factory.getPair(token0.address, WETH.address),
+    JSON.stringify(DXswapPair.abi), provider
+  ).connect(dxdao)
   const wethToken1Pair = new Contract(
     await factory.getPair(token1.address, WETH.address),
     JSON.stringify(DXswapPair.abi), provider
   ).connect(dxdao)
 
-  return { factory, feeSetter, feeReceiver, WETH, token0, token1, pair, wethToken1Pair }
+  return { factory, feeSetter, feeReceiver, WETH, token0, token1, pair, wethToken0Pair, wethToken1Pair }
 }

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -1,4 +1,4 @@
-import { Contract, Wallet } from 'ethers'
+import { Contract, ethers, Wallet } from 'ethers'
 import { Web3Provider } from 'ethers/providers'
 import { defaultAbiCoder } from 'ethers/utils'
 import { deployContract } from 'ethereum-waffle'
@@ -27,9 +27,9 @@ const overrides = {
 export async function factoryFixture(provider: Web3Provider, [dxdao, ethReceiver]: Wallet[]): Promise<FactoryFixture> {
   const WETH = await deployContract(dxdao, WETH9)
   const dxSwapDeployer = await deployContract(
-    dxdao, DXswapDeployer, [ ethReceiver.address, dxdao.address, WETH.address, [], [], [], ], overrides
+    dxdao, DXswapDeployer, [ethReceiver.address, dxdao.address, WETH.address, [], [], [],], overrides
   )
-  await dxdao.sendTransaction({to: dxSwapDeployer.address, gasPrice: 0, value: 1})
+  await dxdao.sendTransaction({ to: dxSwapDeployer.address, gasPrice: 0, value: 1 })
   const deployTx = await dxSwapDeployer.deploy()
   const deployTxReceipt = await provider.getTransactionReceipt(deployTx.hash);
   const factoryAddress = deployTxReceipt.logs !== undefined
@@ -47,47 +47,48 @@ interface PairFixture extends FactoryFixture {
   token0: Contract
   token1: Contract
   pair: Contract
-  wethPair: Contract
+  wethToken1Pair: Contract
 }
 
 export async function pairFixture(provider: Web3Provider, [dxdao, wallet, ethReceiver]: Wallet[]): Promise<PairFixture> {
   const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
   const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
   const WETH = await deployContract(wallet, WETH9)
-  await WETH.deposit({value: expandTo18Decimals(1000)})
+  await WETH.deposit({ value: expandTo18Decimals(1000) })
   const token0 = tokenA.address < tokenB.address ? tokenA : tokenB
   const token1 = token0.address === tokenA.address ? tokenB : tokenA
-  
+
   const dxSwapDeployer = await deployContract(
     dxdao, DXswapDeployer, [
-      ethReceiver.address,
-      dxdao.address,
-      WETH.address,
-      [token0.address, token1.address],
-      [token1.address, WETH.address],
-      [15, 15],
-    ], overrides
+    ethReceiver.address,
+    dxdao.address,
+    WETH.address,
+    [token0.address, token1.address],
+    [token1.address, WETH.address],
+    [15, 15],
+  ], overrides
   )
-  await dxdao.sendTransaction({to: dxSwapDeployer.address, gasPrice: 0, value: 1})
+
+  await dxdao.sendTransaction({ to: dxSwapDeployer.address, gasPrice: 0, value: 1 })
   const deployTx = await dxSwapDeployer.deploy()
   const deployTxReceipt = await provider.getTransactionReceipt(deployTx.hash);
   const factoryAddress = deployTxReceipt.logs !== undefined
     ? defaultAbiCoder.decode(['address'], deployTxReceipt.logs[0].data)[0]
     : null
-  
+
   const factory = new Contract(factoryAddress, JSON.stringify(DXswapFactory.abi), provider).connect(dxdao)
   const feeSetterAddress = await factory.feeToSetter()
   const feeSetter = new Contract(feeSetterAddress, JSON.stringify(DXswapFeeSetter.abi), provider).connect(dxdao)
   const feeReceiverAddress = await factory.feeTo()
   const feeReceiver = new Contract(feeReceiverAddress, JSON.stringify(DXswapFeeReceiver.abi), provider).connect(dxdao)
   const pair = new Contract(
-     await factory.getPair(token0.address, token1.address),
-     JSON.stringify(DXswapPair.abi), provider
-   ).connect(dxdao)
-  const wethPair = new Contract(
-     await factory.getPair(token1.address, WETH.address),
-     JSON.stringify(DXswapPair.abi), provider
-   ).connect(dxdao)
+    await factory.getPair(token0.address, token1.address),
+    JSON.stringify(DXswapPair.abi), provider
+  ).connect(dxdao)
+  const wethToken1Pair = new Contract(
+    await factory.getPair(token1.address, WETH.address),
+    JSON.stringify(DXswapPair.abi), provider
+  ).connect(dxdao)
 
-  return { factory, feeSetter, feeReceiver, WETH, token0, token1, pair, wethPair }
+  return { factory, feeSetter, feeReceiver, WETH, token0, token1, pair, wethToken1Pair }
 }


### PR DESCRIPTION
# Summary
Closes #39 
The goal is to upgrade FeeReceiver contract to fix swap issue and add fee split feature.

***New features***

- change DXswapFeeReceiver contract to protect from situation where takeProtocolFee function tries to swap token in pair with too small liquidity
- allow to control fee split and recipient for each pair
- supports max one external recipient address
- no deadline to claim protocol fee
- modify another contracts accordingly
