### PR TITLE
WIP: Feature/protocol-fee

### DIFF
--- a/contracts/DXswapFactory.sol
+++ b/contracts/DXswapFactory.sol
@@ -59,4 +59,14 @@ contract DXswapFactory is IDXswapFactory {
         require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');
         IDXswapPair(_pair).setSwapFee(_swapFee);
     }
+
+    function setExternalFeeRecipient(address _pair, address _externalFeeRecipient) external {
+        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');
+        IDXswapPair(_pair).setExternalFeeRecipient(_externalFeeRecipient);
+    }
+
+    function setPercentFeeToExternalRecipient(address _pair, uint32 _percentFeeToExternalRecipient) external {
+        require(msg.sender == feeToSetter, 'DXswapFactory: FORBIDDEN');
+        IDXswapPair(_pair).setPercentFeeToExternalRecipient(_percentFeeToExternalRecipient);
+    }
 }

--- a/contracts/DXswapFeeReceiver.sol
+++ b/contracts/DXswapFeeReceiver.sol
@@ -2,11 +2,12 @@ pragma solidity =0.5.16;
 
 import './interfaces/IDXswapFactory.sol';
 import './interfaces/IDXswapPair.sol';
+import './interfaces/IDXswapFeeReceiver.sol';
 import './interfaces/IWETH.sol';
 import './libraries/TransferHelper.sol';
 import './libraries/SafeMath.sol';
 
-contract DXswapFeeReceiver {
+contract DXswapFeeReceiver is IDXswapFeeReceiver {
     using SafeMath for uint256;
 
     address public owner;
@@ -75,7 +76,7 @@ contract DXswapFeeReceiver {
                         hex'ff',
                         factory,
                         keccak256(abi.encodePacked(token0, token1)),
-                        hex'61711fee40f324739edb0f7fc7017a47d328ee0b69e93d9a4d1e2215e7d0a2d4' // INIT_CODE_PAIR_HASH
+                        hex'c7f3af50111817ebea773f8f709c40b5d6fb937cd35cee835e6a797e7694903a' // INIT_CODE_PAIR_HASH
                     )
                 )
             )
@@ -181,7 +182,7 @@ contract DXswapFeeReceiver {
         emit TakeProtocolFee(msg.sender, ethReceiver, pairs.length);
     }
 
-    // called by the owner to set maximum swap price impact allowed for single token-weth swap
+    // called by the owner to set maximum swap price impact allowed for single token-weth swap (within 0-100% range)
     function setMaxSwapPriceImpact(uint32 _maxSwapPriceImpact) external {
         require(msg.sender == owner, 'DXswapFeeReceiver: CALLER_NOT_OWNER');
         require(_maxSwapPriceImpact > 0 && _maxSwapPriceImpact < 10000, 'DXswapFeeReceiver: FORBIDDEN_PRICE_IMPACT');

--- a/contracts/DXswapFeeSetter.sol
+++ b/contracts/DXswapFeeSetter.sol
@@ -41,4 +41,14 @@ contract DXswapFeeSetter {
         require((msg.sender == owner) || ((msg.sender == pairOwners[pair])), 'DXswapFeeSetter: FORBIDDEN');
         factory.setSwapFee(pair, swapFee);
     }
+
+    function setExternalFeeRecipient(address pair, address externalFeeRecipient) external {
+        require((msg.sender == owner) || ((msg.sender == pairOwners[pair])), 'DXswapFeeSetter: FORBIDDEN');
+        factory.setExternalFeeRecipient(pair, externalFeeRecipient);
+    }
+
+    function setPercentFeeToExternalRecipient(address pair, uint32 swapFee) external {
+        require((msg.sender == owner) || ((msg.sender == pairOwners[pair])), 'DXswapFeeSetter: FORBIDDEN');
+        factory.setPercentFeeToExternalRecipient(pair, swapFee);
+    }
 }

--- a/contracts/DXswapPair.sol
+++ b/contracts/DXswapPair.sol
@@ -28,6 +28,9 @@ contract DXswapPair is IDXswapPair, DXswapERC20 {
     uint256 public kLast; // reserve0 * reserve1, as of immediately after the most recent liquidity event
     uint32 public swapFee = 25; // uses 0.25% fee as default
 
+    address public externalFeeRecipient; // if needed set address of external project which can get % of total earned protocol fee
+    uint32 public percentFeeToExternalRecipient = 0; // % of total protocol fee to external project (100 means 1%), range <0, 50>
+
     uint256 private unlocked = 1;
     modifier lock() {
         require(unlocked == 1, 'DXswapPair: LOCKED');
@@ -87,6 +90,22 @@ contract DXswapPair is IDXswapPair, DXswapERC20 {
         require(msg.sender == factory, 'DXswapPair: FORBIDDEN'); // sufficient check
         require(_swapFee <= 1000, 'DXswapPair: FORBIDDEN_FEE'); // fee percentage check
         swapFee = _swapFee;
+    }
+
+    // called by the factory to set external recipient address
+    function setExternalFeeRecipient(address _externalFeeRecipient) external {
+        require(msg.sender == factory, 'DXswapPair: FORBIDDEN'); // sufficient check
+        externalFeeRecipient = _externalFeeRecipient;
+    }
+
+    // called by the factory to set % of total protocol fee which should be sent to project address
+    function setPercentFeeToExternalRecipient(uint32 _percentFeeToExternalRecipient) external {
+        require(msg.sender == factory, 'DXswapPair: FORBIDDEN'); // sufficient check
+        require(
+            _percentFeeToExternalRecipient >= 0 && _percentFeeToExternalRecipient <= 5000,
+            'DXswapPair: FORBIDDEN_FEE_SPLIT'
+        ); // sufficient check
+        percentFeeToExternalRecipient = _percentFeeToExternalRecipient;
     }
 
     // update reserves and, on the first call per block, price accumulators

--- a/contracts/interfaces/IDXswapFactory.sol
+++ b/contracts/interfaces/IDXswapFactory.sol
@@ -23,7 +23,11 @@ interface IDXswapFactory {
 
     function setFeeToSetter(address) external;
 
-    function setProtocolFee(uint8 _protocolFee) external;
+    function setProtocolFee(uint8 protocolFee) external;
 
     function setSwapFee(address pair, uint32 swapFee) external;
+
+    function setExternalFeeRecipient(address pair, address externalFeeRecipient) external;
+
+    function setPercentFeeToExternalRecipient(address pair, uint32 percentFeeToExternalRecipient) external;
 }

--- a/contracts/interfaces/IDXswapFeeReceiver.sol
+++ b/contracts/interfaces/IDXswapFeeReceiver.sol
@@ -1,0 +1,27 @@
+pragma solidity >=0.5.0;
+
+import './IDXswapPair.sol';
+
+interface IDXswapFeeReceiver {
+    event TakeProtocolFee(address indexed sender, address indexed to, uint256 NumberOfPairs);
+
+    function owner() external view returns (address);
+
+    function factory() external view returns (address);
+
+    function WETH() external view returns (address);
+
+    function ethReceiver() external view returns (address);
+
+    function fallbackReceiver() external view returns (address);
+
+    function maxSwapPriceImpact() external view returns (uint32);
+
+    function transferOwnership(address) external;
+
+    function changeReceivers(address, address) external;
+
+    function takeProtocolFee(IDXswapPair[] calldata pairs) external;
+
+    function setMaxSwapPriceImpact(uint32) external;
+}

--- a/contracts/interfaces/IDXswapPair.sol
+++ b/contracts/interfaces/IDXswapPair.sol
@@ -79,6 +79,10 @@ interface IDXswapPair {
 
     function swapFee() external view returns (uint32);
 
+    function externalFeeRecipient() external view returns (address);
+
+    function percentFeeToExternalRecipient() external view returns (uint32);
+
     function mint(address to) external returns (uint256 liquidity);
 
     function burn(address to) external returns (uint256 amount0, uint256 amount1);
@@ -97,4 +101,8 @@ interface IDXswapPair {
     function initialize(address, address) external;
 
     function setSwapFee(uint32) external;
+
+    function setExternalFeeRecipient(address) external;
+
+    function setPercentFeeToExternalRecipient(uint32) external;
 }

--- a/test/DXswapDeployer.spec.ts
+++ b/test/DXswapDeployer.spec.ts
@@ -18,11 +18,11 @@ describe('DXswapDeployer', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 12000000
+    gasLimit: 15000000
   })
   const [dxdao, tokenOwner, protocolFeeReceiver, other] = provider.getWallets()
   const overrides = {
-    gasLimit: 12000000
+    gasLimit: 15000000
   }
 
   let dxSwapDeployer: Contract

--- a/test/DXswapERC20.spec.ts
+++ b/test/DXswapERC20.spec.ts
@@ -18,7 +18,7 @@ describe('DXswapERC20', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 9999999
+    gasLimit: 15000000
   })
   const [wallet, other] = provider.getWallets()
 

--- a/test/DXswapFactory.spec.ts
+++ b/test/DXswapFactory.spec.ts
@@ -41,7 +41,7 @@ describe('DXswapFactory', () => {
     expect(await factory.feeTo()).to.eq(AddressZero)
     expect(await factory.feeToSetter()).to.eq(wallet.address)
     expect(await factory.allPairsLength()).to.eq(0)
-    expect(await factory.INIT_CODE_PAIR_HASH()).to.eq('0x61711fee40f324739edb0f7fc7017a47d328ee0b69e93d9a4d1e2215e7d0a2d4')
+    expect(await factory.INIT_CODE_PAIR_HASH()).to.eq('0xc7f3af50111817ebea773f8f709c40b5d6fb937cd35cee835e6a797e7694903a')
   })
 
   async function createPair(tokens: [string, string]) {

--- a/test/DXswapFactory.spec.ts
+++ b/test/DXswapFactory.spec.ts
@@ -5,7 +5,7 @@ import { bigNumberify } from 'ethers/utils'
 import { solidity, MockProvider, createFixtureLoader } from 'ethereum-waffle'
 
 import { getCreate2Address } from './shared/utilities'
-import { factoryFixture } from './shared/fixtures'
+import { factoryFixture, pairFixture } from './shared/fixtures'
 
 import DXswapPair from '../build/DXswapPair.json'
 
@@ -20,7 +20,7 @@ describe('DXswapFactory', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 9999999
+    gasLimit: 15000000
   })
   const [wallet, protocolFeeReceiver, other] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [wallet, protocolFeeReceiver, other])
