### PR TITLE
chore: adds licence comment to avoid warnings

### DIFF
--- a/contracts/DXswapDeployer.sol
+++ b/contracts/DXswapDeployer.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 import './DXswapFactory.sol';

--- a/contracts/DXswapERC20.sol
+++ b/contracts/DXswapERC20.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 import './interfaces/IDXswapERC20.sol';

--- a/contracts/DXswapFactory.sol
+++ b/contracts/DXswapFactory.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 import './interfaces/IDXswapFactory.sol';

--- a/contracts/DXswapFeeReceiver.sol
+++ b/contracts/DXswapFeeReceiver.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 import './interfaces/IDXswapFactory.sol';

--- a/contracts/DXswapFeeSetter.sol
+++ b/contracts/DXswapFeeSetter.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 import './interfaces/IDXswapFactory.sol';

--- a/contracts/DXswapPair.sol
+++ b/contracts/DXswapPair.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 import './interfaces/IDXswapPair.sol';

--- a/contracts/interfaces/IDXswapCallee.sol
+++ b/contracts/interfaces/IDXswapCallee.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
 interface IDXswapCallee {

--- a/contracts/interfaces/IDXswapERC20.sol
+++ b/contracts/interfaces/IDXswapERC20.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
 interface IDXswapERC20 {

--- a/contracts/interfaces/IDXswapFactory.sol
+++ b/contracts/interfaces/IDXswapFactory.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
 interface IDXswapFactory {

--- a/contracts/interfaces/IDXswapPair.sol
+++ b/contracts/interfaces/IDXswapPair.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
 interface IDXswapPair {

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
 interface IERC20 {

--- a/contracts/interfaces/IWETH.sol
+++ b/contracts/interfaces/IWETH.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
 interface IWETH {

--- a/contracts/libraries/Math.sol
+++ b/contracts/libraries/Math.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 // a library for performing various math operations

--- a/contracts/libraries/SafeMath.sol
+++ b/contracts/libraries/SafeMath.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 // a library for performing overflow-safe math, courtesy of DappHub (https://github.com/dapphub/ds-math)

--- a/contracts/libraries/TransferHelper.sol
+++ b/contracts/libraries/TransferHelper.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 // helper methods for interacting with ERC20 tokens and sending ETH that do not consistently return true/false

--- a/contracts/libraries/UQ112x112.sol
+++ b/contracts/libraries/UQ112x112.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 // a library for handling binary fixed point numbers (https://en.wikipedia.org/wiki/Q_(number_format))

--- a/contracts/test/ERC20.sol
+++ b/contracts/test/ERC20.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 import '../DXswapERC20.sol';

--- a/contracts/test/WETH9.sol
+++ b/contracts/test/WETH9.sol
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//SPDX-License-Identifier: MIT
 pragma solidity =0.5.16;
 
 contract WETH9 {


### PR DESCRIPTION
Just adds the licence comment to avoid warnings like this when importing @swapr on contracts built with newer compilers
```
Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
--> /Users/dxdao/swapr-lp-zapping/node_modules/@swapr/core/contracts/interfaces/IDXswapPair.sol
```