@@ -41,7 +41,7 @@ describe('DXswapFactory', () => {
     expect(await factory.feeTo()).to.eq(AddressZero)
     expect(await factory.feeToSetter()).to.eq(wallet.address)
     expect(await factory.allPairsLength()).to.eq(0)
-    expect(await factory.INIT_CODE_PAIR_HASH()).to.eq('0xd306a548755b9295ee49cc729e13ca4a45e00199bbd890fa146da43a50571776')
+    expect(await factory.INIT_CODE_PAIR_HASH()).to.eq('0x61711fee40f324739edb0f7fc7017a47d328ee0b69e93d9a4d1e2215e7d0a2d4')
   })
 
   async function createPair(tokens: [string, string]) {
@@ -75,7 +75,7 @@ describe('DXswapFactory', () => {
   it('createPair:gas', async () => {
     const tx = await factory.createPair(...TEST_ADDRESSES)
     const receipt = await tx.wait()
-    expect(receipt.gasUsed).to.eq(2136142)
+    expect(receipt.gasUsed).to.eq(2241653)
   })
 
   it('setFeeTo', async () => {

--- a/test/DXswapFeeReceiver.spec.ts
+++ b/test/DXswapFeeReceiver.spec.ts
@@ -25,12 +25,12 @@ describe('DXswapFeeReceiver', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 9999999
+    gasLimit: 15000000
   })
   const overrides = {
-    gasLimit: 9999999
+    gasLimit: 15000000
   }
-  const [dxdao, wallet, protocolFeeReceiver, other] = provider.getWallets()
+  const [dxdao, wallet, protocolFeeReceiver, other, externalFeeRecipient] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [dxdao, wallet, protocolFeeReceiver])
 
   async function getAmountOut(pair: Contract, tokenIn: string, amountIn: BigNumber) {
@@ -81,7 +81,8 @@ describe('DXswapFeeReceiver', () => {
   let token0: Contract
   let token1: Contract
   let pair: Contract
-  let wethPair: Contract
+  let wethToken0Pair: Contract
+  let wethToken1Pair: Contract
   let WETH: Contract
   let feeSetter: Contract
   let feeReceiver: Contract
@@ -91,7 +92,8 @@ describe('DXswapFeeReceiver', () => {
     token0 = fixture.token0
     token1 = fixture.token1
     pair = fixture.pair
-    wethPair = fixture.wethPair
+    wethToken0Pair = fixture.wethToken0Pair
+    wethToken1Pair = fixture.wethToken1Pair
     WETH = fixture.WETH
     feeSetter = fixture.feeSetter
     feeReceiver = fixture.feeReceiver
@@ -109,9 +111,9 @@ describe('DXswapFeeReceiver', () => {
       await token1.transfer(pair.address, tokenAmount)
       await pair.mint(wallet.address, overrides)
 
-      await token1.transfer(wethPair.address, tokenAmount)
-      await WETH.transfer(wethPair.address, wethAmount)
-      await wethPair.mint(wallet.address, overrides)
+      await token1.transfer(wethToken1Pair.address, tokenAmount)
+      await WETH.transfer(wethToken1Pair.address, wethAmount)
+      await wethToken1Pair.mint(wallet.address, overrides)
 
       let amountOut = await getAmountOut(pair, token0.address, amountIn);
 
@@ -137,7 +139,7 @@ describe('DXswapFeeReceiver', () => {
       const token1FromProtocolFee = protocolFeeLPToknesReceived
         .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
 
-      const wethFromToken1FromProtocolFee = await getAmountOut(wethPair, token1.address, token1FromProtocolFee);
+      const wethFromToken1FromProtocolFee = await getAmountOut(wethToken1Pair, token1.address, token1FromProtocolFee);
 
       const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
 
@@ -149,10 +151,10 @@ describe('DXswapFeeReceiver', () => {
       expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
       expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
 
-      expect((await provider.getBalance(protocolFeeReceiver.address)))
-        .to.be.eq(protocolFeeReceiverBalanceBeforeTake.add(wethFromToken1FromProtocolFee))
       expect((await token0.balanceOf(dxdao.address)))
         .to.be.eq(token0FromProtocolFee)
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalanceBeforeTake.add(wethFromToken1FromProtocolFee))
     })
 
   it('should receive everything in ETH from one WETH-token1 pair', async () => {
@@ -161,61 +163,62 @@ describe('DXswapFeeReceiver', () => {
     const wethAmount = expandTo18Decimals(100);
     const amountIn = expandTo18Decimals(50);
 
-    await token1.transfer(wethPair.address, tokenAmount)
-    await WETH.transfer(wethPair.address, wethAmount)
-    await wethPair.mint(wallet.address, overrides)
+    await token1.transfer(wethToken1Pair.address, tokenAmount)
+    await WETH.transfer(wethToken1Pair.address, wethAmount)
+    await wethToken1Pair.mint(wallet.address, overrides)
 
     const token1IsFirstToken = (token1.address < WETH.address)
 
-    let amountOut = await getAmountOut(wethPair, token1.address, amountIn);
-    await token1.transfer(wethPair.address, amountIn)
-    await wethPair.swap(
+    let amountOut = await getAmountOut(wethToken1Pair, token1.address, amountIn);
+    await token1.transfer(wethToken1Pair.address, amountIn)
+    await wethToken1Pair.swap(
       token1IsFirstToken ? 0 : amountOut,
       token1IsFirstToken ? amountOut : 0,
       wallet.address, '0x', overrides
     )
 
-    amountOut = await getAmountOut(wethPair, WETH.address, amountIn);
-    await WETH.transfer(wethPair.address, amountIn)
-    await wethPair.swap(
+    amountOut = await getAmountOut(wethToken1Pair, WETH.address, amountIn);
+    await WETH.transfer(wethToken1Pair.address, amountIn)
+    await wethToken1Pair.swap(
       token1IsFirstToken ? amountOut : 0,
       token1IsFirstToken ? 0 : amountOut,
       wallet.address, '0x', overrides
     )
 
-    const protocolFeeToReceive = await calcProtocolFee(wethPair);
+    const protocolFeeToReceive = await calcProtocolFee(wethToken1Pair);
 
-    await token1.transfer(wethPair.address, expandTo18Decimals(10))
-    await WETH.transfer(wethPair.address, expandTo18Decimals(10))
-    await wethPair.mint(wallet.address, overrides)
+    await token1.transfer(wethToken1Pair.address, expandTo18Decimals(10))
+    await WETH.transfer(wethToken1Pair.address, expandTo18Decimals(10))
+    await wethToken1Pair.mint(wallet.address, overrides)
 
-    const protocolFeeLPToknesReceived = await wethPair.balanceOf(feeReceiver.address);
+    const protocolFeeLPToknesReceived = await wethToken1Pair.balanceOf(feeReceiver.address);
     expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
       .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
 
     const token1FromProtocolFee = protocolFeeLPToknesReceived
-      .mul(await token1.balanceOf(wethPair.address)).div(await wethPair.totalSupply());
+      .mul(await token1.balanceOf(wethToken1Pair.address)).div(await wethToken1Pair.totalSupply());
     const wethFromProtocolFee = protocolFeeLPToknesReceived
-      .mul(await WETH.balanceOf(wethPair.address)).div(await wethPair.totalSupply());
+      .mul(await WETH.balanceOf(wethToken1Pair.address)).div(await wethToken1Pair.totalSupply());
 
-    const token1ReserveBeforeSwap = (await token1.balanceOf(wethPair.address)).sub(token1FromProtocolFee)
-    const wethReserveBeforeSwap = (await WETH.balanceOf(wethPair.address)).sub(wethFromProtocolFee)
+    const token1ReserveBeforeSwap = (await token1.balanceOf(wethToken1Pair.address)).sub(token1FromProtocolFee)
+    const wethReserveBeforeSwap = (await WETH.balanceOf(wethToken1Pair.address)).sub(wethFromProtocolFee)
     const wethFromToken1FromProtocolFee = await getAmountOutSync(
       token1IsFirstToken ? token1ReserveBeforeSwap : wethReserveBeforeSwap,
       token1IsFirstToken ? wethReserveBeforeSwap : token1ReserveBeforeSwap,
       token1IsFirstToken,
       token1FromProtocolFee,
-      await wethPair.swapFee()
+      await wethToken1Pair.swapFee()
     );
 
     const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
 
-    await feeReceiver.connect(wallet).takeProtocolFee([wethPair.address], overrides)
+    await feeReceiver.connect(wallet).takeProtocolFee([wethToken1Pair.address], overrides)
 
     expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
     expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
-    expect(await wethPair.balanceOf(feeReceiver.address)).to.eq(0)
+    expect(await wethToken1Pair.balanceOf(feeReceiver.address)).to.eq(0)
     expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
     expect(await token1.balanceOf(dxdao.address)).to.be.eq(0)
     expect((await provider.getBalance(protocolFeeReceiver.address)))
       .to.be.eq(protocolFeeReceiverBalanceBeforeTake.add(wethFromToken1FromProtocolFee).add(wethFromProtocolFee))
@@ -436,15 +439,19 @@ describe('DXswapFeeReceiver', () => {
     })
 
   it(
-    'should revert with insufficient liquidity error if there is not any liquidity in the WETH pair',
+    'should send token to fee receiver if there is not any liquidity in the WETH pair',
     async () => {
       const tokenAmount = expandTo18Decimals(100);
-      const wethAmount = expandTo18Decimals(100);
       const amountIn = expandTo18Decimals(50);
 
       await token0.transfer(pair.address, tokenAmount)
       await token1.transfer(pair.address, tokenAmount)
       await pair.mint(wallet.address, overrides)
+
+      const amountOutToken0WETH = await getAmountOut(wethToken1Pair, token0.address, expandTo18Decimals(1));
+      const amountOutToken1WETH = await getAmountOut(wethToken1Pair, token1.address, expandTo18Decimals(1));
+      expect(amountOutToken0WETH).to.be.eq(0)
+      expect(amountOutToken1WETH).to.be.eq(0)
 
       let amountOut = await getAmountOut(pair, token0.address, amountIn);
       await token0.transfer(pair.address, amountIn)
@@ -466,19 +473,909 @@ describe('DXswapFeeReceiver', () => {
 
       const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
 
-      await expect(feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)).to.be.revertedWith('DXswapFeeReceiver: INSUFFICIENT_LIQUIDITY')
+      await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
 
-      expect(await pair.balanceOf(feeReceiver.address)).to.eq(protocolFeeLPToknesReceived)
+      const token0FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply());
+      const token1FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
+
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
       expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
       expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
       expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
       expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(protocolFeeReceiver.address)).to.eq(protocolFeeReceiverBalance)
+
+      expect((await token0.balanceOf(dxdao.address)))
+        .to.be.eq(token0FromProtocolFee)
+      expect((await token1.balanceOf(dxdao.address)))
+        .to.be.eq(token1FromProtocolFee)
+    })
+
+  // Where token0-token1 and token1-WETH pairs exist AND PRICE IMPACT TOO HIGH 
+  it(
+    'should receive token0 and token1 if price impact token1-weth pool is too high',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(1);
+      // add very small liquidity to weth-token1 pool
+      const wethTknAmountLowLP = bigNumberify(1).mul(bigNumberify(10).pow(15));
+
+      await token0.transfer(pair.address, tokenAmount)
+      await token1.transfer(pair.address, tokenAmount)
+      await pair.mint(wallet.address, overrides)
+
+      await token1.transfer(wethToken1Pair.address, wethTknAmountLowLP)
+      await WETH.transfer(wethToken1Pair.address, wethTknAmountLowLP)
+      await wethToken1Pair.mint(wallet.address, overrides)
+
+      let amountOut = await getAmountOut(pair, token0.address, amountIn);
+
+      await token0.transfer(pair.address, amountIn)
+      await pair.swap(0, amountOut, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+
+      const protocolFeeToReceive = await calcProtocolFee(pair);
+
+      await token0.transfer(pair.address, expandTo18Decimals(15))
+      await token1.transfer(pair.address, expandTo18Decimals(15))
+      await pair.mint(wallet.address, overrides)
+
+      const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const token0FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply());
+      const token1FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
+
+      const wethFromToken1FromProtocolFee = await getAmountOut(wethToken1Pair, token1.address, token1FromProtocolFee);
+
+      const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
+
+      expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalanceBeforeTake)
+      expect((await token0.balanceOf(dxdao.address)))
+        .to.be.eq(token0FromProtocolFee)
+      expect((await token1.balanceOf(dxdao.address)))
+        .to.be.eq(token1FromProtocolFee)
+    })
+
+  it(
+    'should only allow owner to set max price impact',
+    async () => {
+      await expect(feeReceiver.connect(other).setMaxSwapPriceImpact(500))
+        .to.be.revertedWith('DXswapFeeReceiver: CALLER_NOT_OWNER')
+      await feeReceiver.connect(dxdao).setMaxSwapPriceImpact(500);
+      expect(await feeReceiver.maxSwapPriceImpact()).to.be.eq(500)
+    })
+
+  it(
+    'should set max price impact within the range 0 - 10000',
+    async () => {
+      expect(await feeReceiver.maxSwapPriceImpact()).to.be.eq(100)
+      await expect(feeReceiver.connect(dxdao).setMaxSwapPriceImpact(0))
+        .to.be.revertedWith('DXswapFeeReceiver: FORBIDDEN_PRICE_IMPACT')
+      await expect(feeReceiver.connect(dxdao).setMaxSwapPriceImpact(10000))
+        .to.be.revertedWith('DXswapFeeReceiver: FORBIDDEN_PRICE_IMPACT')
+      await feeReceiver.connect(dxdao).setMaxSwapPriceImpact(500);
+      expect(await feeReceiver.maxSwapPriceImpact()).to.be.eq(500)
+    })
+
+  it(
+    'should send tokenA & tokenB default 100% fee to dxdao and 0% fee to external receiver',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(50);
+
+      // Set up tokenA-tokenB
+      const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+      const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+
+      await factory.createPair(tokenA.address, tokenB.address)
+      const tokenATokenBPair = new Contract(
+        await factory.getPair(
+          (tokenA.address < tokenB.address) ? tokenA.address : tokenB.address,
+          (tokenA.address < tokenB.address) ? tokenB.address : tokenA.address
+        ), JSON.stringify(DXswapPair.abi), provider
+      ).connect(wallet)
+
+      await feeSetter.setExternalFeeRecipient(tokenATokenBPair.address, externalFeeRecipient.address)
+
+      await tokenA.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenB.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenATokenBPair.mint(wallet.address, overrides)
+
+      let amountOut = await getAmountOut(tokenATokenBPair, tokenA.address, amountIn)
+      await tokenA.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        wallet.address, '0x', overrides
+      )
+
+      amountOut = await getAmountOut(tokenATokenBPair, tokenB.address, amountIn)
+      await tokenB.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        wallet.address, '0x', overrides
+      )
+
+      let protocolFeeToReceive = await calcProtocolFee(tokenATokenBPair);
+
+      await tokenA.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenB.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenATokenBPair.mint(wallet.address, overrides)
+
+      const protocolFeeLPTokenAtokenBPair = await tokenATokenBPair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPTokenAtokenBPair.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const tokenAFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenA.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+      const tokenBFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenB.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+
+      const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([tokenATokenBPair.address], overrides)
+
+      const percentFeeToExternalRecipient = await tokenATokenBPair.percentFeeToExternalRecipient()
+      const feeToEthReceiver = (bigNumberify(10000).sub(percentFeeToExternalRecipient))
+
+      expect(await provider.getBalance(protocolFeeReceiver.address)).to.eq(protocolFeeReceiverBalance.toString())
+
+      expect(await tokenA.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenB.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
 
       expect((await provider.getBalance(protocolFeeReceiver.address)))
         .to.be.eq(protocolFeeReceiverBalance)
-      expect((await token0.balanceOf(dxdao.address)))
+
+      expect((await tokenA.balanceOf(dxdao.address)))
+        .to.be.eq(tokenAFromProtocolFee)
+      expect((await tokenA.balanceOf(externalFeeRecipient.address)))
         .to.be.eq(0)
-      expect((await token1.balanceOf(dxdao.address)))
+
+      expect((await tokenB.balanceOf(dxdao.address)))
+        .to.be.eq(tokenBFromProtocolFee)
+      expect((await tokenB.balanceOf(externalFeeRecipient.address)))
         .to.be.eq(0)
     })
+
+  it(
+    'should split protocol fee and send tokenA & tokenB to dxdao and external fee receiver',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(50);
+      const newPercentFeeToExternalRecipient = 2000 //20%
+
+      // Set up tokenA-tokenB
+      const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+      const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+
+      await factory.createPair(tokenA.address, tokenB.address)
+      const tokenATokenBPair = new Contract(
+        await factory.getPair(
+          (tokenA.address < tokenB.address) ? tokenA.address : tokenB.address,
+          (tokenA.address < tokenB.address) ? tokenB.address : tokenA.address
+        ), JSON.stringify(DXswapPair.abi), provider
+      ).connect(wallet)
+
+      // set external fee receiver
+      await feeSetter.setExternalFeeRecipient(tokenATokenBPair.address, externalFeeRecipient.address)
+      await feeSetter.setPercentFeeToExternalRecipient(tokenATokenBPair.address, newPercentFeeToExternalRecipient)
+      const percentFeeToExternalRecipient = await tokenATokenBPair.percentFeeToExternalRecipient()
+      expect(percentFeeToExternalRecipient).to.eq(newPercentFeeToExternalRecipient)
+
+      await tokenA.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenB.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenATokenBPair.mint(wallet.address, overrides)
+
+      let amountOut = await getAmountOut(tokenATokenBPair, tokenA.address, amountIn)
+      await tokenA.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        wallet.address, '0x', overrides
+      )
+
+      let protocolFeeToReceive = await calcProtocolFee(tokenATokenBPair);
+
+      await tokenA.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenB.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenATokenBPair.mint(wallet.address, overrides)
+
+      const protocolFeeLPTokenAtokenBPair = await tokenATokenBPair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPTokenAtokenBPair.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const tokenAFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenA.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+      const tokenBFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenB.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+
+      const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([tokenATokenBPair.address], overrides)
+
+      const feeToEthReceiver = (bigNumberify(10000).sub(percentFeeToExternalRecipient))
+
+      expect(await provider.getBalance(protocolFeeReceiver.address)).to.eq(protocolFeeReceiverBalance)
+
+      expect(await tokenA.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenB.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalance)
+
+      expect((await tokenA.balanceOf(dxdao.address)).div(ROUND_EXCEPTION))
+        .to.be.eq(tokenAFromProtocolFee.mul(feeToEthReceiver).div(10000).div(ROUND_EXCEPTION))
+      expect((await tokenA.balanceOf(externalFeeRecipient.address)).div(ROUND_EXCEPTION))
+        .to.be.eq(tokenAFromProtocolFee.mul(percentFeeToExternalRecipient).div(10000).div(ROUND_EXCEPTION))
+
+      expect((await tokenB.balanceOf(dxdao.address)).div(ROUND_EXCEPTION))
+        .to.be.eq(tokenBFromProtocolFee.mul(feeToEthReceiver).div(10000).div(ROUND_EXCEPTION))
+      expect((await tokenB.balanceOf(externalFeeRecipient.address)).div(ROUND_EXCEPTION))
+        .to.be.eq(tokenBFromProtocolFee.mul(percentFeeToExternalRecipient).div(10000).div(ROUND_EXCEPTION))
+    })
+
+  // Where token0-token1, token0-WETH and token1-WETH pairs exist
+  it(
+    'should swap token0 & token 1 to ETH and sent to ethReceiver when extracting fee from token0-token1',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const wethAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(10);
+
+      await token0.transfer(pair.address, tokenAmount)
+      await token1.transfer(pair.address, tokenAmount)
+      await pair.mint(wallet.address, overrides)
+
+      await token0.transfer(wethToken0Pair.address, tokenAmount)
+      await WETH.transfer(wethToken0Pair.address, wethAmount)
+      await wethToken0Pair.mint(wallet.address, overrides)
+
+      await token1.transfer(wethToken1Pair.address, tokenAmount)
+      await WETH.transfer(wethToken1Pair.address, wethAmount)
+      await wethToken1Pair.mint(wallet.address, overrides)
+
+      let amountOut = await getAmountOut(pair, token0.address, amountIn);
+
+      await token0.transfer(pair.address, amountIn)
+      await pair.swap(0, amountOut, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+      const protocolFeeToReceive = await calcProtocolFee(pair);
+
+      await token0.transfer(pair.address, expandTo18Decimals(10))
+      await token1.transfer(pair.address, expandTo18Decimals(10))
+      await pair.mint(wallet.address, overrides)
+
+      const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const token0FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply());
+      const token1FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
+
+      const wethFromToken0FromProtocolFee = await getAmountOut(wethToken0Pair, token0.address, token0FromProtocolFee);
+      const wethFromToken1FromProtocolFee = await getAmountOut(wethToken1Pair, token1.address, token1FromProtocolFee);
+
+      const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
+
+      expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await token0.balanceOf(dxdao.address)))
+        .to.eq(0)
+      expect((await token1.balanceOf(dxdao.address)))
+        .to.eq(0)
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalanceBeforeTake.add(wethFromToken0FromProtocolFee).add(wethFromToken1FromProtocolFee))
+    })
+
+  // Where token0-token1, token0-WETH and token1-WETH pairs exist
+  it(
+    'should receive token0 and ETH when extracting fee from token0-token1 and swap LPs exist but not enough liquidity',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const wethAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(10);
+      // add very small liquidity to weth-token0 pool
+      const wethTknAmountLowLP = bigNumberify(1).mul(bigNumberify(10).pow(6));
+
+      await token0.transfer(pair.address, tokenAmount)
+      await token1.transfer(pair.address, tokenAmount)
+      await pair.mint(wallet.address, overrides)
+
+      await token0.transfer(wethToken0Pair.address, wethTknAmountLowLP)
+      await WETH.transfer(wethToken0Pair.address, wethTknAmountLowLP)
+      await wethToken0Pair.mint(wallet.address, overrides)
+
+      await token1.transfer(wethToken1Pair.address, tokenAmount)
+      await WETH.transfer(wethToken1Pair.address, wethAmount)
+      await wethToken1Pair.mint(wallet.address, overrides)
+
+      let amountOut = await getAmountOut(pair, token0.address, amountIn);
+
+      await token0.transfer(pair.address, amountIn)
+      await pair.swap(0, amountOut, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+      const protocolFeeToReceive = await calcProtocolFee(pair);
+
+      await token0.transfer(pair.address, expandTo18Decimals(10))
+      await token1.transfer(pair.address, expandTo18Decimals(10))
+      await pair.mint(wallet.address, overrides)
+
+      const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const token0FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply());
+      const token1FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
+
+      const wethFromToken0FromProtocolFee = await getAmountOut(wethToken0Pair, token0.address, token0FromProtocolFee);
+      const wethFromToken1FromProtocolFee = await getAmountOut(wethToken1Pair, token1.address, token1FromProtocolFee);
+
+      const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
+
+      expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await token0.balanceOf(dxdao.address)))
+        .to.eq(token0FromProtocolFee)
+      expect((await token1.balanceOf(dxdao.address)))
+        .to.eq(0)
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalanceBeforeTake.add(wethFromToken1FromProtocolFee))
+    })
+
+  // Where token0-token1, token0-WETH and token1-WETH pairs exist
+  it(
+    'should receive token0 and ETH when extracting fee from token0-token1 and swap LPs exist but token reserve is 0',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const wethAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(10);
+      // add very small liquidity to weth-token0 pool
+      const wethTknAmountLowLP = bigNumberify(1).mul(bigNumberify(10).pow(6));
+
+      await token0.transfer(pair.address, tokenAmount)
+      await token1.transfer(pair.address, tokenAmount)
+      await pair.mint(wallet.address, overrides)
+
+      // dont transfer token0 to the pool and dont mint lp tokens
+      await WETH.transfer(wethToken0Pair.address, wethTknAmountLowLP)
+
+      await token1.transfer(wethToken1Pair.address, tokenAmount)
+      await WETH.transfer(wethToken1Pair.address, wethAmount)
+      await wethToken1Pair.mint(wallet.address, overrides)
+
+      let amountOut = await getAmountOut(pair, token0.address, amountIn);
+
+      await token0.transfer(pair.address, amountIn)
+      await pair.swap(0, amountOut, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+      const protocolFeeToReceive = await calcProtocolFee(pair);
+
+      await token0.transfer(pair.address, expandTo18Decimals(10))
+      await token1.transfer(pair.address, expandTo18Decimals(10))
+      await pair.mint(wallet.address, overrides)
+
+      const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const token0FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply());
+      const token1FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
+
+      const wethFromToken0FromProtocolFee = await getAmountOut(wethToken0Pair, token0.address, token0FromProtocolFee);
+      const wethFromToken1FromProtocolFee = await getAmountOut(wethToken1Pair, token1.address, token1FromProtocolFee);
+
+      const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
+
+      expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await token0.balanceOf(dxdao.address)))
+        .to.eq(token0FromProtocolFee)
+      expect((await token1.balanceOf(dxdao.address)))
+        .to.eq(0)
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalanceBeforeTake.add(wethFromToken1FromProtocolFee))
+    })
+
+  // Where token0-token1, token0-WETH and token1-WETH pairs exist
+  it(
+    'should swap tkn0 & tkn1 to ETH and split protocol fee when extracting from token0-token1',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const wethAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(10);
+      const newPercentFeeToExternalRecipient = 2000 //20%
+
+      await token0.transfer(pair.address, tokenAmount)
+      await token1.transfer(pair.address, tokenAmount)
+      await pair.mint(wallet.address, overrides)
+
+      await token0.transfer(wethToken0Pair.address, tokenAmount)
+      await WETH.transfer(wethToken0Pair.address, wethAmount)
+      await wethToken0Pair.mint(wallet.address, overrides)
+
+      await token1.transfer(wethToken1Pair.address, tokenAmount)
+      await WETH.transfer(wethToken1Pair.address, wethAmount)
+      await wethToken1Pair.mint(wallet.address, overrides)
+
+      // set external fee receiver
+      await feeSetter.setExternalFeeRecipient(pair.address, externalFeeRecipient.address)
+      await feeSetter.setPercentFeeToExternalRecipient(pair.address, newPercentFeeToExternalRecipient)
+      const percentFeeToExternalRecipient = await pair.percentFeeToExternalRecipient()
+      expect(percentFeeToExternalRecipient).to.eq(newPercentFeeToExternalRecipient)
+
+      let amountOut = await getAmountOut(pair, token0.address, amountIn);
+
+      await token0.transfer(pair.address, amountIn)
+      await pair.swap(0, amountOut, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+      const protocolFeeToReceive = await calcProtocolFee(pair);
+
+      await token0.transfer(pair.address, expandTo18Decimals(10))
+      await token1.transfer(pair.address, expandTo18Decimals(10))
+      await pair.mint(wallet.address, overrides)
+
+      const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const token0FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply());
+      const token1FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
+
+      const wethFromToken0FromProtocolFee = await getAmountOut(wethToken0Pair, token0.address, token0FromProtocolFee);
+      const wethFromToken1FromProtocolFee = await getAmountOut(wethToken1Pair, token1.address, token1FromProtocolFee);
+
+      const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
+      const externalFeeRecipientBalanceBeforeTake = await provider.getBalance(externalFeeRecipient.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
+
+      expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await token0.balanceOf(dxdao.address)))
+        .to.eq(0)
+      expect((await token1.balanceOf(dxdao.address)))
+        .to.eq(0)
+      expect((await token0.balanceOf(externalFeeRecipient.address)))
+        .to.eq(0)
+      expect((await token1.balanceOf(externalFeeRecipient.address)))
+        .to.eq(0)
+
+      const totalWethFromFees = wethFromToken0FromProtocolFee.add(wethFromToken1FromProtocolFee)
+      const wethToExternalRecipient = totalWethFromFees.mul(percentFeeToExternalRecipient).div(10000)
+      const wethToProtocolFeeReceiver = totalWethFromFees.sub(wethToExternalRecipient)
+
+      expect((await provider.getBalance(protocolFeeReceiver.address)).div(ROUND_EXCEPTION))
+        .to.be.eq((protocolFeeReceiverBalanceBeforeTake.add(wethToProtocolFeeReceiver)).div(ROUND_EXCEPTION))
+      expect((await provider.getBalance(externalFeeRecipient.address)).div(ROUND_EXCEPTION))
+        .to.be.eq((externalFeeRecipientBalanceBeforeTake.add(wethToExternalRecipient)).div(ROUND_EXCEPTION))
+    })
+
+  // Where token0-token1, token0-WETH and token1-WETH pairs exist
+  it(
+    'should send tkn0 & tkn1 and split protocol fee when extracting from token0-token1 and swap to weth impossible',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const wethAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(10);
+      const newPercentFeeToExternalRecipient = 2000 //20%
+
+      await token0.transfer(pair.address, tokenAmount)
+      await token1.transfer(pair.address, tokenAmount)
+      await pair.mint(wallet.address, overrides)
+
+      // set external fee receiver
+      await feeSetter.setExternalFeeRecipient(pair.address, externalFeeRecipient.address)
+      await feeSetter.setPercentFeeToExternalRecipient(pair.address, newPercentFeeToExternalRecipient)
+      const percentFeeToExternalRecipient = await pair.percentFeeToExternalRecipient()
+      expect(percentFeeToExternalRecipient).to.eq(newPercentFeeToExternalRecipient)
+
+      let amountOut = await getAmountOut(pair, token0.address, amountIn);
+
+      await token0.transfer(pair.address, amountIn)
+      await pair.swap(0, amountOut, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+      const protocolFeeToReceive = await calcProtocolFee(pair);
+
+      await token0.transfer(pair.address, expandTo18Decimals(10))
+      await token1.transfer(pair.address, expandTo18Decimals(10))
+      await pair.mint(wallet.address, overrides)
+
+      const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const token0FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply());
+      const token1FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
+
+      const dxdaoBalanceBeforeTake = await provider.getBalance(dxdao.address)
+      const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
+      const externalFeeRecipientBalanceBeforeTake = await provider.getBalance(externalFeeRecipient.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
+
+      const tkn0ToExternalRecipient = token0FromProtocolFee.mul(percentFeeToExternalRecipient).div(10000)
+      const tkn1ToExternalRecipient = token1FromProtocolFee.mul(percentFeeToExternalRecipient).div(10000)
+      const tkn0ToProtocolFeeReceiver = token0FromProtocolFee.sub(tkn0ToExternalRecipient)
+      const tkn1ToProtocolFeeReceiver = token1FromProtocolFee.sub(tkn1ToExternalRecipient)
+
+      expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      // send token0 and token1 to fallbackreceiver and external fee receiver
+      expect((await token0.balanceOf(dxdao.address)))
+        .to.eq(tkn0ToProtocolFeeReceiver)
+      expect((await token1.balanceOf(dxdao.address)))
+        .to.eq(tkn1ToProtocolFeeReceiver)
+      expect((await token0.balanceOf(externalFeeRecipient.address)))
+        .to.eq(tkn0ToExternalRecipient)
+      expect((await token1.balanceOf(externalFeeRecipient.address)))
+        .to.eq(tkn1ToExternalRecipient)
+
+      // should not change eth balance
+      expect((await provider.getBalance(dxdao.address)))
+        .to.eq(dxdaoBalanceBeforeTake)
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.eq(protocolFeeReceiverBalanceBeforeTake)
+      expect((await provider.getBalance(externalFeeRecipient.address)))
+        .to.eq(externalFeeRecipientBalanceBeforeTake)
+    })
+
+  // Where token0-token1, token0-WETH and token1-WETH pairs exist
+  it(
+    'should change protocol fee, send tkn0 & tkn1 and split protocol fee when extracting from token0-token1 and swap to weth impossible',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const wethAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(10);
+      const newPercentFeeToExternalRecipient = 2000 //20%
+
+      await token0.transfer(pair.address, tokenAmount)
+      await token1.transfer(pair.address, tokenAmount)
+      await pair.mint(wallet.address, overrides)
+
+      // set external fee receiver
+      await feeSetter.setExternalFeeRecipient(pair.address, externalFeeRecipient.address)
+      await feeSetter.setPercentFeeToExternalRecipient(pair.address, newPercentFeeToExternalRecipient)
+      const percentFeeToExternalRecipient = await pair.percentFeeToExternalRecipient()
+      expect(percentFeeToExternalRecipient).to.eq(newPercentFeeToExternalRecipient)
+
+      let amountOut = await getAmountOut(pair, token0.address, amountIn);
+
+      await token0.transfer(pair.address, amountIn)
+      await pair.swap(0, amountOut, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+      // change protocol fee
+      await feeSetter.connect(dxdao).setProtocolFee(20)
+      expect(await factory.protocolFeeDenominator()).to.eq(20)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(pair, token1.address, amountIn);
+      await token1.transfer(pair.address, amountIn)
+      await pair.swap(amountOut, 0, wallet.address, '0x', overrides)
+
+
+      const protocolFeeToReceive = await calcProtocolFee(pair);
+
+      await token0.transfer(pair.address, expandTo18Decimals(10))
+      await token1.transfer(pair.address, expandTo18Decimals(10))
+      await pair.mint(wallet.address, overrides)
+
+      const protocolFeeLPToknesReceived = await pair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPToknesReceived.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const token0FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token0.balanceOf(pair.address)).div(await pair.totalSupply());
+      const token1FromProtocolFee = protocolFeeLPToknesReceived
+        .mul(await token1.balanceOf(pair.address)).div(await pair.totalSupply());
+
+      const dxdaoBalanceBeforeTake = await provider.getBalance(dxdao.address)
+      const protocolFeeReceiverBalanceBeforeTake = await provider.getBalance(protocolFeeReceiver.address)
+      const externalFeeRecipientBalanceBeforeTake = await provider.getBalance(externalFeeRecipient.address)
+
+      await feeReceiver.connect(wallet).takeProtocolFee([pair.address], overrides)
+
+      const tkn0ToExternalRecipient = token0FromProtocolFee.mul(percentFeeToExternalRecipient).div(10000)
+      const tkn1ToExternalRecipient = token1FromProtocolFee.mul(percentFeeToExternalRecipient).div(10000)
+      const tkn0ToProtocolFeeReceiver = token0FromProtocolFee.sub(tkn0ToExternalRecipient)
+      const tkn1ToProtocolFeeReceiver = token1FromProtocolFee.sub(tkn1ToExternalRecipient)
+
+      expect(await token0.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await token1.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      // send token0 and token1 to fallbackreceiver and external fee receiver
+      expect((await token0.balanceOf(dxdao.address)))
+        .to.eq(tkn0ToProtocolFeeReceiver)
+      expect((await token1.balanceOf(dxdao.address)))
+        .to.eq(tkn1ToProtocolFeeReceiver)
+      expect((await token0.balanceOf(externalFeeRecipient.address)))
+        .to.eq(tkn0ToExternalRecipient)
+      expect((await token1.balanceOf(externalFeeRecipient.address)))
+        .to.eq(tkn1ToExternalRecipient)
+
+      // should not change eth balance
+      expect((await provider.getBalance(dxdao.address)))
+        .to.eq(dxdaoBalanceBeforeTake)
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.eq(protocolFeeReceiverBalanceBeforeTake)
+      expect((await provider.getBalance(externalFeeRecipient.address)))
+        .to.eq(externalFeeRecipientBalanceBeforeTake)
+    })
+
+  // Where tokenA-tokenB, tokenC-tokenD and tokenC-WETH pairs exist
+  it(
+    'should receive tokenA,B,D and WETH from tokenC from tokenA-tonkenB and tokenC-tokenD pairs',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(50);
+
+      // Set up tokenA-tokenB
+      const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+      const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+
+      await factory.createPair(tokenA.address, tokenB.address);
+      const tokenATokenBPair = new Contract(
+        await factory.getPair(
+          (tokenA.address < tokenB.address) ? tokenA.address : tokenB.address,
+          (tokenA.address < tokenB.address) ? tokenB.address : tokenA.address
+        ), JSON.stringify(DXswapPair.abi), provider
+      ).connect(wallet)
+
+      await tokenA.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenB.transfer(tokenATokenBPair.address, tokenAmount)
+      await tokenATokenBPair.mint(wallet.address, overrides)
+
+      let amountOut = await getAmountOut(tokenATokenBPair, tokenA.address, amountIn);
+      await tokenA.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        wallet.address, '0x', overrides
+      )
+
+      amountOut = await getAmountOut(tokenATokenBPair, tokenB.address, amountIn);
+      await tokenB.transfer(tokenATokenBPair.address, amountIn)
+      await tokenATokenBPair.swap(
+        (tokenA.address < tokenB.address) ? amountOut : 0,
+        (tokenA.address < tokenB.address) ? 0 : amountOut,
+        wallet.address, '0x', overrides
+      )
+
+      let protocolFeeToReceive = await calcProtocolFee(tokenATokenBPair);
+
+      await tokenA.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenB.transfer(tokenATokenBPair.address, expandTo18Decimals(10))
+      await tokenATokenBPair.mint(wallet.address, overrides)
+
+      const protocolFeeLPTokenAtokenBPair = await tokenATokenBPair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPTokenAtokenBPair.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      // Set up tokenC-tokenD pair
+      const tokenC = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+      const tokenD = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
+
+      await factory.createPair(tokenC.address, tokenD.address);
+      const tokenCTokenDPair = new Contract(
+        await factory.getPair(
+          (tokenC.address < tokenD.address) ? tokenC.address : tokenD.address,
+          (tokenC.address < tokenD.address) ? tokenD.address : tokenC.address
+        ), JSON.stringify(DXswapPair.abi), provider
+      ).connect(wallet)
+
+
+      await tokenC.transfer(tokenCTokenDPair.address, tokenAmount)
+      await tokenD.transfer(tokenCTokenDPair.address, tokenAmount)
+      await tokenCTokenDPair.mint(wallet.address, overrides)
+
+      // Set up tokenC-WETH pair
+      await factory.createPair(tokenC.address, WETH.address);
+      const tokenCWETHPair = new Contract(
+        await factory.getPair(
+          (tokenC.address < WETH.address) ? tokenC.address : WETH.address,
+          (tokenC.address < WETH.address) ? WETH.address : tokenC.address
+        ), JSON.stringify(DXswapPair.abi), provider
+      ).connect(wallet)
+      await tokenC.transfer(tokenCWETHPair.address, tokenAmount)
+      await WETH.transfer(tokenCWETHPair.address, tokenAmount)
+      await tokenCWETHPair.mint(wallet.address, overrides)
+
+      // swap
+      amountOut = await getAmountOut(tokenCTokenDPair, tokenC.address, amountIn);
+      await tokenC.transfer(tokenCTokenDPair.address, amountIn)
+      await tokenCTokenDPair.swap(
+        (tokenC.address < tokenD.address) ? 0 : amountOut,
+        (tokenC.address < tokenD.address) ? amountOut : 0,
+        wallet.address, '0x', overrides
+      )
+
+      amountOut = await getAmountOut(tokenCTokenDPair, tokenD.address, amountIn);
+      await tokenD.transfer(tokenCTokenDPair.address, amountIn)
+      await tokenCTokenDPair.swap(
+        (tokenC.address < tokenD.address) ? amountOut : 0,
+        (tokenC.address < tokenD.address) ? 0 : amountOut,
+        wallet.address, '0x', overrides
+      )
+
+      protocolFeeToReceive = await calcProtocolFee(tokenCTokenDPair);
+
+      await tokenC.transfer(tokenCTokenDPair.address, expandTo18Decimals(10))
+      await tokenD.transfer(tokenCTokenDPair.address, expandTo18Decimals(10))
+      await tokenCTokenDPair.mint(wallet.address, overrides)
+
+      const protocolFeeLPTokenCtokenDPair = await tokenCTokenDPair.balanceOf(feeReceiver.address);
+      expect(protocolFeeLPTokenCtokenDPair.div(ROUND_EXCEPTION))
+        .to.be.eq(protocolFeeToReceive.div(ROUND_EXCEPTION))
+
+      const tokenAFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenA.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+      const tokenBFromProtocolFee = protocolFeeLPTokenAtokenBPair
+        .mul(await tokenB.balanceOf(tokenATokenBPair.address)).div(await tokenATokenBPair.totalSupply());
+      const tokenCFromProtocolFee = protocolFeeLPTokenCtokenDPair
+        .mul(await tokenC.balanceOf(tokenCTokenDPair.address)).div(await tokenCTokenDPair.totalSupply());
+      const tokenDFromProtocolFee = protocolFeeLPTokenCtokenDPair
+        .mul(await tokenD.balanceOf(tokenCTokenDPair.address)).div(await tokenCTokenDPair.totalSupply());
+
+
+      const wethFromTokenCFromProtocolFee = await getAmountOut(tokenCWETHPair, tokenC.address, tokenCFromProtocolFee);
+      const protocolFeeReceiverBalance = await provider.getBalance(protocolFeeReceiver.address)
+
+      await expect(feeReceiver.connect(wallet).takeProtocolFee([tokenATokenBPair.address, tokenCTokenDPair.address], overrides)
+      ).to.emit(feeReceiver, 'TakeProtocolFee').withArgs(wallet.address, protocolFeeReceiver.address, 2)
+
+      expect(await tokenA.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenB.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenC.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await tokenD.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await WETH.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await pair.balanceOf(feeReceiver.address)).to.eq(0)
+      expect(await provider.getBalance(feeReceiver.address)).to.eq(0)
+
+      expect((await tokenA.balanceOf(dxdao.address)))
+        .to.be.eq(tokenAFromProtocolFee)
+      expect((await tokenB.balanceOf(dxdao.address)))
+        .to.be.eq(tokenBFromProtocolFee)
+      expect((await tokenD.balanceOf(dxdao.address)))
+        .to.be.eq(tokenDFromProtocolFee)
+      expect((await tokenC.balanceOf(dxdao.address)))
+        .to.eq(0)
+      expect((await provider.getBalance(protocolFeeReceiver.address)))
+        .to.be.eq(protocolFeeReceiverBalance.add(wethFromTokenCFromProtocolFee))
+    })
+
+  // Where token0-token1 and token1-WETH pairs exist
+  it(
+    'should emit TakeProtocolFee event',
+    async () => {
+      const tokenAmount = expandTo18Decimals(100);
+      const wethAmount = expandTo18Decimals(100);
+      const amountIn = expandTo18Decimals(10);
+
+      await token0.transfer(pair.address, tokenAmount)
+      await token1.transfer(pair.address, tokenAmount)
+      await pair.mint(wallet.address, overrides)
+
+      await token1.transfer(wethToken1Pair.address, tokenAmount)
+      await WETH.transfer(wethToken1Pair.address, wethAmount)
+      await wethToken1Pair.mint(wallet.address, overrides)
+
+      let amountOut = await getAmountOut(pair, token0.address, amountIn);
+      await token0.transfer(pair.address, amountIn)
+      await pair.swap(0, amountOut, wallet.address, '0x', overrides)
+
+      amountOut = await getAmountOut(wethToken1Pair, token1.address, amountIn);
+      await token1.transfer(wethToken1Pair.address, amountIn)
+      await wethToken1Pair.swap(0, amountOut, wallet.address, '0x', overrides)
+
+      await token0.transfer(pair.address, expandTo18Decimals(10))
+      await token1.transfer(pair.address, expandTo18Decimals(10))
+      await pair.mint(wallet.address, overrides)
+
+      await token1.transfer(wethToken1Pair.address, expandTo18Decimals(10))
+      await WETH.transfer(wethToken1Pair.address, expandTo18Decimals(10))
+      await wethToken1Pair.mint(wallet.address, overrides)
+
+      await expect(feeReceiver.connect(wallet).takeProtocolFee([pair.address, wethToken1Pair.address], overrides)
+      ).to.emit(feeReceiver, 'TakeProtocolFee').withArgs(wallet.address, protocolFeeReceiver.address, 2)
+
+    })
+
+
 })

--- a/test/DXswapFeeSetter.spec.ts
+++ b/test/DXswapFeeSetter.spec.ts
@@ -21,7 +21,7 @@ describe('DXswapFeeSetter', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 9999999
+    gasLimit: 15000000
   })
   const [dxdao, pairOwner, protocolFeeReceiver, other] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [dxdao, other, protocolFeeReceiver])

--- a/test/DXswapFeeSetter.spec.ts
+++ b/test/DXswapFeeSetter.spec.ts
@@ -53,7 +53,7 @@ describe('DXswapFeeSetter', () => {
     await expect(feeSetter.connect(other).setFeeTo(other.address)).to.be.revertedWith('DXswapFeeSetter: FORBIDDEN')
     await feeSetter.connect(dxdao).setFeeTo(dxdao.address)
 
-    // If feeToSetter changes it will will fail in DXswapFactory check when trying to setFeeTo from FeeSetter.
+    // If feeToSetter changes it will fail in DXswapFactory check when trying to setFeeTo from FeeSetter.
     await feeSetter.connect(dxdao).setFeeToSetter(other.address)
     await expect(feeSetter.connect(dxdao).setFeeTo(dxdao.address)).to.be.revertedWith('DXswapFactory: FORBIDDEN')
   })
@@ -64,7 +64,7 @@ describe('DXswapFeeSetter', () => {
     await feeSetter.connect(dxdao).setProtocolFee(5)
     expect(await factory.protocolFeeDenominator()).to.eq(5)
 
-    // If feeToSetter changes it will will fail in DXswapFactory check when trying to setProtocolFee from FeeSetter.
+    // If feeToSetter changes it will fail in DXswapFactory check when trying to setProtocolFee from FeeSetter.
     await feeSetter.connect(dxdao).setFeeToSetter(other.address)
     await expect(feeSetter.connect(dxdao).setProtocolFee(5)).to.be.revertedWith('DXswapFactory: FORBIDDEN')
   })
@@ -89,7 +89,7 @@ describe('DXswapFeeSetter', () => {
     await feeSetter.connect(dxdao).transferPairOwnership(pair.address, AddressZero)
     await expect(feeSetter.connect(pairOwner).setSwapFee(pair.address, 5)).to.be.revertedWith('DXswapFeeSetter: FORBIDDEN')
 
-    // If feeToSetter changes it will will fail in DXswapFactory check when trying to setSwapFee from FeeSetter.
+    // If feeToSetter changes it will fail in DXswapFactory check when trying to setSwapFee from FeeSetter.
     await feeSetter.connect(dxdao).setFeeToSetter(other.address)
     await expect(feeSetter.connect(dxdao).setSwapFee(pair.address, 5)).to.be.revertedWith('DXswapFactory: FORBIDDEN')
   })
@@ -99,7 +99,35 @@ describe('DXswapFeeSetter', () => {
     await expect(feeSetter.connect(other).setFeeToSetter(other.address)).to.be.revertedWith('DXswapFeeSetter: FORBIDDEN')
     await feeSetter.connect(dxdao).setFeeToSetter(other.address)
     expect(await factory.feeToSetter()).to.eq(other.address)
-    // If feeToSetter changes it will will fail in DXswapFactory check when trying to setFeeToSetter from FeeSetter.
+
+    // If feeToSetter changes it will fail in DXswapFactory check when trying to setFeeToSetter from FeeSetter.
     await expect(feeSetter.connect(dxdao).setFeeToSetter(dxdao.address)).to.be.revertedWith('DXswapFactory: FORBIDDEN')
+  })
+
+  it('setExternalFeeRecipient', async () => {
+    // Should be set to zero address by default
+    expect(await pair.externalFeeRecipient()).to.eq(AddressZero)
+
+    // Should not allow to setFeeToSetter from other address taht is not owner calling feeSetter
+    await expect(feeSetter.connect(other).setExternalFeeRecipient(pair.address, other.address)).to.be.revertedWith('DXswapFeeSetter: FORBIDDEN')
+    await feeSetter.connect(dxdao).setExternalFeeRecipient(pair.address, other.address)
+    expect(await pair.externalFeeRecipient()).to.eq(other.address)
+
+    // If feeToSetter changes it will  fail in DXswapFactory check when trying to setFeeToSetter from FeeSetter.
+    await feeSetter.connect(dxdao).setFeeToSetter(other.address)
+    await expect(feeSetter.connect(dxdao).setExternalFeeRecipient(pair.address, other.address)).to.be.revertedWith('DXswapFactory: FORBIDDEN')
+  })
+
+  it('setPercentFeeToExternalRecipient', async () => {
+    // Should be set to zero by default
+    expect(await pair.percentFeeToExternalRecipient()).to.eq(0)
+    // Should not allow to setFeeToSetter from other address taht is not owner calling feeSetter
+    await expect(feeSetter.connect(other).setPercentFeeToExternalRecipient(pair.address, feeReceiver.address, 2000)).to.be.revertedWith('DXswapFeeSetter: FORBIDDEN')
+    await feeSetter.connect(dxdao).setPercentFeeToExternalRecipient(pair.address, feeReceiver.address, 2000)
+    expect(await pair.percentFeeToExternalRecipient()).to.eq(2000)
+
+    // If feeToSetter changes it will  fail in DXswapFactory check when trying to setFeeToSetter from FeeSetter.
+    await feeSetter.connect(dxdao).setFeeToSetter(other.address)
+    await expect(feeSetter.connect(dxdao).setPercentFeeToExternalRecipient(pair.address, feeReceiver.address, 1000)).to.be.revertedWith('DXswapFactory: FORBIDDEN')
   })
 })

--- a/test/DXswapPair.spec.ts
+++ b/test/DXswapPair.spec.ts
@@ -31,6 +31,7 @@ describe('DXswapPair', () => {
   let token1: Contract
   let pair: Contract
   let feeSetter: Contract
+  let feeReceiver: Contract
 
   beforeEach(async () => {
     const fixture = await loadFixture(pairFixture)
@@ -39,6 +40,7 @@ describe('DXswapPair', () => {
     token1 = fixture.token1
     pair = fixture.pair
     feeSetter = fixture.feeSetter
+    feeReceiver = fixture.feeReceiver
     await feeSetter.setFeeTo(AddressZero);
   })
 
@@ -398,13 +400,13 @@ describe('DXswapPair', () => {
   it('fail on trying to set percent fee to external recipient higher than 50%', async () => {
     expect(await pair.percentFeeToExternalRecipient())
       .to.eq(0)
-    await feeSetter.setPercentFeeToExternalRecipient(pair.address, 5000)
+    await feeSetter.setPercentFeeToExternalRecipient(pair.address, feeReceiver.address, 5000)
     expect(await pair.percentFeeToExternalRecipient())
       .to.eq(5000)
-    await feeSetter.setPercentFeeToExternalRecipient(pair.address, 100)
+    await feeSetter.setPercentFeeToExternalRecipient(pair.address, feeReceiver.address, 100)
     expect(await pair.percentFeeToExternalRecipient())
       .to.eq(100)
-    await expect(feeSetter.setPercentFeeToExternalRecipient(pair.address, 5001)).to.be.revertedWith(
+    await expect(feeSetter.setPercentFeeToExternalRecipient(pair.address, feeReceiver.address, 5001)).to.be.revertedWith(
       'DXswapPair: FORBIDDEN_FEE_SPLIT'
     )
   })

--- a/test/DynamicFees.spec.ts
+++ b/test/DynamicFees.spec.ts
@@ -16,14 +16,14 @@ const ROUND_EXCEPTION = bigNumberify(10000)
 chai.use(solidity)
 
 const overrides = {
-  gasLimit: 9999999
+  gasLimit: 15000000
 }
 
 describe('DynamicFees', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
-    gasLimit: 9999999
+    gasLimit: 15000000
   })
   const [dxdao, wallet, protocolFeeReceiver, other] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [dxdao, wallet, protocolFeeReceiver])


### PR DESCRIPTION
# Summary
Closes #39 
The goal is to upgrade FeeReceiver contract to fix swap issue and add fee split feature.

***New features***

- change DXswapFeeReceiver contract to protect from situation where takeProtocolFee function tries to swap token in pair with too small liquidity
- allow to control fee split and recipient for each pair
- supports max one external recipient address
- no deadline to claim protocol fee
- modify another contracts accordingly
